### PR TITLE
feature(calendar): support custom arrow components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-modules-commonjs"]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.js",
   "description": "React Native Calendar Components",
   "scripts": {
-    "test": "jasmine src/*.spec.js && npm run lint",
+    "test": "babel-node spec/runner.js && npm run lint",
     "lint": "eslint src/ example/src"
   },
   "repository": {
@@ -24,7 +24,9 @@
     "react-native": "0.44.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "eslint": "^3.19.0",
     "eslint-plugin-react": "^7.0.0",
     "jasmine": "^2.5.2",

--- a/spec/runner.js
+++ b/spec/runner.js
@@ -1,0 +1,6 @@
+import Jasmine from 'jasmine';
+import path from 'path';
+
+var jasmine = new Jasmine();
+jasmine.loadConfigFile(path.resolve(__dirname, 'support', 'jasmine.json'));
+jasmine.execute();

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,8 @@
+{
+  "spec_dir": "src",
+  "spec_files": [
+    "*.spec.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -1,13 +1,8 @@
-import React, {Component} from 'react';
-import {ActivityIndicator} from 'react-native';
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  Image
-} from 'react-native';
+import React, { Component } from 'react';
+import { ActivityIndicator } from 'react-native';
+import { View, Text, TouchableOpacity, Image } from 'react-native';
 import styleConstructor from './style';
-import {weekDayNames} from '../../dateutils';
+import { weekDayNames } from '../../dateutils';
 
 class CalendarHeader extends Component {
   constructor(props) {
@@ -26,7 +21,10 @@ class CalendarHeader extends Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    if (nextProps.month.toString('yyyy MM') !== this.props.month.toString('yyyy MM')) {
+    if (
+      nextProps.month.toString('yyyy MM') !==
+      this.props.month.toString('yyyy MM')
+    ) {
       return true;
     }
     if (nextProps.showIndicator !== this.props.showIndicator) {
@@ -36,41 +34,52 @@ class CalendarHeader extends Component {
   }
 
   render() {
-    let leftArrow = (<View/>);
-    let rightArrow = (<View/>);
+    let leftArrow = <View />;
+    let rightArrow = <View />;
     let weekDaysNames = weekDayNames(this.props.firstDay);
     if (!this.props.hideArrows) {
       leftArrow = (
-        <TouchableOpacity onPress={this.substractMonth} style={this.style.arrow}>
+        <TouchableOpacity
+          onPress={this.substractMonth}
+          style={this.style.arrow}
+        >
           {this.props.renderArrow
-            ? React.cloneElement(this.props.renderArrow('left'))
-            : <Image source={require('../img/previous.png')} style={this.style.arrowImage} />}
+            ? this.props.renderArrow('left')
+            : <Image
+                source={require('../img/previous.png')}
+                style={this.style.arrowImage}
+              />}
         </TouchableOpacity>
       );
       rightArrow = (
         <TouchableOpacity onPress={this.addMonth} style={this.style.arrow}>
           {this.props.renderArrow
-            ? React.cloneElement(this.props.renderArrow('right'))
-            : <Image source={require('../img/next.png')} style={this.style.arrowImage} />}
+            ? this.props.renderArrow('right')
+            : <Image
+                source={require('../img/next.png')}
+                style={this.style.arrowImage}
+              />}
         </TouchableOpacity>
       );
     }
     let indicator;
     if (this.props.showIndicator) {
-      indicator = (<ActivityIndicator/>);
+      indicator = <ActivityIndicator />;
     }
     return (
       <View>
         <View style={this.style.header}>
           {leftArrow}
-          <View style={{flexDirection: 'row'}}>
-            <Text style={this.style.monthText}>{this.props.month.toString('MMMM yyyy')}</Text>
+          <View style={{ flexDirection: 'row' }}>
+            <Text style={this.style.monthText}>
+              {this.props.month.toString('MMMM yyyy')}
+            </Text>
             {indicator}
           </View>
           {rightArrow}
         </View>
         <View style={this.style.week}>
-          {weekDaysNames.map((day) => (
+          {weekDaysNames.map(day => (
             <Text key={day} style={this.style.dayHeader}>{day}</Text>
           ))}
         </View>

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -42,11 +42,17 @@ class CalendarHeader extends Component {
     if (!this.props.hideArrows) {
       leftArrow = (
         <TouchableOpacity onPress={this.substractMonth} style={this.style.arrow}>
-          <Image source={require('../img/previous.png')} style={this.style.arrowImage}/></TouchableOpacity>
+          {this.props.leftArrow
+            ? React.cloneElement(this.props.leftArrow)
+            : <Image source={require('../img/previous.png')} style={this.style.arrowImage} />}
+        </TouchableOpacity>
       );
       rightArrow = (
         <TouchableOpacity onPress={this.addMonth} style={this.style.arrow}>
-          <Image source={require('../img/next.png')} style={this.style.arrowImage}/></TouchableOpacity>
+          {this.props.rightArrow
+            ? React.cloneElement(this.props.rightArrow)
+            : <Image source={require('../img/next.png')} style={this.style.arrowImage} />}
+        </TouchableOpacity>
       );
     }
     let indicator;

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -42,15 +42,15 @@ class CalendarHeader extends Component {
     if (!this.props.hideArrows) {
       leftArrow = (
         <TouchableOpacity onPress={this.substractMonth} style={this.style.arrow}>
-          {this.props.leftArrow
-            ? React.cloneElement(this.props.leftArrow)
+          {this.props.renderArrow
+            ? React.cloneElement(this.props.renderArrow('left'))
             : <Image source={require('../img/previous.png')} style={this.style.arrowImage} />}
         </TouchableOpacity>
       );
       rightArrow = (
         <TouchableOpacity onPress={this.addMonth} style={this.style.arrow}>
-          {this.props.rightArrow
-            ? React.cloneElement(this.props.rightArrow)
+          {this.props.renderArrow
+            ? React.cloneElement(this.props.renderArrow('right'))
             : <Image source={require('../img/next.png')} style={this.style.arrowImage} />}
         </TouchableOpacity>
       );

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -119,8 +119,6 @@ class Calendar extends Component {
             onPress={this.pressDay.bind(this, day)}
             marked={this.getDateMarking(day)}
             markingExists={markingExists}
-            leftArrow={this.props.leftArrow}
-            rightArrow={this.props.rightArrow}
           >
             {day.getDate()}
           </DayComp>
@@ -174,6 +172,7 @@ class Calendar extends Component {
           addMonth={this.addMonth}
           showIndicator={indicator}
           firstDay={this.props.firstDay}
+          renderArrow={this.props.renderArrow}
         />
         {weeks}
       </View>);

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -119,6 +119,8 @@ class Calendar extends Component {
             onPress={this.pressDay.bind(this, day)}
             marked={this.getDateMarking(day)}
             markingExists={markingExists}
+            leftArrow={this.props.leftArrow}
+            rightArrow={this.props.rightArrow}
           >
             {day.getDate()}
           </DayComp>

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,4 @@
-import Calendar from './calendar';
-import CalendarList from './calendar-list';
-import Agenda from './agenda';
-import XDate from 'xdate';
-
-const LocaleConfig = XDate;
-
-module.exports = {
-  Calendar,
-  CalendarList,
-  Agenda,
-  LocaleConfig
-};
+export { default as Calendar } from './calendar';
+export { default as CalendarList } from './calendar-list';
+export { default as Agenda } from './agenda';
+export { default as LocaleConfig } from 'xdate';

--- a/src/interface.js
+++ b/src/interface.js
@@ -1,4 +1,4 @@
-import XDate = from 'xdate';
+import XDate from 'xdate';
 
 function padNumber(n) {
   if (n < 10) {

--- a/src/interface.js
+++ b/src/interface.js
@@ -1,13 +1,4 @@
-const XDate = require('xdate');
-
-function xdateToData(xdate) {
-  return {
-    year: xdate.getFullYear(),
-    month: xdate.getMonth() + 1,
-    day: xdate.getDate(),
-    timestamp: XDate(xdate.toString('yyyy-MM-dd'), true).getTime()
-  };
-}
+import XDate = from 'xdate';
 
 function padNumber(n) {
   if (n < 10) {
@@ -16,7 +7,16 @@ function padNumber(n) {
   return n;
 }
 
-function parseDate(d) {
+export function xdateToData(xdate) {
+  return {
+    year: xdate.getFullYear(),
+    month: xdate.getMonth() + 1,
+    day: xdate.getDate(),
+    timestamp: XDate(xdate.toString('yyyy-MM-dd'), true).getTime()
+  };
+}
+
+export function parseDate(d) {
   if (!d) {
     return;
   } else if (d.timestamp) { // conventional data timestamp
@@ -33,8 +33,3 @@ function parseDate(d) {
     return XDate(d, true);
   }
 }
-
-module.exports = {
-  xdateToData,
-  parseDate
-};


### PR DESCRIPTION
This PR brings full web compatibility to address issue #2

Changes made:
Remove mixed import/module.exports for Webpack 2 support
Allow `<CalendarHeader />` component to take `leftArrow` and `rightArrow` props allowing any component to be used for arrow replacement.

![scores-and-schedule](https://cloud.githubusercontent.com/assets/3629876/26453500/fa663040-4131-11e7-94a8-1aa75a8fe5f6.gif)
