### PR TITLE
feat(agenda): add onDayChange prop

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -135,6 +135,10 @@ export default class AgendaView extends Component {
     this.setState({
       selectedDay: parseDate(day)
     });
+
+    if (this.props.onDayChange) {
+      this.props.onDayChange(xdateToData(newDate));
+    }
   }
 
   render() {


### PR DESCRIPTION
Callback property when the day changes via scroll event.

Currently the only way to know when days change is via `onDayPress`. However, if the day is changed via scroll events, that information is tucked away. This exposes that change via `onDayChange`.

```jsx
<Agenda
  ...
  onDayChange={day => this.doSomethingWithNewDay(day)}
/>
```

My only gripe is that there's now two date change callbacks, but it is helpful to know the distinction, so it's not a huge complaint.

Although it might be worth consolidating both behind a "day changed" property, and perhaps passing a second argument describing the event source (`'press'` vs `'scroll'`)