### PR TITLE
Add optional native gesture handler (makes the agenda calendar natively draggable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "prop-types": "^15.5.10",
+    "react-native-interactable": "0.0.9",
     "xdate": "^0.8.0"
   },
   "peerDependencies": {

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -183,12 +183,12 @@ export default class AgendaView extends Component {
       this.calendar.scrollToDay(day, CALENDAR_OFFSET, true);
     }
     
-    // if (this.props.loadItemsForMonth) {
-    //   this.props.loadItemsForMonth(xdateToData(day));
-    // }
-    // if (this.props.onDayPress) {
-    //   this.props.onDayPress(xdateToData(day));
-    // }
+    if (this.props.loadItemsForMonth) {
+      this.props.loadItemsForMonth(xdateToData(day));
+    }
+    if (this.props.onDayPress) {
+      this.props.onDayPress(xdateToData(day));
+    }
   }
 
   renderReservations() {

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -15,6 +15,12 @@ import dateutils from '../dateutils';
 import CalendarList from '../calendar-list';
 import ReservationsList from './reservation-list';
 import styleConstructor from './style';
+import Interactable from 'react-native-interactable';
+
+const Screen = {
+  width: Dimensions.get('window').width,
+  height: Dimensions.get('window').height - 75
+}
 
 const CALENDAR_OFFSET = 38;
 
@@ -62,25 +68,33 @@ export default class AgendaView extends Component {
     this.screenHeight = Dimensions.get('window').height;
     this.scrollTimeout = undefined;
     this.state = {
-      openAnimation: new Animated.Value(0),
-      calendarScrollable: false,
+      calendarExpanded: false,
       firstResevationLoad: false,
       selectedDay: parseDate(this.props.selected) || XDate(true),
       topDay: parseDate(this.props.selected) || XDate(true),
     };
     this.currentMonth = this.state.selectedDay.clone();
+
+    this.retractCalendar = this.retractCalendar.bind(this);
     this.expandCalendar = this.expandCalendar.bind(this);
+
     this.getCalendaryStyle = this.getCalendaryStyle.bind(this);
     this.getWeedaysStyle = this.getWeedaysStyle.bind(this);
 
     if (this.props.draggable) {
       this._deltaY = new Animated.Value(0);
+      this.renderDraggable = this.renderDraggable.bind(this);
+      this.onDrawerSnap = this.onDrawerSnap.bind(this);
+    } else {
+      this._openAnimation = new Animated.Value(0);
     }
   }
 
   onLayout(event) {
     this.screenHeight = event.nativeEvent.layout.height;
-    this.calendar.scrollToDay(this.state.selectedDay.clone(), CALENDAR_OFFSET, false);
+    if (this.calendar) {
+      this.calendar.scrollToDay(this.state.selectedDay.clone(), CALENDAR_OFFSET, false);
+    }
   }
 
   onVisibleMonthsChange(months) {
@@ -120,33 +134,53 @@ export default class AgendaView extends Component {
     }
   }
 
+  retractCalendar(day) {
+    this.setState({
+      calendarExpanded: false
+    });
+    if(this.props.draggable) {
+      this.dropDown.snapTo({index: 1});
+    } else {
+      Animated.timing(this._openAnimation, {
+        toValue: 0,
+        duration: 200
+      }).start();
+      this.calendar.scrollToDay(day, CALENDAR_OFFSET, true);
+    }
+  }
+
   expandCalendar() {
     this.setState({
-      calendarScrollable: true
+      calendarExpanded: true
     });
-    Animated.timing(this.state.openAnimation, {
+    if(!this.props.draggable) {
+      Animated.timing(this._openAnimation, {
       toValue: 1,
       duration: 300
-    }).start();
-    this.calendar.scrollToDay(this.state.selectedDay, 100 - ((this.screenHeight / 2) - 16), true);
+      }).start();
+      this.calendar.scrollToDay(this.state.selectedDay, 100 - ((this.screenHeight / 2) - 16), true);
+    } else {
+      this.dropDown.setVelocity({y: 2000});
+      this.dropDown.snapTo({index: 0});
+    }
   }
 
   chooseDay(d) {
     const day = parseDate(d);
     this.setState({
-      calendarScrollable: false,
+      calendarExpanded: false,
       selectedDay: day.clone()
     });
-    if (this.state.calendarScrollable) {
-      this.setState({
-        topDay: day.clone()
-      });
+    this.setState({
+      topDay: day.clone()
+    });
+    if (this.state.calendarExpanded) {
+      this.retractCalendar(day);
+    } else if (!this.props.draggable) {
+      this.calendar.scrollToDay(day, CALENDAR_OFFSET, true);
     }
-    Animated.timing(this.state.openAnimation, {
-      toValue: 0,
-      duration: 200
-    }).start();
-    this.calendar.scrollToDay(day, CALENDAR_OFFSET, true);
+  
+    
     if (this.props.loadItemsForMonth) {
       this.props.loadItemsForMonth(xdateToData(day));
     }
@@ -186,81 +220,90 @@ export default class AgendaView extends Component {
     }
   }
 
+  onDrawerSnap(event) {
+    this.setState({
+      calendarExpanded: event.nativeEvent.id === 'top',
+    });
+  }
+
   getCalendaryStyle() {
     return !this.props.draggable
-      ? [this.styles.calendar, {height: this.state.openAnimation.interpolate({
+      ? [this.styles.calendar, {height: this._openAnimation.interpolate({
         inputRange: [0, 1],
         outputRange: [104, this.screenHeight + 20]
       })}]
-      : [this.styles.calendar, {height: this.screenHeight}];
+      : [this.styles.calendar, {height: this.screenHeight, transform: [{
+        translateY: this._deltaY.interpolate({
+          inputRange: [-this.screenHeight , 0],
+          outputRange: [0.62*(this.screenHeight - 75), 0]
+        })
+      }]}];
   }
 
   getWeedaysStyle() {
     return !this.props.draggable
-      ? [this.styles.weekdays, {opacity: this.state.openAnimation.interpolate({
+      ? [this.styles.weekdays, {top: 0}, {opacity: this._openAnimation.interpolate({
         inputRange: [0, 1],
         outputRange: [1, 0]
       })}]
-      : [this.styles.weekdays,  {
+      : [this.styles.weekdays, {
+        bottom: 25,
         opacity: this._deltaY.interpolate({
-          inputRange: [-0.75*this.screenHeight, -0.3*this.screenHeight],
-          outputRange: [1, 0]
-      })},{transform: [{
-        translateY: this._deltaY.interpolate({
-          inputRange: [-this.screenHeight, 0],
-          outputRange: [0, -0.75*this.screenHeight]
-        }) 
-      }]}];
+            inputRange: [-0.75*Screen.height, -0.3*Screen.height],
+            outputRange: [1, 0]
+        }),
+        transform: [{
+          translateY: this._deltaY.interpolate({
+            inputRange: [-Screen.height, 0],
+            outputRange: [0, -0.75*Screen.height]
+          }) 
+        }]
+      }];
   }
-
+  
   renderDraggable(wrappedComponent) {
+    setTimeout(() => {
+      this.calendar.scrollToDay(this.state.selectedDay, 100 - ((this.screenHeight / 2) - 16), true);
+    }, 0);
+    const maxHeight = this.screenHeight - 75;
     return (
-    <View style={styles.panelContainer}>
+    <View style={{
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0
+    }}>
       <Interactable.View
         verticalOnly={true}
         snapPoints={[{y: 0, tension: 0, damping: 1, id:'top'}, {y: -Screen.height + 50, id:'bottom'}]}
-        gravityPoints={[{y: 0, strength: 220, falloff: Screen.height*8, damping: 0.7, influenceArea: {top: (-Screen.height + 80) * 0.5}}]}
+        gravityPoints={[{y: 0, strength: 200, falloff: Screen.height*8, damping: 0.7, influenceArea: {top: (-Screen.height + 50) * 0.5}}]}
         initialPosition={{y: -Screen.height + 50}}
         boundaries={{top: -Screen.height, bottom: 0, bounce: 2, haptics: true}}
         animatedValueY={this._deltaY}
         onSnap={this.onDrawerSnap}
-        ref={c => {this.dropDown = c;}}
+        ref={c => { this.dropDown = c;}}
         animatedNativeDriver={true}>
-        {wrappedComponent}
+        <View style={{height: this.screenHeight}}>
+          {wrappedComponent}
+        </View>
       </Interactable.View>
     </View>);
   }
 
-  render2() {
-    const weekDaysNames = dateutils.weekDayNames(this.props.firstDay);
-    const maxCalHeight = this.screenHeight + 20;
-    const calendarStyle = [this.styles.calendar, {height: this.state.openAnimation.interpolate({
-      inputRange: [0, 1],
-      outputRange: [104, maxCalHeight]
-    })}];
-    const weekdaysStyle = [this.styles.weekdays, {opacity: this.state.openAnimation.interpolate({
-      inputRange: [0, 1],
-      outputRange: [1, 0]
-    })}];
-
-    let knob = (<View style={this.styles.knobContainer}/>);
-
-    if (!this.props.hideKnob) {
-      knob = (
-        <View style={this.styles.knobContainer}>
-          <TouchableOpacity onPress={this.expandCalendar}>
+  render() {
+    const knob = this.props.hideKnob
+      ? <View style={this.styles.knobContainer}/>
+      : <View style={this.styles.knobContainer}>
+          <TouchableOpacity onPress={() => this.state.calendarExpanded ? this.retractCalendar():this.expandCalendar()}>
             <View style={this.styles.knob}/>
           </TouchableOpacity>
         </View>
-      );
-    }
 
-    return (
-      <View onLayout={this.onLayout.bind(this)} style={[this.props.style, {flex: 1}]}>
-        <View style={this.styles.reservations}>
-          {this.renderReservations()}
-        </View>
-        <Animated.View style={calendarStyle}>
+    const weekDaysNames = dateutils.weekDayNames(this.props.firstDay);
+    const calendarListView = (
+      <View style={[this.styles.calendarContainer, {height: this.screenHeight}]}>
+        <Animated.View style={this.getCalendaryStyle()}>
           <CalendarList
             theme={this.props.theme}
             onVisibleMonthsChange={this.onVisibleMonthsChange.bind(this)}
@@ -269,57 +312,20 @@ export default class AgendaView extends Component {
             current={this.currentMonth}
             markedDates={this.props.items}
             onDayPress={this.chooseDay.bind(this)}
-            scrollingEnabled={this.state.calendarScrollable}
-            hideExtraDays={this.state.calendarScrollable}
+            scrollingEnabled={this.state.calendarExpanded}
+            hideExtraDays={this.state.calendarExpanded}
             firstDay={this.props.firstDay}
             theme={this.props.theme}
           />
-          {knob}
+          {!this.props.draggable ? knob : null}
         </Animated.View>
-        <Animated.View style={weekdaysStyle}>
+        {this.props.draggable ? knob : null}
+        <Animated.View style={this.getWeedaysStyle()} pointerEvents="none">
           {weekDaysNames.map((day) => (
             <Text key={day} style={this.styles.weekday}>{day}</Text>
           ))}
         </Animated.View>
       </View>
-    );
-  }
-
-  render() {
-    const weekDaysNames = dateutils.weekDayNames(this.props.firstDay);
-    const calendarStyle = this.getCalendaryStyle();
-    const weekdaysStyle = this.getWeedaysStyle();
-
-    const knob = this.props.hideKnob
-      ? <View style={this.styles.knobContainer}/>
-      : <View style={this.styles.knobContainer}>
-          <TouchableOpacity onPress={this.expandCalendar}>
-            <View style={this.styles.knob}/>
-          </TouchableOpacity>
-        </View>
-
-    const calendarListView = (
-      <Animated.View style={this.getCalendaryStyle()}>
-          <CalendarList
-            theme={this.props.theme}
-            onVisibleMonthsChange={this.onVisibleMonthsChange.bind(this)}
-            ref={(c) => this.calendar = c}
-            selected={[this.state.selectedDay]}
-            current={this.currentMonth}
-            markedDates={this.props.items}
-            onDayPress={this.chooseDay.bind(this)}
-            scrollingEnabled={this.state.calendarScrollable}
-            hideExtraDays={this.state.calendarScrollable}
-            firstDay={this.props.firstDay}
-            theme={this.props.theme}
-          />
-          {knob}
-          <Animated.View style={weekdaysStyle}>
-            {weekDaysNames.map((day) => (
-              <Text key={day} style={this.styles.weekday}>{day}</Text>
-            ))}
-          </Animated.View>
-      </Animated.View>
     );
 
     return (
@@ -328,7 +334,7 @@ export default class AgendaView extends Component {
           {this.renderReservations()}
         </View>
         {this.props.draggable
-          ? renderDraggable(calendarListView)
+          ? this.renderDraggable(calendarListView)
           : calendarListView}
       </View>
     );

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -23,6 +23,7 @@ const Screen = {
 }
 
 const CALENDAR_OFFSET = 38;
+let firstRender = true;
 
 export default class AgendaView extends Component {
   static propTypes = {
@@ -179,14 +180,13 @@ export default class AgendaView extends Component {
     } else if (!this.props.draggable) {
       this.calendar.scrollToDay(day, CALENDAR_OFFSET, true);
     }
-  
     
-    if (this.props.loadItemsForMonth) {
-      this.props.loadItemsForMonth(xdateToData(day));
-    }
-    if (this.props.onDayPress) {
-      this.props.onDayPress(xdateToData(day));
-    }
+    // if (this.props.loadItemsForMonth) {
+    //   this.props.loadItemsForMonth(xdateToData(day));
+    // }
+    // if (this.props.onDayPress) {
+    //   this.props.onDayPress(xdateToData(day));
+    // }
   }
 
   renderReservations() {
@@ -264,6 +264,10 @@ export default class AgendaView extends Component {
   renderDraggable(wrappedComponent) {
     setTimeout(() => {
       this.calendar.scrollToDay(this.state.selectedDay, 100 - ((this.screenHeight / 2) - 16), true);
+      if (firstRender) {
+        firstRender = false;
+        this.dropDown.snapTo({index: 1})
+      }
     }, 0);
     const maxHeight = this.screenHeight - 75;
     return (
@@ -272,7 +276,8 @@ export default class AgendaView extends Component {
       top: 0,
       bottom: 0,
       left: 0,
-      right: 0
+      right: 0,
+      opacity: (firstRender) ? 0 : 1,
     }}>
       <Interactable.View
         verticalOnly={true}

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -51,6 +51,9 @@ export default class AgendaView extends Component {
 
     // Hide knob button. Default = false
     hideKnob: PropTypes.bool,
+
+    // Make the calendar natively draggable
+    draggable: PropTypes.bool,
   };
 
   constructor(props) {
@@ -67,6 +70,12 @@ export default class AgendaView extends Component {
     };
     this.currentMonth = this.state.selectedDay.clone();
     this.expandCalendar = this.expandCalendar.bind(this);
+    this.getCalendaryStyle = this.getCalendaryStyle.bind(this);
+    this.getWeedaysStyle = this.getWeedaysStyle.bind(this);
+
+    if (this.props.draggable) {
+      this._deltaY = new Animated.Value(0);
+    }
   }
 
   onLayout(event) {
@@ -177,7 +186,52 @@ export default class AgendaView extends Component {
     }
   }
 
-  render() {
+  getCalendaryStyle() {
+    return !this.props.draggable
+      ? [this.styles.calendar, {height: this.state.openAnimation.interpolate({
+        inputRange: [0, 1],
+        outputRange: [104, this.screenHeight + 20]
+      })}]
+      : [this.styles.calendar, {height: this.screenHeight}];
+  }
+
+  getWeedaysStyle() {
+    return !this.props.draggable
+      ? [this.styles.weekdays, {opacity: this.state.openAnimation.interpolate({
+        inputRange: [0, 1],
+        outputRange: [1, 0]
+      })}]
+      : [this.styles.weekdays,  {
+        opacity: this._deltaY.interpolate({
+          inputRange: [-0.75*this.screenHeight, -0.3*this.screenHeight],
+          outputRange: [1, 0]
+      })},{transform: [{
+        translateY: this._deltaY.interpolate({
+          inputRange: [-this.screenHeight, 0],
+          outputRange: [0, -0.75*this.screenHeight]
+        }) 
+      }]}];
+  }
+
+  renderDraggable(wrappedComponent) {
+    return (
+    <View style={styles.panelContainer}>
+      <Interactable.View
+        verticalOnly={true}
+        snapPoints={[{y: 0, tension: 0, damping: 1, id:'top'}, {y: -Screen.height + 50, id:'bottom'}]}
+        gravityPoints={[{y: 0, strength: 220, falloff: Screen.height*8, damping: 0.7, influenceArea: {top: (-Screen.height + 80) * 0.5}}]}
+        initialPosition={{y: -Screen.height + 50}}
+        boundaries={{top: -Screen.height, bottom: 0, bounce: 2, haptics: true}}
+        animatedValueY={this._deltaY}
+        onSnap={this.onDrawerSnap}
+        ref={c => {this.dropDown = c;}}
+        animatedNativeDriver={true}>
+        {wrappedComponent}
+      </Interactable.View>
+    </View>);
+  }
+
+  render2() {
     const weekDaysNames = dateutils.weekDayNames(this.props.firstDay);
     const maxCalHeight = this.screenHeight + 20;
     const calendarStyle = [this.styles.calendar, {height: this.state.openAnimation.interpolate({
@@ -227,6 +281,55 @@ export default class AgendaView extends Component {
             <Text key={day} style={this.styles.weekday}>{day}</Text>
           ))}
         </Animated.View>
+      </View>
+    );
+  }
+
+  render() {
+    const weekDaysNames = dateutils.weekDayNames(this.props.firstDay);
+    const calendarStyle = this.getCalendaryStyle();
+    const weekdaysStyle = this.getWeedaysStyle();
+
+    const knob = this.props.hideKnob
+      ? <View style={this.styles.knobContainer}/>
+      : <View style={this.styles.knobContainer}>
+          <TouchableOpacity onPress={this.expandCalendar}>
+            <View style={this.styles.knob}/>
+          </TouchableOpacity>
+        </View>
+
+    const calendarListView = (
+      <Animated.View style={this.getCalendaryStyle()}>
+          <CalendarList
+            theme={this.props.theme}
+            onVisibleMonthsChange={this.onVisibleMonthsChange.bind(this)}
+            ref={(c) => this.calendar = c}
+            selected={[this.state.selectedDay]}
+            current={this.currentMonth}
+            markedDates={this.props.items}
+            onDayPress={this.chooseDay.bind(this)}
+            scrollingEnabled={this.state.calendarScrollable}
+            hideExtraDays={this.state.calendarScrollable}
+            firstDay={this.props.firstDay}
+            theme={this.props.theme}
+          />
+          {knob}
+          <Animated.View style={weekdaysStyle}>
+            {weekDaysNames.map((day) => (
+              <Text key={day} style={this.styles.weekday}>{day}</Text>
+            ))}
+          </Animated.View>
+      </Animated.View>
+    );
+
+    return (
+      <View onLayout={this.onLayout.bind(this)} style={[this.props.style, {flex: 1}]}>
+        <View style={this.styles.reservations}>
+          {this.renderReservations()}
+        </View>
+        {this.props.draggable
+          ? renderDraggable(calendarListView)
+          : calendarListView}
       </View>
     );
   }

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -20,7 +20,7 @@ import Interactable from 'react-native-interactable';
 const Screen = {
   width: Dimensions.get('window').width,
   height: Dimensions.get('window').height - 75
-}
+};
 
 const CALENDAR_OFFSET = 38;
 // For some reason the only way to make the scrollToDay work on the first render
@@ -158,8 +158,8 @@ export default class AgendaView extends Component {
     });
     if(!this.props.draggable) {
       Animated.timing(this._openAnimation, {
-      toValue: 1,
-      duration: 300
+        toValue: 1,
+        duration: 300
       }).start();
       this.calendar.scrollToDay(this.state.selectedDay, 100 - ((this.screenHeight / 2) - 16), true);
     } else {
@@ -251,8 +251,8 @@ export default class AgendaView extends Component {
       : [this.styles.weekdays, {
         bottom: 25,
         opacity: this._deltaY.interpolate({
-            inputRange: [-0.75*Screen.height, -0.3*Screen.height],
-            outputRange: [1, 0]
+          inputRange: [-0.75*Screen.height, -0.3*Screen.height],
+          outputRange: [1, 0]
         }),
         transform: [{
           translateY: this._deltaY.interpolate({
@@ -269,12 +269,11 @@ export default class AgendaView extends Component {
     setTimeout(() => {
       if (firstDraggableRender) {
         firstDraggableRender = false;
-        this.dropDown.snapTo({index: 1})
+        this.dropDown.snapTo({index: 1});
       } else {
         this.calendar.scrollToDay(this.state.selectedDay, 100 - ((this.screenHeight / 2) - 16), true);
       }
     }, 0);
-    const maxHeight = this.screenHeight - 75;
     return (
     <View style={{
       position: 'absolute',
@@ -308,7 +307,7 @@ export default class AgendaView extends Component {
           <TouchableOpacity onPress={() => this.state.calendarExpanded ? this.retractCalendar():this.expandCalendar()}>
             <View style={this.styles.knob}/>
           </TouchableOpacity>
-        </View>
+        </View>;
 
     const weekDaysNames = dateutils.weekDayNames(this.props.firstDay);
     const calendarListView = (

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -23,7 +23,9 @@ const Screen = {
 }
 
 const CALENDAR_OFFSET = 38;
-let firstRender = true;
+// For some reason the only way to make the scrollToDay work on the first render
+// is to trigger a snapTo. Therefore, we need to track the firstDraggable render.
+let firstDraggableRender = true;
 
 export default class AgendaView extends Component {
   static propTypes = {
@@ -262,11 +264,14 @@ export default class AgendaView extends Component {
   }
   
   renderDraggable(wrappedComponent) {
+    // We use setTimeout, otherwise the dropDown and calendar reference are not
+    // yet defined
     setTimeout(() => {
-      this.calendar.scrollToDay(this.state.selectedDay, 100 - ((this.screenHeight / 2) - 16), true);
-      if (firstRender) {
-        firstRender = false;
+      if (firstDraggableRender) {
+        firstDraggableRender = false;
         this.dropDown.snapTo({index: 1})
+      } else {
+        this.calendar.scrollToDay(this.state.selectedDay, 100 - ((this.screenHeight / 2) - 16), true);
       }
     }, 0);
     const maxHeight = this.screenHeight - 75;
@@ -277,7 +282,7 @@ export default class AgendaView extends Component {
       bottom: 0,
       left: 0,
       right: 0,
-      opacity: (firstRender) ? 0 : 1,
+      opacity: (firstDraggableRender) ? 0 : 1,
     }}>
       <Interactable.View
         verticalOnly={true}

--- a/src/agenda/style.android.js
+++ b/src/agenda/style.android.js
@@ -9,21 +9,22 @@ export default function styleConstructor(theme = {}) {
       top: 0,
       left: 0,
       right: 0,
-      borderBottomWidth: 1,
-      borderColor: appStyle.separatorColor
+      // borderBottomWidth: 1,
+      // borderColor: appStyle.separatorColor
     },
     calendarContainer: {
       position: 'absolute',
       top: 0,
       left: 0,
-      right: 0
+      right: 0,
+      bottom: 0,
     },
     knobContainer: {
       flex: 1,
       position: 'absolute',
       left: 0,
       right: 0,
-      height: 24,
+      height: 25,
       bottom: 0,
       alignItems: 'center',
       backgroundColor: appStyle.calendarBackground
@@ -55,7 +56,7 @@ export default function styleConstructor(theme = {}) {
     },
     reservations: {
       flex: 1,
-      marginTop: 100,
+      marginTop: 92,
       backgroundColor: appStyle.backgroundColor
     },
   });

--- a/src/agenda/style.android.js
+++ b/src/agenda/style.android.js
@@ -12,6 +12,12 @@ export default function styleConstructor(theme = {}) {
       borderBottomWidth: 1,
       borderColor: appStyle.separatorColor
     },
+    calendarContainer: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0
+    },
     knobContainer: {
       flex: 1,
       position: 'absolute',
@@ -33,7 +39,6 @@ export default function styleConstructor(theme = {}) {
       position: 'absolute',
       left: 0,
       right: 0,
-      top: 0,
       flexDirection: 'row',
       justifyContent: 'space-between',
       paddingLeft: 24,

--- a/src/agenda/style.android.js
+++ b/src/agenda/style.android.js
@@ -55,7 +55,7 @@ export default function styleConstructor(theme = {}) {
     },
     reservations: {
       flex: 1,
-      marginTop: 104,
+      marginTop: 100,
       backgroundColor: appStyle.backgroundColor
     },
   });

--- a/src/agenda/style.js
+++ b/src/agenda/style.js
@@ -56,7 +56,7 @@ export default function styleConstructor(theme = {}) {
     },
     reservations: {
       flex: 1,
-      marginTop: 104,
+      marginTop: 100,
       backgroundColor: appStyle.backgroundColor
     },
   });

--- a/src/agenda/style.js
+++ b/src/agenda/style.js
@@ -12,6 +12,12 @@ export default function styleConstructor(theme = {}) {
       borderBottomWidth: 1,
       borderColor: appStyle.separatorColor
     },
+    calendarContainer: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0
+    },
     knobContainer: {
       flex: 1,
       position: 'absolute',

--- a/src/agenda/style.js
+++ b/src/agenda/style.js
@@ -16,7 +16,8 @@ export default function styleConstructor(theme = {}) {
       position: 'absolute',
       top: 0,
       left: 0,
-      right: 0
+      right: 0,
+      bottom: 0,
     },
     knobContainer: {
       flex: 1,
@@ -39,7 +40,6 @@ export default function styleConstructor(theme = {}) {
       position: 'absolute',
       left: 0,
       right: 0,
-      top: 0,
       flexDirection: 'row',
       justifyContent: 'space-around',
       marginLeft: 15,
@@ -56,7 +56,7 @@ export default function styleConstructor(theme = {}) {
     },
     reservations: {
       flex: 1,
-      marginTop: 100,
+      marginTop: 90,
       backgroundColor: appStyle.backgroundColor
     },
   });


### PR DESCRIPTION


React-native-interactable make it possible to have very fluid interactions. This pull request add the possibility to drag the calendar down.

As suggested in #55, the functionality is optional. If draggable is set to false, the current option will be used (click on the knob to expand the calendar).

I did not have an iphone to test on IOS. 

There is probably some work left to do (and doc), but I wanted to have feedback on it (whether or not it make sense for this library to have this kind of integration) before putting more work into it.

![draggable_calendar](https://user-images.githubusercontent.com/13083475/27014601-2bb1086e-4eca-11e7-8c50-cc596249f2ac.gif)


