### PR TITLE
Updates to <Calendar> styles to allow customization

### DIFF
--- a/src/calendar/day/basic/style.js
+++ b/src/calendar/day/basic/style.js
@@ -11,7 +11,8 @@ export default function styleConstructor(theme={}) {
     },
     text: {
       marginTop: 4,
-      fontSize: 16,
+      fontSize: appStyle.textDayFontSize,
+      fontFamily: appStyle.textDayFontFamily,
       fontWeight: '300',
       color: appStyle.dayTextColor,
       backgroundColor: 'rgba(255, 255, 255, 0)'

--- a/src/calendar/day/interactive/style.js
+++ b/src/calendar/day/interactive/style.js
@@ -35,7 +35,8 @@ export default function styleConstructor(theme={}) {
     },
     text: {
       marginTop: 7,
-      fontSize: 16,
+      fontSize: appStyle.textDayFontSize,
+      fontFamily: appStyle.textDayFontFamily,
       fontWeight: '300',
       color: appStyle.dayTextColor || '#2d4150',
       backgroundColor: 'rgba(255, 255, 255, 0)'
@@ -68,4 +69,3 @@ export default function styleConstructor(theme={}) {
     }
   });
 }
-

--- a/src/calendar/header/style.js
+++ b/src/calendar/header/style.js
@@ -12,7 +12,8 @@ export default function(theme={}) {
       alignItems: 'center'
     },
     monthText: {
-      fontSize: 16,
+      fontSize: appStyle.textMonthFontSize,
+      fontFamily: appStyle.textMonthFontFamily,
       fontWeight: '300',
       color: appStyle.monthTextColor,
       margin: 10
@@ -40,7 +41,8 @@ export default function(theme={}) {
       marginBottom: 7,
       width: 32,
       textAlign: 'center',
-      fontSize: 13,
+      fontSize: appStyle.textDayHeaderFontSize,
+      fontFamily: appStyle.textDayHeaderFontFamily,
       color: appStyle.textSectionTitleColor
     }
   });

--- a/src/style.js
+++ b/src/style.js
@@ -11,10 +11,10 @@ export const textColor = '#43515c';
 export const textLinkColor = '#00adf5';
 export const textSecondaryColor = '#7a92a5';
 
-export const textDayFontFamily = "System";
-export const textMonthFontFamily = "System";
-export const textDayHeaderFontFamily = "System";
-export const textTodayFontFamily = "System";
+export const textDayFontFamily = 'System';
+export const textMonthFontFamily = 'System';
+export const textDayHeaderFontFamily = 'System';
+export const textTodayFontFamily = 'System';
 
 export const textDayFontSize = 16;
 export const textMonthFontSize = 16;

--- a/src/style.js
+++ b/src/style.js
@@ -11,6 +11,15 @@ export const textColor = '#43515c';
 export const textLinkColor = '#00adf5';
 export const textSecondaryColor = '#7a92a5';
 
+export const textDayFontFamily = "System";
+export const textMonthFontFamily = "System";
+export const textDayHeaderFontFamily = "System";
+export const textTodayFontFamily = "System";
+
+export const textDayFontSize = 16
+export const textMonthFontSize = 16
+export const textDayHeaderFontSize = 13
+
 export const calendarBackground = foregroundColor;
 export const textSectionTitleColor = '#b6c1cd';
 export const selectedDayBackgroundColor = textLinkColor;

--- a/src/style.js
+++ b/src/style.js
@@ -16,9 +16,9 @@ export const textMonthFontFamily = "System";
 export const textDayHeaderFontFamily = "System";
 export const textTodayFontFamily = "System";
 
-export const textDayFontSize = 16
-export const textMonthFontSize = 16
-export const textDayHeaderFontSize = 13
+export const textDayFontSize = 16;
+export const textMonthFontSize = 16;
+export const textDayHeaderFontSize = 13;
 
 export const calendarBackground = foregroundColor;
 export const textSectionTitleColor = '#b6c1cd';


### PR DESCRIPTION
This pull request gives the ability to set appStyle props to change the fontFamily and fontSize for <Calendar> component. 

The default "System" font and default sizes are retained and used as a backup if the props are not defined.

There likely is a more elegant way to do this and if you have any suggestions I'd be happy to make modifications.

**New props**

- textDayFontFamily
- textMonthFontFamily
- textDayHeaderFontFamily
- textTodayFontFamily
- textDayFontSize
- textMonthFontSize
- textDayHeaderFontSize

**Original**
<img width="362" alt="screen shot 2017-06-20 at 12 17 38 pm" src="https://user-images.githubusercontent.com/19731815/27343925-7f344714-55b2-11e7-99d7-211051c6a214.png">

**With props added**
<img width="364" alt="screen shot 2017-06-20 at 12 16 44 pm" src="https://user-images.githubusercontent.com/19731815/27343934-84bb948a-55b2-11e7-828b-fa228e37eb84.png">
