### PR TITLE
Add option to disable all dates and provide array of dates to enable

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -115,7 +115,7 @@ class Calendar extends Component {
     const maxDate = parseDate(this.props.maxDate);
 
     if(this.props.enabledDates && this.props.disabledByDefault) {
-      if(!this.props.enabledDates.includes(day.toString("yyyy-MM-dd"))) {
+      if(!this.props.enabledDates.includes(day.toString('yyyy-MM-dd'))) {
         return;
       }
     }
@@ -158,7 +158,7 @@ class Calendar extends Component {
     } else if (dateutils.sameDate(day, XDate())) {
       state = 'today';
     } else if (this.props.enabledDates && this.props.disabledByDefault) {
-      if(this.props.enabledDates.includes(day.toString("yyyy-MM-dd"))) {
+      if(this.props.enabledDates.includes(day.toString('yyyy-MM-dd'))) {
         state = '';
       }
     }

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -21,6 +21,12 @@ class Calendar extends Component {
     // Collection of dates that have to be marked. Default = {}
     markedDates: PropTypes.object,
 
+    // Collection of dates that should be enabled. Default = {}
+    enabledDates: PropTypes.array,
+
+    // Disable dates by default. Default = false
+    disabledByDefault: PropTypes.bool,
+
     // Specify style for calendar container element. Default = {}
     style: ViewPropTypes.style,
 
@@ -107,6 +113,13 @@ class Calendar extends Component {
   pressDay(day) {
     const minDate = parseDate(this.props.minDate);
     const maxDate = parseDate(this.props.maxDate);
+
+    if(this.props.enabledDates && this.props.disabledByDefault) {
+      if(!this.props.enabledDates.includes(day.toString("yyyy-MM-dd"))) {
+        return;
+      }
+    }
+
     if (!(minDate && !dateutils.isGTE(day, minDate)) && !(maxDate && !dateutils.isLTE(day, maxDate))) {
       this.updateMonth(day);
       if (this.props.onDayPress) {
@@ -135,7 +148,7 @@ class Calendar extends Component {
   renderDay(day, id) {
     const minDate = parseDate(this.props.minDate);
     const maxDate = parseDate(this.props.maxDate);
-    let state = '';
+    let state = this.props.disabledByDefault ? 'disabled' : '';
     if (this.isSelected(day)) {
       state = 'selected';
     } else if ((minDate && !dateutils.isGTE(day, minDate)) || (maxDate && !dateutils.isLTE(day, maxDate))) {
@@ -144,7 +157,12 @@ class Calendar extends Component {
       state = 'disabled';
     } else if (dateutils.sameDate(day, XDate())) {
       state = 'today';
+    } else if (this.props.enabledDates && this.props.disabledByDefault) {
+      if(this.props.enabledDates.includes(day.toString("yyyy-MM-dd"))) {
+        state = '';
+      }
     }
+
     let dayComp;
     if (!dateutils.sameMonth(day, this.state.currentMonth) && this.props.hideExtraDays) {
       if (this.props.markingType === 'interactive') {


### PR DESCRIPTION
This pull request creates two new <Calendar> props: 
```
// Collection of dates that should be enabled. Default = {}
    enabledDates: PropTypes.array,

// Disable dates by default. Default = false
    disabledByDefault: PropTypes.bool,
```
They can be used like this:
```
<Calendar
    ...
    disabledByDefault = {true}
    enabledDates = {['2017-06-20', '2017-06-23', '2017-06-25']}
    ...
/>
```
During the initial styling, if disabledByDefault == true, then it checks if the day is included in the enabledDates array.  

In pressDay it also checks to see if the new props exist and simply returns; if true.  It uses the same XDate library to format the day into this string format 'yyyy-MM-dd.'

There may be a better way to handle checking the array, especially with extremely large data sets. 

**Screenshot**
<img width="359" alt="screen shot 2017-06-20 at 4 43 59 pm" src="https://user-images.githubusercontent.com/19731815/27355408-ec7e556e-55d8-11e7-9f07-edd763c79022.png">

**LIMITATION**
This does not work with date ranges.  For example, if I have the array of values above, the user can click on 6/20 and then on 6/25 and complete the range.  I don't believe this is something that you will want to solve for in the library, and should instead be handled in the individual app code.

If there are modification suggestions or areas you need improved, please let me know and I'll try to take care of them.