### PR TITLE
renderItem callback could receive the date

### DIFF
--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -133,7 +133,7 @@ class ReactComp extends Component {
     let content;
     if (reservation) {
       const firstItem = date ? true : false;
-      content = this.props.renderItem(reservation, firstItem);
+      content = this.props.renderItem(reservation, firstItem, date);
     } else {
       content = this.props.renderEmptyDate(date);
     }


### PR DESCRIPTION
I don't really see why renderEmptyDate would receive it and not renderItem. I need this because my last day item is always a CTA button to "add availability". Without the date I have to resort on trying to get back the date from the items list of my component which is a bit annoying