### PR TITLE
Prevent week day names from using more than one line. Related to #101

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -322,7 +322,7 @@ export default class AgendaView extends Component {
         </Animated.View>
         <Animated.View style={weekdaysStyle}>
           {weekDaysNames.map((day) => (
-            <Text key={day} style={this.styles.weekday}>{day}</Text>
+            <Text key={day} style={this.styles.weekday} numberOfLines={1}>{day}</Text>
           ))}
         </Animated.View>
         <Animated.ScrollView


### PR DESCRIPTION
#101 reproduces differently on my machine when weekday names are too long, so this may not be a full fix.