### PR TITLE
remove componentWillReceiveProps

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -76,15 +76,6 @@ class Calendar extends Component {
     this.shouldComponentUpdate = shouldComponentUpdate;
   }
 
-  componentWillReceiveProps(nextProps) {
-    const current= parseDate(nextProps.current);
-    if (current && current.toString('yyyy MM') !== this.state.currentMonth.toString('yyyy MM')) {
-      this.setState({
-        currentMonth: current.clone()
-      });
-    }
-  }
-
   updateMonth(day, doNotTriggerListeners) {
     if (day.toString('yyyy MM') === this.state.currentMonth.toString('yyyy MM')) {
       return;


### PR DESCRIPTION
This is the proposed fix for issue #99 
 componentWillReceiveProps method is resetting the currentMonth when a current date is passed as props overriding the next/prev arrow behavior. The current month behavior is already covered by the constructor. 