### PR TITLE
Add fallback to support RN version < 0.44

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -19,13 +19,16 @@ import { VelocityTracker } from '../input';
 const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
 
+//Fallback when RN version is < 0.44
+const viewPropTypes = ViewPropTypes || View.propTypes;
+
 export default class AgendaView extends Component {
   static propTypes = {
     // Specify theme properties to override specific styles for calendar parts. Default = {}
     theme: PropTypes.object,
 
     // agenda container style
-    style: ViewPropTypes.style,
+    style: viewPropTypes.style,
 
     // the list of items that have to be displayed in agenda. If you want to render item as empty date
     // the value of date key has to be an empty array []. If there exists no value for date key it is


### PR DESCRIPTION
To check if ViewPropTypes is available, if no, fallback to use View.propTypes