### PR TITLE
Add missing "backgroundColor" theme prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The loading indicator next to month name will be displayed if `<Calendar />` has
   }}
   // Specify theme properties to override specific styles for calendar parts. Default = {}
   theme={{
+    backgroundColor: '#ffffff',
     calendarBackground: '#ffffff',
     textSectionTitleColor: '#b6c1cd',
     selectedDayBackgroundColor: '#00adf5',


### PR DESCRIPTION
This made me loose some time due to not understanding why `calendarBackground` was not applying to the reservation-list