### PR TITLE
Agenda: allow custom markedDates

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ An advanced agenda component that can display interactive listings for calendar 
   rowHasChanged={(r1, r2) => {return r1.text !== r2.text}}
   // Hide knob button. Default = false
   hideKnob={true}
+  // By default, agenda dates are marked if they have item, but you can override this if needed
+  markedDates={{
+    '2012-05-16': {selected: true, marked: true},
+    '2012-05-17': {marked: true},
+    '2012-05-18': {disabled: true}
+  }}
   // agenda theme
   theme={{
     ...calendarTheme,

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ An advanced agenda component that can display interactive listings for calendar 
   rowHasChanged={(r1, r2) => {return r1.text !== r2.text}}
   // Hide knob button. Default = false
   hideKnob={true}
-  // By default, agenda dates are marked if they have item, but you can override this if needed
+  // By default, agenda dates are marked if they have at least one item, but you can override this if needed
   markedDates={{
     '2012-05-16': {selected: true, marked: true},
     '2012-05-17': {marked: true},

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -58,6 +58,9 @@ export default class AgendaView extends Component {
     minDate: PropTypes.any,
     // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
     maxDate: PropTypes.any,
+    
+    // Collection of dates that have to be marked. Default = items
+    markedDates: PropTypes.object,
 
     // Hide knob button. Default = false
     hideKnob: PropTypes.bool,
@@ -333,7 +336,7 @@ export default class AgendaView extends Component {
               maxDate={this.props.maxDate}
               selected={[this.state.selectedDay]}
               current={this.currentMonth}
-              markedDates={this.props.items}
+              markedDates={this.props.markedDates || this.props.items}
               onDayPress={this._chooseDayFromCalendar.bind(this)}
               scrollingEnabled={this.state.calendarScrollable}
               hideExtraDays={this.state.calendarScrollable}


### PR DESCRIPTION
current markedDates=items default setting is not flexible enough for my usecase which if to mark the date only if one row of the day match a predicate