### PR TITLE
Day: allow custom marking to override state marking

### DIFF
--- a/src/calendar/day/basic/index.js
+++ b/src/calendar/day/basic/index.js
@@ -53,7 +53,7 @@ class Day extends Component {
       textStyle.push(this.style.alignedText);
     }
 
-    if (typeof marked.selected !== 'undefined' ? marked.selected : this.props.state === 'selected' || ) {
+    if (typeof marked.selected !== 'undefined' ? marked.selected : this.props.state === 'selected') {
       containerStyle.push(this.style.selected);
       dotStyle.push(this.style.selectedDot);
       textStyle.push(this.style.selectedText);

--- a/src/calendar/day/basic/index.js
+++ b/src/calendar/day/basic/index.js
@@ -53,11 +53,11 @@ class Day extends Component {
       textStyle.push(this.style.alignedText);
     }
 
-    if (this.props.state === 'selected' || marked.selected) {
+    if (typeof marked.selected !== 'undefined' ? marked.selected : this.props.state === 'selected' || ) {
       containerStyle.push(this.style.selected);
       dotStyle.push(this.style.selectedDot);
       textStyle.push(this.style.selectedText);
-    } else if (this.props.state === 'disabled' || marked.disabled) {
+    } else if (typeof marked.disabled !== 'undefined' ? marked.disabled : this.props.state === 'disabled') {
       textStyle.push(this.style.disabledText);
     } else if (this.props.state === 'today') {
       textStyle.push(this.style.todayText);


### PR DESCRIPTION
Currently if I provide 


`markedDays={{"dayString": {disabled: false}}}` to Calendar it won't necessarily "not mark" the day, particularly if the Calendar has computed state="disabled"

I think it makes sense to let the user override the state computated in parent calendar if he wants to
