### PR TITLE
fix(calendar-list): fixes onscroll returning early on web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 .idea
 yarn.lock
+.vscode

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -188,7 +188,7 @@ class CalendarList extends Component {
   }
 
   onScroll(event) {
-    if (Platform.OS !== 'android') {
+    if (Platform.OS !== 'android' && Platform.OS !== 'web') {
       return;
     }
     if (!this.state.scrolled) {
@@ -250,8 +250,8 @@ class CalendarList extends Component {
         initialListSize={this.pastScrollRange * this.futureScrollRange + 1}
         dataSource={this.state.dataSource}
         scrollRenderAheadDistance={calendarHeight}
-                //snapToAlignment='start'
-                //snapToInterval={calendarHeight}
+        //snapToAlignment='start'
+        //snapToInterval={calendarHeight}
         pageSize={1}
         removeClippedSubviews
         onChangeVisibleRows={this.visibleRowsChange.bind(this)}


### PR DESCRIPTION
Hey hey! Thanks again for such an amazing library! Really love the API and its such a pleasure to work with! We are using this library for our cross-platform component lib and on web the calendar list view does not load months once the scroll into view due to the onScroll handler returning early for any platform that is not `android`. In a `react-native-web`/universal component system this causes web to not work.

____
![early-return](https://user-images.githubusercontent.com/3629876/29952232-207c263e-8e96-11e7-9e7a-264ac373020e.gif)
____

I have updated the check to only return specifically for ios and this fixes the issue. Let me know if you need me to do anything else! Thanks again for all of the hard work!

___
![with-ios-specific-check](https://user-images.githubusercontent.com/3629876/29952248-3cd2f600-8e96-11e7-997b-4a250ca72e48.gif)
___
