### PR TITLE
Fix CalendarList initialScrollIndex

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -168,7 +168,7 @@ class CalendarList extends Component {
         showsVerticalScrollIndicator={false}
         scrollEnabled={this.props.scrollingEnabled !== undefined ? this.props.scrollingEnabled : true}
         keyExtractor={(item, index) => index}
-        initialScrollIndex={this.props.current ? this.getMonthIndex(this.props.current) : false}
+        initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
         getItemLayout={this.getItemLayout}
       />
     );


### PR DESCRIPTION
## Description
Loading `CalendarList` without `current` prop set would cause it to be incorrectly scrolled to the earliest possible date.

## Expected result
The `CalendarList` should be scrolled to a current date in case no `current` prop is specified.

## Solution
Use `this.state.openDate` instead of `this.props.current` to properly handle the case where the `current` prop is not set and is instead defaulted to new Date.