### PR TITLE
Fixing marked dates gap issue on Android

### DIFF
--- a/src/calendar/day/interactive/index.js
+++ b/src/calendar/day/interactive/index.js
@@ -109,6 +109,7 @@ class Day extends Component {
     const textStyle = [this.style.text];
     let leftFillerStyle = {};
     let rightFillerStyle = {};
+    let fillerStyle = {};
     let fillers;
 
     if (this.props.state === 'disabled') {
@@ -159,6 +160,7 @@ class Day extends Component {
       } else if (flags.day) {
         leftFillerStyle = {backgroundColor: flags.day.color};
         rightFillerStyle = {backgroundColor: flags.day.color};
+        fillerStyle = {backgroundColor: flags.day.color};
       } else if (flags.endingDay && flags.startingDay) {
         rightFillerStyle = {
           backgroundColor: this.theme.calendarBackground
@@ -172,7 +174,7 @@ class Day extends Component {
       }
 
       fillers = (
-        <View style={this.style.fillers}>
+        <View style={[this.style.fillers, fillerStyle]}>
           <View style={[this.style.leftFiller, leftFillerStyle]}/>
           <View style={[this.style.rightFiller, rightFillerStyle]}/>
         </View>


### PR DESCRIPTION
This pull request fixes #61 and #158 and is a fix across iOS (although not problematic) and Android.

**Fix**
The fix simply applies a `backgroundColor` style to the filler.

**Screenshot**

Before:
![screen shot 2017-09-15 at 11 29 22](https://user-images.githubusercontent.com/5614282/30478517-42eb16d4-9a09-11e7-897d-a71436faa745.png)

After:
![screen shot 2017-09-15 at 11 30 05](https://user-images.githubusercontent.com/5614282/30478521-47fcb9fc-9a09-11e7-8196-4dd4ad52fbea.png)

