### PR TITLE
Custom rendering a day when markingType is 'period'

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ LocaleConfig.defaultLocale = 'fr';
   firstDay={1}
   // Hide day names. Default = false
   hideDayNames={true}
+  // Replace default day rendering with a custom one (only if markingType is 'interactive')
+  // renderDay={(textStyle, xDate) => (<Text style={textStyle}>{String(xDate.getDate())}</Text>)}
 />
 ```
 

--- a/src/calendar/day/interactive/index.js
+++ b/src/calendar/day/interactive/index.js
@@ -23,6 +23,7 @@ class Day extends Component {
     day: PropTypes.object,
 
     markingExists: PropTypes.bool,
+    renderDay: PropTypes.func
   };
 
   constructor(props) {
@@ -31,6 +32,7 @@ class Day extends Component {
     this.style = styleConstructor(props.theme);
     this.markingStyle = this.getDrawingStyle(props.marked);
     this.onDayPress = this.onDayPress.bind(this);
+    this.renderDay = this.renderDay.bind(this);
   }
 
   onDayPress() {
@@ -102,6 +104,15 @@ class Day extends Component {
       }
       return prev;
     }, {});
+  }
+
+  renderDay(textStyle) {
+    if (this.props.renderDay) {
+      return this.props.renderDay(textStyle, this.props.day);
+    }
+    return (
+      <Text style={textStyle}>{String(this.props.children)}</Text>
+    );
   }
 
   render() {
@@ -184,7 +195,7 @@ class Day extends Component {
         <View style={this.style.wrapper}>
           {fillers}
           <View style={containerStyle}>
-            <Text style={textStyle}>{String(this.props.children)}</Text>
+            { this.renderDay(textStyle) }
           </View>
         </View>
       </TouchableWithoutFeedback>

--- a/src/calendar/day/interactive/index.js
+++ b/src/calendar/day/interactive/index.js
@@ -195,7 +195,7 @@ class Day extends Component {
         <View style={this.style.wrapper}>
           {fillers}
           <View style={containerStyle}>
-            { this.renderDay(textStyle) }
+            {this.renderDay(textStyle)}
           </View>
         </View>
       </TouchableWithoutFeedback>

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -63,7 +63,9 @@ class Calendar extends Component {
     // Disables changing month when click on days of other months (when hideExtraDays is false). Default = false
     disableMonthChange: PropTypes.bool,
     //Hide day names. Default = false
-    hideDayNames: PropTypes.bool
+    hideDayNames: PropTypes.bool,
+    // Replace default day with custom one
+    renderDay: PropTypes.func
   };
 
   constructor(props) {
@@ -177,6 +179,7 @@ class Calendar extends Component {
             day={day}
             marked={this.getDateMarking(day)}
             markingExists={markingExists}
+            renderDay={this.props.renderDay}
           >
             {day.getDate()}
           </DayComp>


### PR DESCRIPTION
I needed to add another row for each day in the calendar with a custom text:

![screen shot 2017-09-22 at 13 36 48](https://user-images.githubusercontent.com/31845465/30741103-49ba0194-9f9c-11e7-92d8-0163d17a8f03.png)

This works only if markingType is 'interactive'. 

I wasn't sure how it should be done with simple markingType.