### PR TITLE
Add styling customization options

### DIFF
--- a/src/calendar/header/style.js
+++ b/src/calendar/header/style.js
@@ -16,7 +16,8 @@ export default function(theme={}) {
       fontFamily: appStyle.textMonthFontFamily,
       fontWeight: '300',
       color: appStyle.monthTextColor,
-      margin: 10
+      margin: 10,
+      ...appStyle.monthText
     },
     arrow: {
       padding: 10
@@ -43,7 +44,8 @@ export default function(theme={}) {
       textAlign: 'center',
       fontSize: appStyle.textDayHeaderFontSize,
       fontFamily: appStyle.textDayHeaderFontFamily,
-      color: appStyle.textSectionTitleColor
+      color: appStyle.textSectionTitleColor,
+      ...appStyle.dayHeader
     }
   });
 }

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -17,6 +17,8 @@ import shouldComponentUpdate from './updater';
 //Fallback when RN version is < 0.44
 const viewPropTypes = ViewPropTypes || View.propTypes;
 
+const DATE_FORMAT = 'yyyy-MM-dd'
+
 const EmptyArray = [];
 
 class Calendar extends Component {
@@ -62,7 +64,7 @@ class Calendar extends Component {
     monthFormat: PropTypes.string,
     // Disables changing month when click on days of other months (when hideExtraDays is false). Default = false
     disableMonthChange: PropTypes.bool,
-    //Hide day names. Default = false
+    // Hide day names. Default = false
     hideDayNames: PropTypes.bool
   };
 
@@ -189,7 +191,7 @@ class Calendar extends Component {
     if (!this.props.markedDates) {
       return false;
     }
-    const dates = this.props.markedDates[day.toString('yyyy-MM-dd')] || EmptyArray;
+    const dates = this.props.markedDates[day.toString(DATE_FORMAT)] || EmptyArray;
     if (dates.length || dates) {
       return dates;
     } else {
@@ -215,7 +217,7 @@ class Calendar extends Component {
     let indicator;
     const current = parseDate(this.props.current);
     if (current) {
-      const lastMonthOfDay = current.clone().addMonths(1, true).setDate(1).addDays(-1).toString('yyyy-MM-dd');
+      const lastMonthOfDay = current.clone().addMonths(1, true).setDate(1).addDays(-1).toString(DATE_FORMAT);
       if (this.props.displayLoadingIndicator &&
           !(this.props.markedDates && this.props.markedDates[lastMonthOfDay])) {
         indicator = true;

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -17,8 +17,6 @@ import shouldComponentUpdate from './updater';
 //Fallback when RN version is < 0.44
 const viewPropTypes = ViewPropTypes || View.propTypes;
 
-const DATE_FORMAT = 'yyyy-MM-dd'
-
 const EmptyArray = [];
 
 class Calendar extends Component {
@@ -191,7 +189,7 @@ class Calendar extends Component {
     if (!this.props.markedDates) {
       return false;
     }
-    const dates = this.props.markedDates[day.toString(DATE_FORMAT)] || EmptyArray;
+    const dates = this.props.markedDates[day.toString('yyyy-MM-dd')] || EmptyArray;
     if (dates.length || dates) {
       return dates;
     } else {
@@ -217,9 +215,9 @@ class Calendar extends Component {
     let indicator;
     const current = parseDate(this.props.current);
     if (current) {
-      const lastMonthOfDay = current.clone().addMonths(1, true).setDate(1).addDays(-1).toString(DATE_FORMAT);
+      const lastDayOfMonth = current.clone().addMonths(1, true).setDate(1).addDays(-1).toString('yyyy-MM-dd');
       if (this.props.displayLoadingIndicator &&
-          !(this.props.markedDates && this.props.markedDates[lastMonthOfDay])) {
+          !(this.props.markedDates && this.props.markedDates[lastDayOfMonth])) {
         indicator = true;
       }
     }


### PR DESCRIPTION
This PR adds a few styling customisation options as well as some minor fixes.

However, in the future (maybe in a new version, cause it's a breaking change) it would be cool to have a more structured way of styling each component so we can allow full customisation of the styles while keeping a default.

Example:

```
const headerStyle = {
  // all the header styles,
  ...appStyle.header
}

const dayStyle = {
  // all the day styles,
  ...appStyle.day
}
```

This way it would be easy for the user to change whatever we wants regarding styles (instead of just some props that we keep adding so we can customize) and we can even use the "normal" stylesheet api, instead of names like `textSectionTitleColor` it turns out even harder to use and document.