### PR TITLE
Hotfix/standardization

### DIFF
--- a/src/dateutils.js
+++ b/src/dateutils.js
@@ -22,8 +22,8 @@ function isLTE(a, b) {
 }
 
 function fromTo(a, b) {
-  var days = [];
-  var from = +a, to = +b;
+  const days = [];
+  let from = +a, to = +b;
   for (; from <= to; from = new XDate(from, true).addDays(1).getTime()) {
     days.push(new XDate(from, true));
   }
@@ -31,11 +31,11 @@ function fromTo(a, b) {
 }
 
 function month(xd) {
-  var year = xd.getFullYear(), month = xd.getMonth();
-  var days = new Date(year, month + 1, 0).getDate();
+  const year = xd.getFullYear(), month = xd.getMonth();
+  const days = new Date(year, month + 1, 0).getDate();
 
-  var firstDay = new XDate(year, month, 1, 0, 0, 0, true);
-  var lastDay = new XDate(year, month, days, 0, 0, 0, true);
+  const firstDay = new XDate(year, month, 1, 0, 0, 0, true);
+  const lastDay = new XDate(year, month, days, 0, 0, 0, true);
 
   return fromTo(firstDay, lastDay);
 }
@@ -50,20 +50,21 @@ function weekDayNames(firstDayOfWeek = 0) {
 }
 
 function page(xd, firstDayOfWeek) {
-  var days = month(xd), before = [], after = [];
+  const days = month(xd);
+  let before = [], after = [];
 
-  var fdow = ((7 + firstDayOfWeek) % 7) || 7;
-  var ldow = (fdow + 6) % 7;
+  const fdow = ((7 + firstDayOfWeek) % 7) || 7;
+  const ldow = (fdow + 6) % 7;
 
   firstDayOfWeek = firstDayOfWeek || 0;
 
-  var from = days[0].clone();
+  const from = days[0].clone();
   if (from.getDay() !== fdow) {
     from.addDays(-(from.getDay() + 7 - fdow) % 7);
   }
 
-  var to = days[days.length - 1].clone();
-  var day = to.getDay();
+  const to = days[days.length - 1].clone();
+  const day = to.getDay();
   if (day !== ldow) {
     to.addDays((ldow + 7 - day) % 7);
   }

--- a/src/dateutils.spec.js
+++ b/src/dateutils.spec.js
@@ -1,11 +1,11 @@
-const xdate = require('xdate');
+const XDate = require('xdate');
 const dateutils = require('./dateutils');
 
 describe('dateutils', function () {
   describe('sameMonth()', function () {
     it('2014-01-01 === 2014-01-10', function () {
-      const a = xdate(2014, 0, 1, true);
-      const b = xdate(2014, 0, 10, true);
+      const a = XDate(2014, 0, 1, true);
+      const b = XDate(2014, 0, 10, true);
       expect(dateutils.sameMonth(a, b)).toEqual(true);
     });
     it('for non-XDate instances is false', function () {
@@ -13,8 +13,8 @@ describe('dateutils', function () {
       expect(dateutils.sameMonth(123, 345)).toEqual(false);
       expect(dateutils.sameMonth(null, false)).toEqual(false);
 
-      const a = xdate(2014, 0, 1, true);
-      const b = xdate(2014, 0, 10, true);
+      const a = XDate(2014, 0, 1, true);
+      const b = XDate(2014, 0, 10, true);
       expect(dateutils.sameMonth(a, undefined)).toEqual(false);
       expect(dateutils.sameMonth(null, b)).toEqual(false);
     });
@@ -22,26 +22,26 @@ describe('dateutils', function () {
 
   describe('isLTE()', function () {
     it('2014-01-20 >= 2013-12-31', function () {
-      const a = xdate(2013, 12, 31);
-      const b = xdate(2014, 1, 20);
+      const a = XDate(2013, 12, 31);
+      const b = XDate(2014, 1, 20);
       expect(dateutils.isLTE(a, b)).toBe(true);
     });
 
     it('2014-10-20 >= 2014-10-19', function () {
-      const a = xdate(2014, 10, 19);
-      const b = xdate(2014, 10, 20);
+      const a = XDate(2014, 10, 19);
+      const b = XDate(2014, 10, 20);
       expect(dateutils.isLTE(a, b)).toBe(true);
     });
 
     it('2014-10-20 >= 2014-09-30', function () {
-      const a = xdate(2014, 9, 30);
-      const b = xdate(2014, 10, 20);
+      const a = XDate(2014, 9, 30);
+      const b = XDate(2014, 10, 20);
       expect(dateutils.isLTE(a, b)).toBe(true);
     });
 
     it('works for dates that differ by less than a day', function () {
-      const a = xdate(2014, 9, 30, 0, 1, 0);
-      const b = xdate(2014, 9, 30, 1, 0, 1);
+      const a = XDate(2014, 9, 30, 0, 1, 0);
+      const b = XDate(2014, 9, 30, 1, 0, 1);
       expect(dateutils.isLTE(a, b)).toBe(true);
       expect(dateutils.isLTE(b, a)).toBe(true);
     });
@@ -49,26 +49,26 @@ describe('dateutils', function () {
 
   describe('isGTE()', function () {
     it('2014-01-20 >= 2013-12-31', function () {
-      const a = xdate(2013, 12, 31);
-      const b = xdate(2014, 1, 20);
+      const a = XDate(2013, 12, 31);
+      const b = XDate(2014, 1, 20);
       expect(dateutils.isGTE(b, a)).toBe(true);
     });
 
     it('2014-10-20 >= 2014-10-19', function () {
-      const a = xdate(2014, 10, 19);
-      const b = xdate(2014, 10, 20);
+      const a = XDate(2014, 10, 19);
+      const b = XDate(2014, 10, 20);
       expect(dateutils.isGTE(b, a)).toBe(true);
     });
 
     it('2014-10-20 >= 2014-09-30', function () {
-      const a = xdate(2014, 9, 30);
-      const b = xdate(2014, 10, 20);
+      const a = XDate(2014, 9, 30);
+      const b = XDate(2014, 10, 20);
       expect(dateutils.isGTE(b, a)).toBe(true);
     });
 
     it('works for dates that differ by less than a day', function () {
-      const a = xdate(2014, 9, 30, 0, 1, 0);
-      const b = xdate(2014, 9, 30, 1, 0, 1);
+      const a = XDate(2014, 9, 30, 0, 1, 0);
+      const b = XDate(2014, 9, 30, 1, 0, 1);
       expect(dateutils.isGTE(a, b)).toBe(true);
       expect(dateutils.isGTE(b, a)).toBe(true);
     });
@@ -76,54 +76,54 @@ describe('dateutils', function () {
 
   describe('month()', function () {
     it('2014 May', function () {
-      const days = dateutils.month(xdate(2014, 4, 1));
+      const days = dateutils.month(XDate(2014, 4, 1));
       expect(days.length).toBe(31);
     });
 
     it('2014 August', function () {
-      const days = dateutils.month(xdate(2014, 7, 1));
+      const days = dateutils.month(XDate(2014, 7, 1));
       expect(days.length).toBe(31);
     });
   });
 
   describe('page()', function () {
     it('2014 March', function () {
-      const days = dateutils.page(xdate(2014, 2, 23, true));
+      const days = dateutils.page(XDate(2014, 2, 23, true));
       expect(days.length).toBe(42);
       expect(days[0].toString())
-        .toBe(xdate(2014, 1, 23, 0, 0, 0, true).toString());
+        .toBe(XDate(2014, 1, 23, 0, 0, 0, true).toString());
       expect(days[days.length - 1].toString())
-        .toBe(xdate(2014, 3, 5, 0, 0, 0, true).toString());
+        .toBe(XDate(2014, 3, 5, 0, 0, 0, true).toString());
     });
 
     it('2014 May', function () {
-      const days = dateutils.page(xdate(2014, 4, 23));
+      const days = dateutils.page(XDate(2014, 4, 23));
       expect(days.length).toBe(35);
     });
 
     it('2014 June', function () {
-      const days = dateutils.page(xdate(2014, 5, 23));
+      const days = dateutils.page(XDate(2014, 5, 23));
       expect(days.length).toBe(35);
     });
 
     it('2014 August', function () {
-      const days = dateutils.page(xdate(2014, 7, 23));
+      const days = dateutils.page(XDate(2014, 7, 23));
       expect(days.length).toBe(42);
     });
 
     it('2014 October', function () {
-      const days = dateutils.page(xdate(2014, 9, 21));
+      const days = dateutils.page(XDate(2014, 9, 21));
       expect(days.length).toBe(35);
     });
 
     it('has all days in ascending order', function () {
       let days, i, len;
 
-      days = dateutils.page(xdate(2014, 2, 1));
+      days = dateutils.page(XDate(2014, 2, 1));
       for (i = 0, len = days.length - 1; i < len; i++) {
         expect(days[i].diffDays(days[i + 1])).toBe(1);
       }
-      days = dateutils.page(xdate(2014, 9, 1));
+      days = dateutils.page(XDate(2014, 9, 1));
       for (i = 0, len = days.length - 1; i < len; i++) {
         expect(days[i].diffDays(days[i + 1])).toBe(1);
       }

--- a/src/dateutils.spec.js
+++ b/src/dateutils.spec.js
@@ -4,8 +4,8 @@ const dateutils = require('./dateutils');
 describe('dateutils', function () {
   describe('sameMonth()', function () {
     it('2014-01-01 === 2014-01-10', function () {
-      var a = xdate(2014, 0, 1, true);
-      var b = xdate(2014, 0, 10, true);
+      const a = xdate(2014, 0, 1, true);
+      const b = xdate(2014, 0, 10, true);
       expect(dateutils.sameMonth(a, b)).toEqual(true);
     });
     it('for non-XDate instances is false', function () {
@@ -13,8 +13,8 @@ describe('dateutils', function () {
       expect(dateutils.sameMonth(123, 345)).toEqual(false);
       expect(dateutils.sameMonth(null, false)).toEqual(false);
 
-      var a = xdate(2014, 0, 1, true);
-      var b = xdate(2014, 0, 10, true);
+      const a = xdate(2014, 0, 1, true);
+      const b = xdate(2014, 0, 10, true);
       expect(dateutils.sameMonth(a, undefined)).toEqual(false);
       expect(dateutils.sameMonth(null, b)).toEqual(false);
     });
@@ -22,26 +22,26 @@ describe('dateutils', function () {
 
   describe('isLTE()', function () {
     it('2014-01-20 >= 2013-12-31', function () {
-      var a = xdate(2013, 12, 31);
-      var b = xdate(2014, 1, 20);
+      const a = xdate(2013, 12, 31);
+      const b = xdate(2014, 1, 20);
       expect(dateutils.isLTE(a, b)).toBe(true);
     });
 
     it('2014-10-20 >= 2014-10-19', function () {
-      var a = xdate(2014, 10, 19);
-      var b = xdate(2014, 10, 20);
+      const a = xdate(2014, 10, 19);
+      const b = xdate(2014, 10, 20);
       expect(dateutils.isLTE(a, b)).toBe(true);
     });
 
     it('2014-10-20 >= 2014-09-30', function () {
-      var a = xdate(2014, 9, 30);
-      var b = xdate(2014, 10, 20);
+      const a = xdate(2014, 9, 30);
+      const b = xdate(2014, 10, 20);
       expect(dateutils.isLTE(a, b)).toBe(true);
     });
 
     it('works for dates that differ by less than a day', function () {
-      var a = xdate(2014, 9, 30, 0, 1, 0);
-      var b = xdate(2014, 9, 30, 1, 0, 1);
+      const a = xdate(2014, 9, 30, 0, 1, 0);
+      const b = xdate(2014, 9, 30, 1, 0, 1);
       expect(dateutils.isLTE(a, b)).toBe(true);
       expect(dateutils.isLTE(b, a)).toBe(true);
     });
@@ -49,26 +49,26 @@ describe('dateutils', function () {
 
   describe('isGTE()', function () {
     it('2014-01-20 >= 2013-12-31', function () {
-      var a = xdate(2013, 12, 31);
-      var b = xdate(2014, 1, 20);
+      const a = xdate(2013, 12, 31);
+      const b = xdate(2014, 1, 20);
       expect(dateutils.isGTE(b, a)).toBe(true);
     });
 
     it('2014-10-20 >= 2014-10-19', function () {
-      var a = xdate(2014, 10, 19);
-      var b = xdate(2014, 10, 20);
+      const a = xdate(2014, 10, 19);
+      const b = xdate(2014, 10, 20);
       expect(dateutils.isGTE(b, a)).toBe(true);
     });
 
     it('2014-10-20 >= 2014-09-30', function () {
-      var a = xdate(2014, 9, 30);
-      var b = xdate(2014, 10, 20);
+      const a = xdate(2014, 9, 30);
+      const b = xdate(2014, 10, 20);
       expect(dateutils.isGTE(b, a)).toBe(true);
     });
 
     it('works for dates that differ by less than a day', function () {
-      var a = xdate(2014, 9, 30, 0, 1, 0);
-      var b = xdate(2014, 9, 30, 1, 0, 1);
+      const a = xdate(2014, 9, 30, 0, 1, 0);
+      const b = xdate(2014, 9, 30, 1, 0, 1);
       expect(dateutils.isGTE(a, b)).toBe(true);
       expect(dateutils.isGTE(b, a)).toBe(true);
     });
@@ -76,19 +76,19 @@ describe('dateutils', function () {
 
   describe('month()', function () {
     it('2014 May', function () {
-      var days = dateutils.month(xdate(2014, 4, 1));
+      const days = dateutils.month(xdate(2014, 4, 1));
       expect(days.length).toBe(31);
     });
 
     it('2014 August', function () {
-      var days = dateutils.month(xdate(2014, 7, 1));
+      const days = dateutils.month(xdate(2014, 7, 1));
       expect(days.length).toBe(31);
     });
   });
 
   describe('page()', function () {
     it('2014 March', function () {
-      var days = dateutils.page(xdate(2014, 2, 23, true));
+      const days = dateutils.page(xdate(2014, 2, 23, true));
       expect(days.length).toBe(42);
       expect(days[0].toString())
         .toBe(xdate(2014, 1, 23, 0, 0, 0, true).toString());
@@ -97,27 +97,27 @@ describe('dateutils', function () {
     });
 
     it('2014 May', function () {
-      var days = dateutils.page(xdate(2014, 4, 23));
+      const days = dateutils.page(xdate(2014, 4, 23));
       expect(days.length).toBe(35);
     });
 
     it('2014 June', function () {
-      var days = dateutils.page(xdate(2014, 5, 23));
+      const days = dateutils.page(xdate(2014, 5, 23));
       expect(days.length).toBe(35);
     });
 
     it('2014 August', function () {
-      var days = dateutils.page(xdate(2014, 7, 23));
+      const days = dateutils.page(xdate(2014, 7, 23));
       expect(days.length).toBe(42);
     });
 
     it('2014 October', function () {
-      var days = dateutils.page(xdate(2014, 9, 21));
+      const days = dateutils.page(xdate(2014, 9, 21));
       expect(days.length).toBe(35);
     });
 
     it('has all days in ascending order', function () {
-      var days, i, len;
+      let days, i, len;
 
       days = dateutils.page(xdate(2014, 2, 1));
       for (i = 0, len = days.length - 1; i < len; i++) {


### PR DESCRIPTION
## What

 - Updates `dateutils` and its spec to use `const` and `let` instead of `var`
 - Replaces `xdate` with `XDate` in `dateutils`

## Why

Consistency.
`var` is almost never used except in the date util. `let` and `const` are also present in the file.
Other files mention `xdate` as a param and `XDate` as the import, but the util file uses `xdate` for the import.
