### PR TITLE
Agenda View toggled opened/closed callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ An advanced agenda component that can display interactive listings for calendar 
     }}
   // callback that gets called when items for a certain month should be loaded (month became visible)
   loadItemsForMonth={(month) => {console.log('trigger items loading')}}
+  // callback that fires when the calendar is opened or closed
+  calendarToggled={(calendarOpened) => {console.log(calendarOpened)}}
   // callback that gets called on day press
   onDayPress={(day)=>{console.log('day pressed')}}
   // callback that gets called when day changes while scrolling agenda list

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ theme={{
 }}
 ```
 
-**Disclaimer**: issues that arise because something breaks after using stylesheet override will not be supported. Use this option at your own risk. 
+**Disclaimer**: issues that arise because something breaks after using stylesheet override will not be supported. Use this option at your own risk.
 
 ### CalendarList
 
@@ -281,7 +281,7 @@ An advanced agenda component that can display interactive listings for calendar 
   // callback that gets called when items for a certain month should be loaded (month became visible)
   loadItemsForMonth={(month) => {console.log('trigger items loading')}}
   // callback that fires when the calendar is opened or closed
-  calendarToggled={(calendarOpened) => {console.log(calendarOpened)}}
+  onCalendarToggled={(calendarOpened) => {console.log(calendarOpened)}}
   // callback that gets called on day press
   onDayPress={(day)=>{console.log('day pressed')}}
   // callback that gets called when day changes while scrolling agenda list

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -216,7 +216,7 @@ export default class AgendaView extends Component {
       calendarScrollable: true
     });
     if (this.props.calendarToggled) {
-      this.props.calendarToggled(this.state.calendarScrollable);
+      this.props.calendarToggled(true);
     }
     // Enlarge calendarOffset here as a workaround on iOS to force repaint.
     // Otherwise the month after current one or before current one remains invisible.
@@ -240,7 +240,7 @@ export default class AgendaView extends Component {
       selectedDay: day.clone()
     });
     if (this.props.calendarToggled) {
-      this.props.calendarToggled(this.state.calendarScrollable);
+      this.props.calendarToggled(false);
     }
     if (!optimisticScroll) {
       this.setState({

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -38,7 +38,7 @@ export default class AgendaView extends Component {
     // callback that gets called when items for a certain month should be loaded (month became visible)
     loadItemsForMonth: PropTypes.func,
     // callback that fires when the calendar is opened or closed
-    calendarToggled: PropTypes.func,
+    onCalendarToggled: PropTypes.func,
     // callback that gets called on day press
     onDayPress: PropTypes.func,
     // callback that gets called when day changes while scrolling agenda list
@@ -215,8 +215,8 @@ export default class AgendaView extends Component {
     this.setState({
       calendarScrollable: true
     });
-    if (this.props.calendarToggled) {
-      this.props.calendarToggled(true);
+    if (this.props.onCalendarToggled) {
+      this.props.onCalendarToggled(true);
     }
     // Enlarge calendarOffset here as a workaround on iOS to force repaint.
     // Otherwise the month after current one or before current one remains invisible.
@@ -239,8 +239,8 @@ export default class AgendaView extends Component {
       calendarScrollable: false,
       selectedDay: day.clone()
     });
-    if (this.props.calendarToggled) {
-      this.props.calendarToggled(false);
+    if (this.props.onCalendarToggled) {
+      this.props.onCalendarToggled(false);
     }
     if (!optimisticScroll) {
       this.setState({

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -37,6 +37,8 @@ export default class AgendaView extends Component {
 
     // callback that gets called when items for a certain month should be loaded (month became visible)
     loadItemsForMonth: PropTypes.func,
+    // callback that fires when the calendar is opened or closed
+    calendarToggled: PropTypes.func,
     // callback that gets called on day press
     onDayPress: PropTypes.func,
     // callback that gets called when day changes while scrolling agenda list
@@ -213,6 +215,9 @@ export default class AgendaView extends Component {
     this.setState({
       calendarScrollable: true
     });
+    if (this.props.calendarToggled) {
+      this.props.calendarToggled(this.state.calendarScrollable);
+    }
     // Enlarge calendarOffset here as a workaround on iOS to force repaint.
     // Otherwise the month after current one or before current one remains invisible.
     // The problem is caused by overflow: 'hidden' style, which we need for dragging
@@ -234,6 +239,9 @@ export default class AgendaView extends Component {
       calendarScrollable: false,
       selectedDay: day.clone()
     });
+    if (this.props.calendarToggled) {
+      this.props.calendarToggled(this.state.calendarScrollable);
+    }
     if (!optimisticScroll) {
       this.setState({
         topDay: day.clone()


### PR DESCRIPTION
We had a need to render content based off whether the calendar was opened or not.  This just adds a prop to have a callback function fire with the state of the calendar when it's toggled opened or closed.  Would love to get this merged asap because it's so small!  Thanks.