### PR TITLE
Calendar List allow showing vertical scroll indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ theme={{
   futureScrollRange={50}
   // Enable or disable scrolling of calendar list
   scrollEnabled={true}
+  // Enable or disable vertical scroll indicator. Default = false
+  showScrollIndicator={true}
   ...calendarParams
 />
 ```

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -25,7 +25,7 @@ class CalendarList extends Component {
     // Enable or disable scrolling of calendar list
     scrollEnabled: PropTypes.bool,
 
-    // Enable or disable vertical scroll indicator
+    // Enable or disable vertical scroll indicator. Default = false
     showScrollIndicator: PropTypes.bool,
   };
 

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -24,6 +24,9 @@ class CalendarList extends Component {
 
     // Enable or disable scrolling of calendar list
     scrollEnabled: PropTypes.bool,
+
+    // Enable or disable vertical scroll indicator
+    showScrollIndicator: PropTypes.bool,
   };
 
   constructor(props) {
@@ -168,7 +171,7 @@ class CalendarList extends Component {
         pageSize={1}
         onViewableItemsChanged={this.onViewableItemsChangedBound}
         renderItem={this.renderCalendarBound}
-        showsVerticalScrollIndicator={false}
+        showsVerticalScrollIndicator={this.props.showScrollIndicator !== undefined ? this.props.showScrollIndicator : false}
         scrollEnabled={this.props.scrollingEnabled !== undefined ? this.props.scrollingEnabled : true}
         keyExtractor={(item, index) => index}
         initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}


### PR DESCRIPTION
Just a tiny PR to add a `showScrollIndicator` prop to Calendar List that sets `showsVerticalScrollIndicator` on the rendered `FlatList`.

Now that I'm writing this, I'm wondering whether I should keep the prop names the same so it's essentially exposing `showsVerticalScrollIndicator`?