### PR TITLE
Disabled touch events for dates marked "disabled"

### DIFF
--- a/src/calendar/day/basic/index.js
+++ b/src/calendar/day/basic/index.js
@@ -88,7 +88,15 @@ class Day extends Component {
       textStyle.push(this.style.todayText);
     }
     return (
-      <TouchableOpacity style={containerStyle} onPress={this.onDayPress}>
+      <TouchableOpacity
+        style={containerStyle}
+        onPress={this.onDayPress}
+        disabled={
+          typeof marking.disabled !== 'undefined'
+            ? marking.disabled
+            : this.props.state === 'disabled'
+        }
+      >
         <Text style={textStyle}>{String(this.props.children)}</Text>
         {dot}
       </TouchableOpacity>


### PR DESCRIPTION
This PR addresses #149 with a potential solution. Thought I'd kick off the PR to discuss possible solutions.

I think a few users feel touch events should be disabled by default for dates which are marked "disabled". I agree that this is the best solution but I'm open to other suggestions such as an additional prop to toggle this behaviour.