### PR TITLE
🎉 Improve week numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ LocaleConfig.defaultLocale = 'fr';
   firstDay={1}
   // Hide day names. Default = false
   hideDayNames={true}
+  // Show week numbers to the left. Default = false
+  showWeekNumbers={true}
 />
 ```
 

--- a/example/src/screens/calendars.js
+++ b/example/src/screens/calendars.js
@@ -96,6 +96,14 @@ export default class CalendarsScreen extends Component {
           }}
           hideArrows={false}
         />
+        <Text style={styles.text}>Calendar with week numbers</Text>
+        <Calendar
+          onDayPress={this.onDayPress}
+          style={styles.calendar}
+          hideExtraDays
+          showWeekNumbers
+          markedDates={{[this.state.selected]: {selected: true}}}
+        />
       </ScrollView>
     );
   }

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -204,16 +204,7 @@ class Calendar extends Component {
   }
 
   renderWeekNumber (weekNumber) {
-    return (
-      <View key={`week-${weekNumber}`} style={{
-        width: 32,
-        height: 32,
-        alignItems: 'center',
-        justifyContent: 'center'
-      }}>
-        <Text>{weekNumber}</Text>
-      </View>
-    );
+    return <Day key={`week-${weekNumber}`} theme={this.props.theme} state='disabled'>{weekNumber}</Day>
   }
 
   renderWeek(days, id) {

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -213,7 +213,7 @@ class Calendar extends Component {
     }, this);
 
     if (this.props.showWeekNumbers) {
-      week.unshift(this.renderWeekNumber(days[0].getWeek()));
+      week.unshift(this.renderWeekNumber(days[days.length - 1].getWeek()));
     }
 
     return (<View style={this.style.week} key={id}>{week}</View>);

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -1,8 +1,7 @@
 import React, {Component} from 'react';
 import {
   View,
-  ViewPropTypes,
-  Text
+  ViewPropTypes
 } from 'react-native';
 import PropTypes from 'prop-types';
 
@@ -204,7 +203,7 @@ class Calendar extends Component {
   }
 
   renderWeekNumber (weekNumber) {
-    return <Day key={`week-${weekNumber}`} theme={this.props.theme} state='disabled'>{weekNumber}</Day>
+    return <Day key={`week-${weekNumber}`} theme={this.props.theme} state='disabled'>{weekNumber}</Day>;
   }
 
   renderWeek(days, id) {

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -63,10 +63,12 @@ class Calendar extends Component {
     monthFormat: PropTypes.string,
     // Disables changing month when click on days of other months (when hideExtraDays is false). Default = false
     disableMonthChange: PropTypes.bool,
-    //Hide day names. Default = false
+    //  Hide day names. Default = false
     hideDayNames: PropTypes.bool,
-    //Disable days by default. Default = false
-    disabledByDefault: PropTypes.bool
+    // Disable days by default. Default = false
+    disabledByDefault: PropTypes.bool,
+    // Show week numbers. Default = false
+    showWeekNumbers: PropTypes.bool,
   };
 
   constructor(props) {


### PR DESCRIPTION
Fixes the aligmet issue: https://github.com/wix/react-native-calendars/pull/239#issuecomment-349905968

- Adds prop types for showWeekNumber
- Documents showWeekNumber
- Changes to using the `<Day />` component for week numbers
- Shows correct number for week number 53 (due to leap years)

I will do another PR that adds a prop to override the styles, component and onPress for the week number 👍 