### PR TITLE
Change months correctly 

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -84,7 +84,8 @@ class CalendarList extends Component {
     const month = parseDate(m);
     const scrollTo = month || this.state.openDate;
     let diffMonths = this.state.openDate.diffMonths(scrollTo);
-    diffMonths = diffMonths < 0 ? Math.ceil(diffMonths) : Math.floor(diffMonths);
+    const isAnotherMonth = this.state.openDate.getMonth() !== scrollTo.getMonth();
+    diffMonths = (diffMonths < 0 || isAnotherMonth) ? Math.ceil(diffMonths) : Math.floor(diffMonths);
     const scrollAmount = (calendarHeight * this.pastScrollRange) + (diffMonths * calendarHeight);
     //console.log(month, this.state.openDate);
     //console.log(scrollAmount, diffMonths);


### PR DESCRIPTION
This should fix #273 

So, actually this more the hard approach to solving that problem as it doesn't consider if hideExtraDays is disabled. In that case it should take into account of the new current date is among those disabled days. I would like to help and continue the work but I'm not sure how to know that the new date is disabled because that's different in every month.

Please understand this pull request as a request for more information so that I can finish with a proper solution. 

https://github.com/wix/react-native-calendars/issues/273