### PR TITLE
getDrawingStyle: use marking data from given parameter instead of from current props

### DIFF
--- a/src/calendar/day/period/index.js
+++ b/src/calendar/day/period/index.js
@@ -58,9 +58,9 @@ class Day extends Component {
     if (!marking) {
       return defaultStyle;
     }
-    if (this.props.marking.disabled) {
+    if (marking.disabled) {
       defaultStyle.textStyle.color = this.theme.textDisabledColor;
-    } else if (this.props.marking.selected) {
+    } else if (marking.selected) {
       defaultStyle.textStyle.color = this.theme.selectedDayTextColor;
     }
     const resultStyle = ([marking]).reduce((prev, next) => {


### PR DESCRIPTION
Faced this issue while resetting `markedDates` to empty object. The selected dates disappeared, because `textColor` was still set to white (background was also white). Also `getDrawingStyle ` should not use `this.props.marking`, since it's getting the marking data from the parameter.