### PR TITLE
remove flex: 1 from calendar container style

### DIFF
--- a/src/calendar/style.js
+++ b/src/calendar/style.js
@@ -9,7 +9,6 @@ export default function getStyle(theme={}) {
     container: {
       paddingLeft: 5,
       paddingRight: 5,
-      flex: 1,
       backgroundColor: appStyle.calendarBackground
     },
     week: {


### PR DESCRIPTION
The calendar fills the view with white space because of the `flex: 1`. Styling of surrounding things should not be part of the library. It's much easier to add it

```jsx
<View style={{flex: 1}} backgroundColor=...>
    <Calendar theme={{calendarBackground: 'transparent'}} />
</View>
```

than removing it using this library.