### PR TITLE
Fix optional multi dot's key 

### DIFF
--- a/src/calendar/day/multi-dot/index.js
+++ b/src/calendar/day/multi-dot/index.js
@@ -62,7 +62,7 @@ class Day extends Component {
     const baseDotStyle = [this.style.dot, this.style.visibleDot];
     if (marking.dots && Array.isArray(marking.dots) && marking.dots.length > 0) {
       // Filter out dots so that we we process only those items which have key and color property
-      const validDots = marking.dots.filter(d => (d && d.key && d.color));
+      const validDots = marking.dots.filter(d => (d && d.color));
       return validDots.map((dot, index) => {
         return (
           <View key={dot.key ? dot.key : index} style={[baseDotStyle, 


### PR DESCRIPTION
To make the key fully optional, we should skip the check of the existence of key prop as well.

connect #342
ref https://github.com/wix/react-native-calendars/pull/324/files#diff-7dbb7000318300fafc323390f0d46412L65