### PR TITLE
Fix warning on dev about keyExtractor as string on VirtualizedList

### DIFF
--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -194,7 +194,7 @@ class ReactComp extends Component {
         showsVerticalScrollIndicator={false}
         scrollEventThrottle={200}
         onMoveShouldSetResponderCapture={() => {this.onListTouch(); return false;}}
-        keyExtractor={(item, index) => index}
+        keyExtractor={(item, index) => String(index)}
       />
     );
   }


### PR DESCRIPTION
By Chaging keyExtractor's type to string on agenda/reservation-list FlatList.