### PR TITLE
calendar refs

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -94,10 +94,10 @@ class Calendar extends Component {
   }
 
   componentDidMount() {
-    this.props.onRef(this)
+    this.props.onRef(this);
   }
   componentWillUnmount() {
-    this.props.onRef(undefined)
+    this.props.onRef(undefined);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -93,6 +93,13 @@ class Calendar extends Component {
     this.shouldComponentUpdate = shouldComponentUpdate;
   }
 
+  componentDidMount() {
+    this.props.onRef(this)
+  }
+  componentWillUnmount() {
+    this.props.onRef(undefined)
+  }
+
   componentWillReceiveProps(nextProps) {
     const current= parseDate(nextProps.current);
     if (current && current.toString('yyyy MM') !== this.state.currentMonth.toString('yyyy MM')) {


### PR DESCRIPTION
added refs to allow calling "addMonth" from outside the calendar component.

with this, and
```
<Calendar
  onRef={ref => (this.cal = ref)}
```

I am able to call `this.cal.addMonth(1)` in the parent component.

there's probably a cleaner way of doing this, but imo, those methods should be accessible.