### PR TITLE
Fix selectable week numbers

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -207,7 +207,7 @@ class Calendar extends Component {
   }
 
   renderWeekNumber (weekNumber) {
-    return <Day key={`week-${weekNumber}`} theme={this.props.theme} state='disabled'>{weekNumber}</Day>;
+    return <Day key={`week-${weekNumber}`} theme={this.props.theme} marking={{disableTouchEvent: true}} state='disabled'>{weekNumber}</Day>;
   }
 
   renderWeek(days, id) {


### PR DESCRIPTION
## Description
This PR fixes a bug where the week numbers on the `Calendar` component would be selectable, and would cause the application to crash, as described on #367

## What changed
Passed the marking prop `{disableTouchEvent: true}` to the `Day` object returned by the `renderWeekNumber` method on the `Calendar` component.

