### PR TITLE
[bug-fix] fix subtract month onPressRight bug

### DIFF
--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -65,7 +65,7 @@ class CalendarHeader extends Component {
   onPressRight() {
     const {onPressArrowRight} = this.props;
     if(typeof onPressArrowRight === 'function') {
-      return onPressArrowRight(this.substractMonth);
+      return onPressArrowRight(this.addMonth);
     }
     return this.addMonth();
   }


### PR DESCRIPTION
There was a bug where the months were moving backwards when I clicked the right arrow. It was a simple mistake of calling subtractMonth instead of addMonth. 