### PR TITLE
Make multi-dot strategy to respect provided selectedColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ Multi-Dot marking
 
 Use markingType = 'multi-dot' if you want to display more than one dot. Both the Calendar and CalendarList control support multiple dots by using 'dots' array in markedDates. The property 'color' is mandatory while 'key' and 'selectedColor' are optional. If key is omitted then the array index is used as key. If selectedColor is omitted then 'color' will be used for selected dates.
 ```javascript
-const vacation = {key:'vacation', color: 'red'};
-const massage = {key:'massage', color: 'blue'};
+const vacation = {key:'vacation', color: 'red', selectedDotColor: 'blue'};
+const massage = {key:'massage', color: 'blue', selectedDotColor: 'blue'};
 const workout = {key:'workout', color: 'green'};
 
 <Calendar

--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ Multi-Dot marking
 
 Use markingType = 'multi-dot' if you want to display more than one dot. Both the Calendar and CalendarList control support multiple dots by using 'dots' array in markedDates. The property 'color' is mandatory while 'key' and 'selectedColor' are optional. If key is omitted then the array index is used as key. If selectedColor is omitted then 'color' will be used for selected dates.
 ```javascript
-const vacation = {key:'vacation', color: 'red', selectedColor: 'blue'};
-const massage = {key:'massage', color: 'blue', selectedColor: 'blue'};
+const vacation = {key:'vacation', color: 'red'};
+const massage = {key:'massage', color: 'blue'};
 const workout = {key:'workout', color: 'green'};
 
 <Calendar
   markedDates={{
-    '2017-10-25': {dots: [vacation, massage, workout], selected: true},
+    '2017-10-25': {dots: [vacation, massage, workout], selected: true, selectedColor: 'red'},
     '2017-10-26': {dots: [massage, workout], disabled: true},
   }},
   markingType={'multi-dot'}

--- a/example/src/screens/calendars.js
+++ b/example/src/screens/calendars.js
@@ -22,7 +22,7 @@ export default class CalendarsScreen extends Component {
           onDayPress={this.onDayPress}
           style={styles.calendar}
           hideExtraDays
-          markedDates={{[this.state.selected]: {selected: true, disableTouchEvent: true, selectedColor: 'orange'}}}
+          markedDates={{[this.state.selected]: {selected: true, disableTouchEvent: true, selectedDotColor: 'orange'}}}
         />
         <Text style={styles.text}>Calendar with marked dates and hidden arrows</Text>
         <Calendar
@@ -92,7 +92,7 @@ export default class CalendarsScreen extends Component {
           markingType={'multi-dot'}
           markedDates={{
             '2012-05-08': {dots: [{key: 'vacation', color: 'blue', selectedDotColor: 'white'}, {key: 'massage', color: 'red', selectedDotColor: 'white'}], selected: true},
-            '2012-05-09': {dots: [{key: 'vacation', color: 'blue', selectedColor: 'red'}, {key: 'massage', color: 'red', selectedColor: 'blue'}], disabled: true}
+            '2012-05-09': {dots: [{key: 'vacation', color: 'blue', selectedDotColor: 'red'}, {key: 'massage', color: 'red', selectedDotColor: 'blue'}], disabled: true}
           }}
           hideArrows={false}
         />

--- a/src/calendar/day/multi-dot/index.js
+++ b/src/calendar/day/multi-dot/index.js
@@ -83,6 +83,9 @@ class Day extends Component {
     if (marking.selected) {
       containerStyle.push(this.style.selected);
       textStyle.push(this.style.selectedText);
+      if (marking.selectedColor) {
+        containerStyle.push({backgroundColor: marking.selectedColor});
+      }
     } else if (typeof marking.disabled !== 'undefined' ? marking.disabled : this.props.state === 'disabled') {
       textStyle.push(this.style.disabledText);
     } else if (this.props.state === 'today') {


### PR DESCRIPTION
```selectedColor``` in the multi-dot section inside README.md is not working and not logically correct because code cannot decide which dot ```selectedColor``` property would be applied if we have multiple dots on one day.

This PR moved ```selectedColor``` one level up (look README.md commit) and adds missing functionality.
I'm using it in my project. It would be cool if you merge this.