### PR TITLE
[Style] Sets date margin by platform type

### DIFF
--- a/src/calendar/day/basic/style.js
+++ b/src/calendar/day/basic/style.js
@@ -12,7 +12,7 @@ export default function styleConstructor(theme={}) {
       alignItems: 'center'
     },
     text: {
-      marginTop: 4,
+      marginTop: Platform.OS === 'android' ? 4 : 6,
       fontSize: appStyle.textDayFontSize,
       fontFamily: appStyle.textDayFontFamily,
       fontWeight: '300',


### PR DESCRIPTION
### Motivation

On iOS the number inside the date circle is not vertically aligned but is on Android.

This PR sets the margin top of the date to be by platform type

### Before
![before](https://user-images.githubusercontent.com/1764217/37520497-3ebddd44-2915-11e8-9e34-883cce5bfbe9.png)

### After
![after](https://user-images.githubusercontent.com/1764217/37520500-40ec7832-2915-11e8-8913-23a99dda03d7.png)

### Android
![android](https://user-images.githubusercontent.com/1764217/37520565-7a88530e-2915-11e8-8d0e-f9fe1e7dfb0d.png)

