### PR TITLE
Move hardcoded width of hidden extra days to style

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -158,7 +158,7 @@ class Calendar extends Component {
       if (this.props.markingType === 'period') {
         dayComp = (<View key={id} style={{flex: 1}}/>);
       } else {
-        dayComp = (<View key={id} style={{width: 32}}/>);
+        dayComp = (<View key={id} style={this.style.hiddenExtraDays}/>);
       }
     } else {
       const DayComp = this.getDayComponent();

--- a/src/calendar/style.js
+++ b/src/calendar/style.js
@@ -17,6 +17,9 @@ export default function getStyle(theme={}) {
       flexDirection: 'row',
       justifyContent: 'space-around'
     },
+    hiddenExtraDays: {
+      width: 32
+    },
     ...(theme[STYLESHEET_ID] || {})
   });
 }


### PR DESCRIPTION
The problem was that if we change the day width (in our example the width was being calculated according to the screen dimensions), hidden extra days stayed 32 and that caused misplace of days in rows that included hidden extra days.

Related to #307 