### PR TITLE
CalendarList initialScrollIndex not working in RN 0.44 or Minor

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -94,7 +94,7 @@ class CalendarList extends Component {
   }
 
   componentDidMount() {
-    setTimeout(() => this.listView.scrollToIndex({index: this.getMonthIndex(this.state.openDate), animated: true}))
+    setTimeout(() => this.listView.scrollToIndex({index: this.getMonthIndex(this.state.openDate), animated: true}));
   }
 
   componentWillReceiveProps(props) {

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -93,6 +93,10 @@ class CalendarList extends Component {
     this.listView.scrollToOffset({offset: scrollAmount, animated: false});
   }
 
+  componentDidMount() {
+    setTimeout(() => this.listView.scrollToIndex({index: this.getMonthIndex(this.state.openDate), animated: true}))
+  }
+
   componentWillReceiveProps(props) {
     const current = parseDate(this.props.current);
     const nextCurrent = parseDate(props.current);


### PR DESCRIPTION
The flatlist has the parameter initialScrollIndex but in React Native 0.44 or minor doesn't work because it doesn't have this props.

So when ```componentDidMount()```it's scrolling to the middle of the CalendarList