### PR TITLE
add remove clipped subviews option

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -386,6 +386,7 @@ export default class AgendaView extends Component {
               current={this.currentMonth}
               markedDates={this.generateMarkings()}
               markingType={this.props.markingType}
+              removeClippedSubviews={this.props.removeClippedSubviews}
               onDayPress={this._chooseDayFromCalendar.bind(this)}
               scrollingEnabled={this.state.calendarScrollable}
               hideExtraDays={this.state.calendarScrollable}

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -177,7 +177,7 @@ class CalendarList extends Component {
         data={this.state.rows}
         //snapToAlignment='start'
         //snapToInterval={this.calendarHeight}
-        removeClippedSubviews={Platform.OS === 'android' ? false : true}
+        removeClippedSubviews={this.props.removeClippedSubviews != null ? this.props.removeClippedSubviews: (Platform.OS === 'android' ? false : true)}
         pageSize={1}
         onViewableItemsChanged={this.onViewableItemsChangedBound}
         renderItem={this.renderCalendarBound}


### PR DESCRIPTION
Added removeClippedSubviews={} to CalendarList and Agenda.

Fix an issue with tab navigator of react-navigation passing removeClippedSubviews={false} to Agenda