### PR TITLE
Add option to make month name bold via theme properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ The loading indicator next to month name will be displayed if `<Calendar />` has
     textDayFontFamily: 'monospace',
     textMonthFontFamily: 'monospace',
     textDayHeaderFontFamily: 'monospace',
+    textMonthFontWeight: 'bold',
     textDayFontSize: 16,
     textMonthFontSize: 16,
     textDayHeaderFontSize: 16

--- a/src/calendar/header/style.js
+++ b/src/calendar/header/style.js
@@ -16,7 +16,7 @@ export default function(theme={}) {
     monthText: {
       fontSize: appStyle.textMonthFontSize,
       fontFamily: appStyle.textMonthFontFamily,
-      fontWeight: '300',
+      fontWeight: appStyle.textMonthFontWeight,
       color: appStyle.monthTextColor,
       margin: 10
     },

--- a/src/style.js
+++ b/src/style.js
@@ -17,6 +17,8 @@ export const textDayFontFamily = 'System';
 export const textMonthFontFamily = 'System';
 export const textDayHeaderFontFamily = 'System';
 
+export const textMonthFontWeight = '300';
+
 export const textDayFontSize = 16;
 export const textMonthFontSize = 16;
 export const textDayHeaderFontSize = 13;


### PR DESCRIPTION
As I saw in Issues, this is often asked for and I needed this today for myself so I decided to make this PR. Added to README too.