### PR TITLE
😈 fix(remove duplicate): remove duplicate this.getItemLayout 

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -77,7 +77,6 @@ class CalendarList extends Component {
       initialized: false
     };
 
-    this.getItemLayout = this.getItemLayout.bind(this);
     this.onViewableItemsChangedBound = this.onViewableItemsChanged.bind(this);
     this.renderCalendarBound = this.renderCalendar.bind(this);
     this.getItemLayout = this.getItemLayout.bind(this);


### PR DESCRIPTION
remove duplicate this.getItemLayout 

in file src/calendar-list/index.js  we have two this.getItemLayout declaration in L80 and L83