### PR TITLE
Add viewabilityConfig prop to CalendarList

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ If you implement an awesome day component please make a PR so that other people 
   scrollEnabled={true}
   // Enable or disable vertical scroll indicator. Default = false
   showScrollIndicator={true}
+  // Set viewabilityConfig defined by viewabilityHelper.js. Default: viewAreaCoveragePercentThreshold=100
+  viewabilityConfig={viewabilityConfigObject}
   ...calendarParams
 />
 ```

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -49,8 +49,9 @@ class CalendarList extends Component {
     this.pastScrollRange = props.pastScrollRange === undefined ? 50 : props.pastScrollRange;
     this.futureScrollRange = props.futureScrollRange === undefined ? 50 : props.futureScrollRange;
     this.style = styleConstructor(props.theme);
-    this.calendarWidth = this.props.calendarWidth || width;
+    this.calendarWidth = props.calendarWidth;
     this.calendarHeight = props.calendarHeight;
+    this.viewabilityConfig = props.viewabilityConfig;
 
     const rows = [];
     const texts = [];
@@ -200,13 +201,18 @@ class CalendarList extends Component {
         initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
         getItemLayout={this.getItemLayout}
         scrollsToTop={this.props.scrollsToTop !== undefined ? this.props.scrollsToTop : false}
+        viewabilityConfig={this.viewabilityConfig}
       />
     );
   }
 }
 
 CalendarList.defaultProps = {
-  calendarHeight: 360
+  calendarHeight: 360,
+  calendarWidth: width,
+  viewabilityConfig: {
+    viewAreaCoveragePercentThreshold: 100,
+  }
 };
 
 export default CalendarList;


### PR DESCRIPTION
### Description
`onMonthChanged` (on `ViewabilityItemsChanged`) is triggered only when the view is perfect fit. With `viewabilityConfig` we get more control on when to trigger `onMonthChanged` based on `viewabilityHelper.js` defined by `react-native`.

### What changed
Added `viewabilityConfig` prop to `CalendarList` that takes an object defined by `viewabilityHelper.js`