### PR TITLE
😈 Fix initialListSize calculate error

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -183,7 +183,7 @@ class CalendarList extends Component {
         ref={(c) => this.listView = c}
         //scrollEventThrottle={1000}
         style={[this.style.container, this.props.style]}
-        initialListSize={this.pastScrollRange * this.futureScrollRange + 1}
+        initialListSize={this.pastScrollRange + this.futureScrollRange + 1}
         data={this.state.rows}
         //snapToAlignment='start'
         //snapToInterval={this.calendarHeight}


### PR DESCRIPTION
It seems the list size here should be the sum of this.pastScrollRange and this.futureScrollRange rather than product.