### PR TITLE
😈 Fix remove unused state

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -73,8 +73,7 @@ class CalendarList extends Component {
     this.state = {
       rows,
       texts,
-      openDate: date,
-      initialized: false
+      openDate: date
     };
 
     this.onViewableItemsChangedBound = this.onViewableItemsChanged.bind(this);


### PR DESCRIPTION
Seems the state `initialized ` has never been used. Shall we remove it for less confusion?