### PR TITLE
Allow to show arrows in CalendarList

### DIFF
--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -23,7 +23,7 @@ class CalendarListItem extends Component {
           theme={this.props.theme}
           style={[{height: this.props.calendarHeight, width: this.props.calendarWidth}, this.style.calendar]}
           current={row}
-          hideArrows
+          hideArrows={this.props.hideArrows === undefined ? true : this.props.hideArrows}
           hideExtraDays={this.props.hideExtraDays === undefined ? true : this.props.hideExtraDays}
           disableMonthChange
           markedDates={this.props.markedDates}


### PR DESCRIPTION
Keep the same default to `true`, but allow to show them when `<CalendarList hideArrows={false} />`