### PR TITLE
Add todayBackgroundColor in day components

### DIFF
--- a/src/calendar/day/basic/index.js
+++ b/src/calendar/day/basic/index.js
@@ -71,6 +71,7 @@ class Day extends Component {
     } else if (isDisabled) {
       textStyle.push(this.style.disabledText);
     } else if (this.props.state === 'today') {
+      containerStyle.push(this.style.today);
       textStyle.push(this.style.todayText);
     }
 

--- a/src/calendar/day/basic/style.js
+++ b/src/calendar/day/basic/style.js
@@ -26,6 +26,9 @@ export default function styleConstructor(theme={}) {
       backgroundColor: appStyle.selectedDayBackgroundColor,
       borderRadius: 16
     },
+    today: {
+      backgroundColor: appStyle.todayBackgroundColor
+    },
     todayText: {
       color: appStyle.todayTextColor
     },

--- a/src/calendar/day/custom/index.js
+++ b/src/calendar/day/custom/index.js
@@ -49,12 +49,13 @@ class Day extends Component {
       };
     }
     const isDisabled = typeof marking.disabled !== 'undefined' ? marking.disabled : this.props.state === 'disabled';
-    
+
     if (marking.selected) {
       containerStyle.push(this.style.selected);
     } else if (isDisabled) {
       textStyle.push(this.style.disabledText);
     } else if (this.props.state === 'today') {
+      containerStyle.push(this.style.today);
       textStyle.push(this.style.todayText);
     }
 

--- a/src/calendar/day/custom/style.js
+++ b/src/calendar/day/custom/style.js
@@ -26,6 +26,9 @@ export default function styleConstructor(theme={}) {
       backgroundColor: appStyle.selectedDayBackgroundColor,
       borderRadius: 16
     },
+    today: {
+      backgroundColor: appStyle.todayBackgroundColor
+    },
     todayText: {
       color: appStyle.todayTextColor
     },

--- a/src/calendar/day/multi-dot/index.js
+++ b/src/calendar/day/multi-dot/index.js
@@ -49,7 +49,7 @@ class Day extends Component {
       const validDots = marking.dots.filter(d => (d && d.color));
       return validDots.map((dot, index) => {
         return (
-          <View key={dot.key ? dot.key : index} style={[baseDotStyle, 
+          <View key={dot.key ? dot.key : index} style={[baseDotStyle,
             { backgroundColor: marking.selected && dot.selectedDotColor ? dot.selectedDotColor : dot.color}]}/>
         );
       });
@@ -73,11 +73,12 @@ class Day extends Component {
     } else if (typeof marking.disabled !== 'undefined' ? marking.disabled : this.props.state === 'disabled') {
       textStyle.push(this.style.disabledText);
     } else if (this.props.state === 'today') {
+      containerStyle.push(this.style.today);
       textStyle.push(this.style.todayText);
     }
     return (
-      <TouchableOpacity 
-        style={containerStyle} 
+      <TouchableOpacity
+        style={containerStyle}
         onPress={this.onDayPress}
         onLongPress={this.onDayLongPress}>
         <Text allowFontScaling={false} style={textStyle}>{String(this.props.children)}</Text>

--- a/src/calendar/day/multi-dot/style.js
+++ b/src/calendar/day/multi-dot/style.js
@@ -26,6 +26,9 @@ export default function styleConstructor(theme={}) {
       backgroundColor: appStyle.selectedDayBackgroundColor,
       borderRadius: 16
     },
+    today: {
+      backgroundColor: appStyle.todayBackgroundColor
+    },
     todayText: {
       color: appStyle.todayTextColor
     },

--- a/src/calendar/day/multi-period/index.js
+++ b/src/calendar/day/multi-period/index.js
@@ -84,6 +84,7 @@ class Day extends Component {
     ) {
       textStyle.push(this.style.disabledText);
     } else if (this.props.state === 'today') {
+      containerStyle.push(this.style.today);
       textStyle.push(this.style.todayText);
     }
     return (

--- a/src/calendar/day/multi-period/style.js
+++ b/src/calendar/day/multi-period/style.js
@@ -26,6 +26,9 @@ export default function styleConstructor(theme = {}) {
       backgroundColor: appStyle.selectedDayBackgroundColor,
       borderRadius: 16,
     },
+    today: {
+      backgroundColor: appStyle.todayBackgroundColor
+    },
     todayText: {
       color: appStyle.todayTextColor,
     },

--- a/src/calendar/day/period/index.js
+++ b/src/calendar/day/period/index.js
@@ -123,6 +123,7 @@ class Day extends Component {
     if (this.props.state === 'disabled') {
       textStyle.push(this.style.disabledText);
     } else if (this.props.state === 'today') {
+      containerStyle.push(this.style.today);
       textStyle.push(this.style.todayText);
     }
 
@@ -191,7 +192,7 @@ class Day extends Component {
     }
 
     return (
-      <TouchableWithoutFeedback 
+      <TouchableWithoutFeedback
         onPress={this.onDayPress}
         onLongPress={this.onDayLongPress}>
         <View style={this.style.wrapper}>

--- a/src/calendar/day/period/style.js
+++ b/src/calendar/day/period/style.js
@@ -43,6 +43,9 @@ export default function styleConstructor(theme={}) {
       color: appStyle.dayTextColor || '#2d4150',
       backgroundColor: 'rgba(255, 255, 255, 0)'
     },
+    today: {
+      backgroundColor: appStyle.todayBackgroundColor
+    },
     todayText: {
       fontWeight: '500',
       color: theme.todayTextColor || appStyle.dayTextColor,

--- a/src/style.js
+++ b/src/style.js
@@ -27,6 +27,7 @@ export const calendarBackground = foregroundColor;
 export const textSectionTitleColor = '#b6c1cd';
 export const selectedDayBackgroundColor = textLinkColor;
 export const selectedDayTextColor = foregroundColor;
+export const todayBackgroundColor = undefined;
 export const todayTextColor = textLinkColor;
 export const dayTextColor = textDefaultColor;
 export const textDisabledColor = '#d9e1e8';


### PR DESCRIPTION
This PR gives more flexibility to style today container. It adds a new todayBackgroundColor:

```jsx
<CalendarList
  theme={{
    todayBackgroundColor: 'blue',
  }}
/>
```

but also allows more customisations:

```jsx
<CalendarList
  theme={{
    'stylesheet.day.basic': {
      today: {
        backgroundColor: 'blue',
        borderRadius: 5,
      }
    }
  }}
/>
```