### PR TITLE
(Agenda) Fix rendering of previous/ future calendars by removing initialScrollIndex

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -380,6 +380,7 @@ export default class AgendaView extends Component {
               onLayout={() => {
                 this.calendar.scrollToDay(this.state.selectedDay.clone(), this.calendarOffset(), false);
               }}
+              shouldInitiallyScrollToMonth={false}
               theme={this.props.theme}
               onVisibleMonthsChange={this.onVisibleMonthsChange.bind(this)}
               ref={(c) => this.calendar = c}

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -100,7 +100,7 @@ class CalendarList extends Component {
     };
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     const current = parseDate(prevProps.current);
     const nextCurrent = parseDate(this.props.current);
 

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -68,7 +68,7 @@ class CalendarList extends Component {
     this.futureScrollRange = props.futureScrollRange === undefined ? 50 : props.futureScrollRange;
     this.style = styleConstructor(props.theme);
     this.calendarWidth = props.calendarWidth || width;
-    this.calendarHeight = props.calendarHeight || 360;
+    this.calendarHeight = props.calendarHeight;
 
     const rows = [];
     const texts = [];

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -109,6 +109,14 @@ class CalendarList extends Component {
     }
   }
 
+  get initialScrollIndex() {
+    if (!this.state.openDate || !this.props.shouldInitiallyScrollToMonth) {
+      return undefined;
+    }
+
+    return this.getMonthIndex(this.state.openDate);
+  }
+
   onLayout(event) {
     if (this.props.onLayout) {
       this.props.onLayout(event);
@@ -224,6 +232,7 @@ class CalendarList extends Component {
         scrollEnabled={this.props.scrollingEnabled !== undefined ? this.props.scrollingEnabled : true}
         keyExtractor={(item, index) => String(index)}
         getItemLayout={this.getItemLayout}
+        initialScrollIndex={this.initialScrollIndex}
         scrollsToTop={this.props.scrollsToTop !== undefined ? this.props.scrollsToTop : false}
       />
     );
@@ -231,7 +240,8 @@ class CalendarList extends Component {
 }
 
 CalendarList.defaultProps = {
-  calendarHeight: 360
+  calendarHeight: 360,
+  shouldInitiallyScrollToMonth: true
 };
 
 export default CalendarList;

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -114,7 +114,7 @@ class CalendarList extends Component {
       return undefined;
     }
 
-    return this.getMonthIndex(this.state.openDate);
+    return this.state.openDate.diffMonths(this.state.openDate) + this.pastScrollRange;
   }
 
   onLayout(event) {


### PR DESCRIPTION
Resolves #468 & #425

Removes `initialScrollIndex` prop on the Flatlist within CalendarList.

Through testing, it was conflicting with either calling `scrollToOffset` or `scrollToDay` (called by Agenda).

Also, migrate to `getDerivedStateFromProps`, and remove usage of deprecated `componentWillReceiveProps` API