### PR TITLE
Feat on press year

### DIFF
--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -112,12 +112,14 @@ class CalendarHeader extends Component {
       <View>
         <View style={this.style.header}>
           {leftArrow}
+          <TouchableOpacity disabled={!this.props.onPressYear} onPress={this.props.onPressYear}>
           <View style={{ flexDirection: 'row' }}>
             <Text allowFontScaling={false} style={this.style.monthText} accessibilityTraits='header'>
               {this.props.month.toString(this.props.monthFormat ? this.props.monthFormat : 'MMMM yyyy')}
             </Text>
             {indicator}
           </View>
+          </TouchableOpacity>
           {rightArrow}
         </View>
         {

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -113,12 +113,12 @@ class CalendarHeader extends Component {
         <View style={this.style.header}>
           {leftArrow}
           <TouchableOpacity disabled={!this.props.onPressYear} onPress={this.props.onPressYear}>
-          <View style={{ flexDirection: 'row' }}>
-            <Text allowFontScaling={false} style={this.style.monthText} accessibilityTraits='header'>
-              {this.props.month.toString(this.props.monthFormat ? this.props.monthFormat : 'MMMM yyyy')}
-            </Text>
-            {indicator}
-          </View>
+            <View style={{ flexDirection: 'row' }}>
+              <Text allowFontScaling={false} style={this.style.monthText} accessibilityTraits='header'>
+                {this.props.month.toString(this.props.monthFormat ? this.props.monthFormat : 'MMMM yyyy')}
+              </Text>
+              {indicator}
+            </View>
           </TouchableOpacity>
           {rightArrow}
         </View>

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -75,7 +75,9 @@ class Calendar extends Component {
     // Handler which gets executed when press arrow icon left. It receive a callback can go back month
     onPressArrowLeft: PropTypes.func,
     // Handler which gets executed when press arrow icon left. It receive a callback can go next month
-    onPressArrowRight: PropTypes.func
+    onPressArrowRight: PropTypes.func,
+    // Handler which gets executed when press on Year / Month in header
+    onPressYear: PropTypes.func
   };
 
   constructor(props) {
@@ -271,6 +273,7 @@ class Calendar extends Component {
           weekNumbers={this.props.showWeekNumbers}
           onPressArrowLeft={this.props.onPressArrowLeft}
           onPressArrowRight={this.props.onPressArrowRight}
+          onPressYear={this.props.onPressYear}
         />
         <View style={this.style.monthView}>{weeks}</View>
       </View>);


### PR DESCRIPTION
Kept command in line with text order for the arrows ie onPressX instead of onXPress

This is useful so I can implement a new component to select the month / year by clicking on it, similar to the workflow of other calendars.