### PR TITLE
Allow additional style to Period Marking Text

### DIFF
--- a/src/calendar/day/period/index.js
+++ b/src/calendar/day/period/index.js
@@ -191,13 +191,13 @@ class Day extends Component {
     }
 
     return (
-      <TouchableWithoutFeedback 
+      <TouchableWithoutFeedback
         onPress={this.onDayPress}
         onLongPress={this.onDayLongPress}>
         <View style={this.style.wrapper}>
           {fillers}
           <View style={containerStyle}>
-            <Text allowFontScaling={false} style={textStyle}>{String(this.props.children)}</Text>
+            <Text allowFontScaling={false} style={[textStyle, this.props.marking.style]}>{String(this.props.children)}</Text>
           </View>
         </View>
       </TouchableWithoutFeedback>


### PR DESCRIPTION
## Motivation:

In addition to being able to pass `textColor` & `color` to a period marking text, I also wanted to be able to make it **bold** or **strike-through** the text when needed. 

## Solution:

Allow a `style` prop on each period day, to let the user pass in any additional style as needed. 
```
'2018-05-14': {
  textColor: MED_GRAY,
  style: {
    textDecorationLine: 'line-through'
  }
}
```

## Results:

<img width="325" alt="screen shot 2018-05-13 at 11 30 06 am" src="https://user-images.githubusercontent.com/7840686/39970480-123fe8e8-56a1-11e8-9026-17a844fd2524.png">
<img width="310" alt="screen shot 2018-05-13 at 11 30 20 am" src="https://user-images.githubusercontent.com/7840686/39970481-12591444-56a1-11e8-91ba-344f1cd96f5d.png">
