### PR TITLE
fix: Agenda header is scrolling to wrong position when minimized #485

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -135,6 +135,7 @@ export default class AgendaView extends Component {
   onLayout(event) {
     this.viewHeight = event.nativeEvent.layout.height;
     this.viewWidth = event.nativeEvent.layout.width;
+    this.calendar.scrollToDay(this.state.selectedDay.clone(), this.calendarOffset(), false);
     this.forceUpdate();
   }
 


### PR DESCRIPTION
I was using version 1.17.0 before upgrading to 1.19.3, compared the agenda view code and tested  returning the scrollToDay function call in the onLayout function. Fixed it on my implementation.