### PR TITLE
Added capability to style right/left calendar arrows separately

### DIFF
--- a/src/calendar/day/custom/index.js
+++ b/src/calendar/day/custom/index.js
@@ -52,6 +52,7 @@ class Day extends Component {
 
     if (marking.selected) {
       containerStyle.push(this.style.selected);
+      textStyle.push(this.style.selectedText);
     } else if (isDisabled) {
       textStyle.push(this.style.disabledText);
     } else if (this.props.state === 'today') {

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -82,28 +82,28 @@ class CalendarHeader extends Component {
       leftArrow = (
         <TouchableOpacity
           onPress={this.onPressLeft}
-          style={this.style.arrow}
+          style={[this.style.arrow, this.style.arrowLeft]}
           hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
         >
           {this.props.renderArrow
             ? this.props.renderArrow('left')
             : <Image
                 source={require('../img/previous.png')}
-                style={this.style.arrowImage}
+                style={[this.style.arrowImage, this.style.arrowImageLeft]}
               />}
         </TouchableOpacity>
       );
       rightArrow = (
         <TouchableOpacity
           onPress={this.onPressRight}
-          style={this.style.arrow}
+          style={[this.style.arrow, this.style.arrowRight]}
           hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
         >
           {this.props.renderArrow
             ? this.props.renderArrow('right')
             : <Image
                 source={require('../img/next.png')}
-                style={this.style.arrowImage}
+                style={[this.style.arrowImage, this.style.arrowImageRight]}
               />}
         </TouchableOpacity>
       );

--- a/src/calendar/header/style.js
+++ b/src/calendar/header/style.js
@@ -23,6 +23,10 @@ export default function(theme={}) {
     arrow: {
       padding: 10
     },
+    arrowLeft: {
+    },
+    arrowRight: {
+    },
     arrowImage: {
       ...Platform.select({
         ios: {
@@ -32,6 +36,10 @@ export default function(theme={}) {
           tintColor: appStyle.arrowColor
         }
       })
+    },
+    arrowImageLeft: {
+    },
+    arrowImageRight: {
     },
     week: {
       marginTop: 7,


### PR DESCRIPTION
Added styles for right/left calendar arrows that are applied in addition to the current "arrow" and "arrowImage" styles.

example usage:
```
<Calendar 
    theme={
        'stylesheet.calendar.header': {
            // for container View
            arrow: {
                // write common styles here or you can skip this entry if you inherit the default style
            },
            arrowLeft: {
                position: 'relative',
                top: 0,
                left: 0
            },
            arrowRight: {
                position: 'relative',
                top: 0,
                right: 0
            },
            // for arrow Image
            arrowImage: {
                // write common styles here or you can skip this entry if you inherit the default style
            },
            arrowImageLeft: {
                ...Platform.select({
                    ios: {
                        tintColor: '#ff0000'
                    },
                    android: {
                        tintColor: '#ff0000'
                    }
                })
            },
            arrowImageRight: {
                ...Platform.select({
                    ios: {
                        tintColor: '#00ff00'
                    },
                    android: {
                        tintColor: '#00ff00'
                    }
                })
            }
        }
    }
/>
```