### PR TITLE
Replace wrapping View with new-style React.Fragment

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -1,20 +1,14 @@
-import React, {Component} from 'react';
-import {
-  Text,
-  View,
-  Dimensions,
-  Animated,
-  ViewPropTypes,
-} from 'react-native';
-import PropTypes from 'prop-types';
-import XDate from 'xdate';
+import React, { Component } from "react";
+import { Text, View, Dimensions, Animated, ViewPropTypes } from "react-native";
+import PropTypes from "prop-types";
+import XDate from "xdate";
 
-import {parseDate, xdateToData} from '../interface';
-import dateutils from '../dateutils';
-import CalendarList from '../calendar-list';
-import ReservationsList from './reservation-list';
-import styleConstructor from './style';
-import { VelocityTracker } from '../input';
+import { parseDate, xdateToData } from "../interface";
+import dateutils from "../dateutils";
+import CalendarList from "../calendar-list";
+import ReservationsList from "./reservation-list";
+import styleConstructor from "./style";
+import { VelocityTracker } from "../input";
 
 const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
@@ -88,24 +82,24 @@ export default class AgendaView extends Component {
     // Set this true while waiting for new data from a refresh.
     refreshing: PropTypes.bool,
     // Display loading indicador. Default = false
-    displayLoadingIndicator: PropTypes.bool,
+    displayLoadingIndicator: PropTypes.bool
   };
 
   constructor(props) {
     super(props);
     this.styles = styleConstructor(props.theme);
-    const windowSize = Dimensions.get('window');
+    const windowSize = Dimensions.get("window");
     this.viewHeight = windowSize.height;
     this.viewWidth = windowSize.width;
     this.scrollTimeout = undefined;
-    this.headerState = 'idle';
+    this.headerState = "idle";
     this.state = {
       scrollY: new Animated.Value(0),
       calendarIsReady: false,
       calendarScrollable: false,
       firstResevationLoad: false,
       selectedDay: parseDate(this.props.selected) || XDate(true),
-      topDay: parseDate(this.props.selected) || XDate(true),
+      topDay: parseDate(this.props.selected) || XDate(true)
     };
     this.currentMonth = this.state.selectedDay.clone();
     this.onLayout = this.onLayout.bind(this);
@@ -116,11 +110,11 @@ export default class AgendaView extends Component {
     this.onSnapAfterDrag = this.onSnapAfterDrag.bind(this);
     this.generateMarkings = this.generateMarkings.bind(this);
     this.knobTracker = new VelocityTracker();
-    this.state.scrollY.addListener(({value}) => this.knobTracker.add(value));
+    this.state.scrollY.addListener(({ value }) => this.knobTracker.add(value));
   }
 
   calendarOffset() {
-    return 90 - (this.viewHeight / 2);
+    return 90 - this.viewHeight / 2;
   }
 
   initialScrollPadPosition() {
@@ -128,7 +122,7 @@ export default class AgendaView extends Component {
   }
 
   setScrollPadPosition(y, animated) {
-    this.scrollPad._component.scrollTo({x: 0, y, animated});
+    this.scrollPad._component.scrollTo({ x: 0, y, animated });
   }
 
   onScrollPadLayout() {
@@ -137,7 +131,7 @@ export default class AgendaView extends Component {
     // scroll position actually changes (it would stay at 0, when scrolled to the top).
     this.setScrollPadPosition(this.initialScrollPadPosition(), false);
     // delay rendering calendar in full height because otherwise it still flickers sometimes
-    setTimeout(() => this.setState({calendarIsReady: true}), 0);
+    setTimeout(() => this.setState({ calendarIsReady: true }), 0);
   }
 
   onLayout(event) {
@@ -147,26 +141,26 @@ export default class AgendaView extends Component {
   }
 
   onTouchStart() {
-    this.headerState = 'touched';
+    this.headerState = "touched";
     if (this.knob) {
-      this.knob.setNativeProps({style: { opacity: 0.5 }});
+      this.knob.setNativeProps({ style: { opacity: 0.5 } });
     }
   }
 
   onTouchEnd() {
     if (this.knob) {
-      this.knob.setNativeProps({style: { opacity: 1 }});
+      this.knob.setNativeProps({ style: { opacity: 1 } });
     }
 
-    if (this.headerState === 'touched') {
+    if (this.headerState === "touched") {
       this.setScrollPadPosition(0, true);
       this.enableCalendarScrolling();
     }
-    this.headerState = 'idle';
+    this.headerState = "idle";
   }
 
   onStartDrag() {
-    this.headerState = 'dragged';
+    this.headerState = "dragged";
     this.knobTracker.reset();
   }
 
@@ -175,9 +169,9 @@ export default class AgendaView extends Component {
     this.onTouchEnd();
     const currentY = e.nativeEvent.contentOffset.y;
     this.knobTracker.add(currentY);
-    const projectedY = currentY + this.knobTracker.estimateSpeed() * 250/*ms*/;
+    const projectedY = currentY + this.knobTracker.estimateSpeed() * 250; /*ms*/
     const maxY = this.initialScrollPadPosition();
-    const snapY = (projectedY > maxY / 2) ? maxY : 0;
+    const snapY = projectedY > maxY / 2 ? maxY : 0;
     this.setScrollPadPosition(snapY, true);
     if (snapY === 0) {
       this.enableCalendarScrolling();
@@ -196,18 +190,24 @@ export default class AgendaView extends Component {
   }
 
   loadReservations(props) {
-    if ((!props.items || !Object.keys(props.items).length) && !this.state.firstResevationLoad) {
-      this.setState({
-        firstResevationLoad: true
-      }, () => {
-        if (this.props.loadItemsForMonth) {
-          this.props.loadItemsForMonth(xdateToData(this.state.selectedDay));
+    if (
+      (!props.items || !Object.keys(props.items).length) &&
+      !this.state.firstResevationLoad
+    ) {
+      this.setState(
+        {
+          firstResevationLoad: true
+        },
+        () => {
+          if (this.props.loadItemsForMonth) {
+            this.props.loadItemsForMonth(xdateToData(this.state.selectedDay));
+          }
         }
-      });
+      );
     }
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this._isMounted = true;
     this.loadReservations(this.props);
   }
@@ -216,7 +216,7 @@ export default class AgendaView extends Component {
     this._isMounted = false;
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     if (props.items) {
       this.setState({
         firstResevationLoad: false
@@ -241,7 +241,11 @@ export default class AgendaView extends Component {
     // in CalendarList listView, but that might impact performance when scrolling
     // month list in expanded CalendarList.
     // Further info https://github.com/facebook/react-native/issues/1831
-    this.calendar.scrollToDay(this.state.selectedDay, this.calendarOffset() + 1, true);
+    this.calendar.scrollToDay(
+      this.state.selectedDay,
+      this.calendarOffset() + 1,
+      true
+    );
   }
 
   _chooseDayFromCalendar(d) {
@@ -288,7 +292,7 @@ export default class AgendaView extends Component {
         topDay={this.state.topDay}
         onDayChange={this.onDayChange.bind(this)}
         onScroll={() => {}}
-        ref={(c) => this.list = c}
+        ref={c => (this.list = c)}
         theme={this.props.theme}
       />
     );
@@ -311,92 +315,120 @@ export default class AgendaView extends Component {
     let markings = this.props.markedDates;
     if (!markings) {
       markings = {};
-      Object.keys(this.props.items  || {}).forEach(key => {
+      Object.keys(this.props.items || {}).forEach(key => {
         if (this.props.items[key] && this.props.items[key].length) {
-          markings[key] = {marked: true};
+          markings[key] = { marked: true };
         }
       });
     }
-    const key = this.state.selectedDay.toString('yyyy-MM-dd');
-    return {...markings, [key]: {...(markings[key] || {}), ...{selected: true}}};
+    const key = this.state.selectedDay.toString("yyyy-MM-dd");
+    return {
+      ...markings,
+      [key]: { ...(markings[key] || {}), ...{ selected: true } }
+    };
   }
 
   render() {
     const agendaHeight = Math.max(0, this.viewHeight - HEADER_HEIGHT);
     const weekDaysNames = dateutils.weekDayNames(this.props.firstDay);
-    const weekdaysStyle = [this.styles.weekdays, {
-      opacity: this.state.scrollY.interpolate({
-        inputRange: [agendaHeight - HEADER_HEIGHT, agendaHeight],
-        outputRange: [0, 1],
-        extrapolate: 'clamp',
-      }),
-      transform: [{ translateY: this.state.scrollY.interpolate({
-        inputRange: [Math.max(0, agendaHeight - HEADER_HEIGHT), agendaHeight],
-        outputRange: [-HEADER_HEIGHT, 0],
-        extrapolate: 'clamp',
-      })}]
-    }];
+    const weekdaysStyle = [
+      this.styles.weekdays,
+      {
+        opacity: this.state.scrollY.interpolate({
+          inputRange: [agendaHeight - HEADER_HEIGHT, agendaHeight],
+          outputRange: [0, 1],
+          extrapolate: "clamp"
+        }),
+        transform: [
+          {
+            translateY: this.state.scrollY.interpolate({
+              inputRange: [
+                Math.max(0, agendaHeight - HEADER_HEIGHT),
+                agendaHeight
+              ],
+              outputRange: [-HEADER_HEIGHT, 0],
+              extrapolate: "clamp"
+            })
+          }
+        ]
+      }
+    ];
 
     const headerTranslate = this.state.scrollY.interpolate({
       inputRange: [0, agendaHeight],
       outputRange: [agendaHeight, 0],
-      extrapolate: 'clamp',
+      extrapolate: "clamp"
     });
 
     const contentTranslate = this.state.scrollY.interpolate({
       inputRange: [0, agendaHeight],
-      outputRange: [0, agendaHeight/2],
-      extrapolate: 'clamp',
+      outputRange: [0, agendaHeight / 2],
+      extrapolate: "clamp"
     });
 
     const headerStyle = [
       this.styles.header,
-      { bottom: agendaHeight, transform: [{ translateY: headerTranslate }] },
+      { bottom: agendaHeight, transform: [{ translateY: headerTranslate }] }
     ];
 
     if (!this.state.calendarIsReady) {
       // limit header height until everything is setup for calendar dragging
-      headerStyle.push({height: 0});
+      headerStyle.push({ height: 0 });
       // fill header with appStyle.calendarBackground background to reduce flickering
-      weekdaysStyle.push({height: HEADER_HEIGHT});
+      weekdaysStyle.push({ height: HEADER_HEIGHT });
     }
 
-    const shouldAllowDragging = !this.props.hideKnob && !this.state.calendarScrollable;
-    const scrollPadPosition = (shouldAllowDragging ? HEADER_HEIGHT  : 0) - KNOB_HEIGHT;
+    const shouldAllowDragging =
+      !this.props.hideKnob && !this.state.calendarScrollable;
+    const scrollPadPosition =
+      (shouldAllowDragging ? HEADER_HEIGHT : 0) - KNOB_HEIGHT;
 
     const scrollPadStyle = {
-      position: 'absolute',
+      position: "absolute",
       width: 80,
       height: KNOB_HEIGHT,
       top: scrollPadPosition,
-      left: (this.viewWidth - 80) / 2,
+      left: (this.viewWidth - 80) / 2
     };
 
-    let knob = (<View style={this.styles.knobContainer}/>);
+    let knob = <View style={this.styles.knobContainer} />;
 
     if (!this.props.hideKnob) {
-      const knobView = this.props.renderKnob ? this.props.renderKnob() : (<View style={this.styles.knob}/>);
+      const knobView = this.props.renderKnob ? (
+        this.props.renderKnob()
+      ) : (
+        <View style={this.styles.knob} />
+      );
       knob = this.state.calendarScrollable ? null : (
         <View style={this.styles.knobContainer}>
-          <View ref={(c) => this.knob = c}>{knobView}</View>
+          <View ref={c => (this.knob = c)}>{knobView}</View>
         </View>
       );
     }
 
     return (
-      <View onLayout={this.onLayout} style={[this.props.style, {flex: 1, overflow: 'hidden'}]}>
+      <View
+        onLayout={this.onLayout}
+        style={[this.props.style, { flex: 1, overflow: "hidden" }]}
+      >
         <View style={this.styles.reservations}>
           {this.renderReservations()}
         </View>
         <Animated.View style={headerStyle}>
-          <Animated.View style={{flex:1, transform: [{ translateY: contentTranslate }]}}>
+          <Animated.View
+            style={{ flex: 1, transform: [{ translateY: contentTranslate }] }}
+          >
             <CalendarList
               onLayout={() => {
-                this.calendar.scrollToDay(this.state.selectedDay.clone(), this.calendarOffset(), false);
+                this.calendar.scrollToDay(
+                  this.state.selectedDay.clone(),
+                  this.calendarOffset(),
+                  false
+                );
               }}
               theme={this.props.theme}
               onVisibleMonthsChange={this.onVisibleMonthsChange.bind(this)}
-              ref={(c) => this.calendar = c}
+              ref={c => (this.calendar = c)}
               minDate={this.props.minDate}
               maxDate={this.props.maxDate}
               current={this.currentMonth}
@@ -419,14 +451,27 @@ export default class AgendaView extends Component {
           {knob}
         </Animated.View>
         <Animated.View style={weekdaysStyle}>
-          {this.props.showWeekNumbers && <Text allowFontScaling={false} style={this.styles.weekday} numberOfLines={1}></Text>}
-          {weekDaysNames.map((day) => (
-            <Text allowFontScaling={false} key={day} style={this.styles.weekday} numberOfLines={1}>{day}</Text>
+          {this.props.showWeekNumbers && (
+            <Text
+              allowFontScaling={false}
+              style={this.styles.weekday}
+              numberOfLines={1}
+            />
+          )}
+          {weekDaysNames.map(day => (
+            <Text
+              allowFontScaling={false}
+              key={day}
+              style={this.styles.weekday}
+              numberOfLines={1}
+            >
+              {day}
+            </Text>
           ))}
         </Animated.View>
         <Animated.ScrollView
-          ref={c => this.scrollPad = c}
-          overScrollMode='never'
+          ref={c => (this.scrollPad = c)}
+          overScrollMode="never"
           showsHorizontalScrollIndicator={false}
           showsVerticalScrollIndicator={false}
           style={scrollPadStyle}
@@ -438,10 +483,13 @@ export default class AgendaView extends Component {
           onScrollEndDrag={this.onSnapAfterDrag}
           onScroll={Animated.event(
             [{ nativeEvent: { contentOffset: { y: this.state.scrollY } } }],
-            { useNativeDriver: true },
+            { useNativeDriver: true }
           )}
         >
-          <View style={{height: agendaHeight + KNOB_HEIGHT}} onLayout={this.onScrollPadLayout} />
+          <View
+            style={{ height: agendaHeight + KNOB_HEIGHT }}
+            onLayout={this.onScrollPadLayout}
+          />
         </Animated.ScrollView>
       </View>
     );

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -1,15 +1,11 @@
-import React, {Component} from 'react';
-import {
-  FlatList,
-  ActivityIndicator,
-  View
-} from 'react-native';
-import Reservation from './reservation';
-import PropTypes from 'prop-types';
-import XDate from 'xdate';
+import React, { Component } from "react";
+import { FlatList, ActivityIndicator, View } from "react-native";
+import Reservation from "./reservation";
+import PropTypes from "prop-types";
+import XDate from "xdate";
 
-import dateutils from '../../dateutils';
-import styleConstructor from './style';
+import dateutils from "../../dateutils";
+import styleConstructor from "./style";
 
 class ReactComp extends Component {
   static propTypes = {
@@ -34,7 +30,7 @@ class ReactComp extends Component {
     topDay: PropTypes.instanceOf(XDate),
     refreshControl: PropTypes.element,
     refreshing: PropTypes.bool,
-    onRefresh: PropTypes.func,
+    onRefresh: PropTypes.func
   };
 
   constructor(props) {
@@ -43,12 +39,12 @@ class ReactComp extends Component {
     this.state = {
       reservations: []
     };
-    this.heights=[];
+    this.heights = [];
     this.selectedDay = this.props.selectedDay;
     this.scrollOver = true;
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.updateDataSource(this.getReservations(this.props).reservations);
   }
 
@@ -66,19 +62,22 @@ class ReactComp extends Component {
         scrollPosition += this.heights[i] || 0;
       }
       this.scrollOver = false;
-      this.list.scrollToOffset({offset: scrollPosition, animated: true});
+      this.list.scrollToOffset({ offset: scrollPosition, animated: true });
     }
     this.selectedDay = props.selectedDay;
     this.updateDataSource(reservations.reservations);
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     if (!dateutils.sameDate(props.topDay, this.props.topDay)) {
-      this.setState({
-        reservations: []
-      }, () => {
-        this.updateReservations(props);
-      });
+      this.setState(
+        {
+          reservations: []
+        },
+        () => {
+          this.updateReservations(props);
+        }
+      );
     } else {
       this.updateReservations(props);
     }
@@ -109,7 +108,7 @@ class ReactComp extends Component {
     this.heights[ind] = event.nativeEvent.layout.height;
   }
 
-  renderRow({item, index}) {
+  renderRow({ item, index }) {
     return (
       <View onLayout={this.onRowLayoutChange.bind(this, index)}>
         <Reservation
@@ -126,7 +125,7 @@ class ReactComp extends Component {
 
   getReservationsForDay(iterator, props) {
     const day = iterator.clone();
-    const res = props.reservations[day.toString('yyyy-MM-dd')];
+    const res = props.reservations[day.toString("yyyy-MM-dd")];
     if (res && res.length) {
       return res.map((reservation, i) => {
         return {
@@ -136,10 +135,12 @@ class ReactComp extends Component {
         };
       });
     } else if (res) {
-      return [{
-        date: iterator.clone(),
-        day
-      }];
+      return [
+        {
+          date: iterator.clone(),
+          day
+        }
+      ];
     } else {
       return false;
     }
@@ -151,7 +152,7 @@ class ReactComp extends Component {
 
   getReservations(props) {
     if (!props.reservations || !props.selectedDay) {
-      return {reservations: [], scrollPosition: 0};
+      return { reservations: [], scrollPosition: 0 };
     }
     let reservations = [];
     if (this.state.reservations && this.state.reservations.length) {
@@ -177,19 +178,22 @@ class ReactComp extends Component {
       iterator.addDays(1);
     }
 
-    return {reservations, scrollPosition};
+    return { reservations, scrollPosition };
   }
 
   render() {
-    if (!this.props.reservations || !this.props.reservations[this.props.selectedDay.toString('yyyy-MM-dd')]) {
+    if (
+      !this.props.reservations ||
+      !this.props.reservations[this.props.selectedDay.toString("yyyy-MM-dd")]
+    ) {
       if (this.props.renderEmptyData) {
         return this.props.renderEmptyData();
       }
-      return (<ActivityIndicator style={{marginTop: 80}}/>);
+      return <ActivityIndicator style={{ marginTop: 80 }} />;
     }
     return (
       <FlatList
-        ref={(c) => this.list = c}
+        ref={c => (this.list = c)}
         style={this.props.style}
         contentContainerStyle={this.styles.content}
         renderItem={this.renderRow.bind(this)}
@@ -197,7 +201,10 @@ class ReactComp extends Component {
         onScroll={this.onScroll.bind(this)}
         showsVerticalScrollIndicator={false}
         scrollEventThrottle={200}
-        onMoveShouldSetResponderCapture={() => {this.onListTouch(); return false;}}
+        onMoveShouldSetResponderCapture={() => {
+          this.onListTouch();
+          return false;
+        }}
         keyExtractor={(item, index) => String(index)}
         refreshControl={this.props.refreshControl}
         refreshing={this.props.refreshing || false}

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -1,17 +1,15 @@
-import React, {Component} from 'react';
-import {
-  FlatList, Platform, Dimensions,
-} from 'react-native';
-import PropTypes from 'prop-types';
-import XDate from 'xdate';
+import React, { Component } from "react";
+import { FlatList, Platform, Dimensions } from "react-native";
+import PropTypes from "prop-types";
+import XDate from "xdate";
 
-import {xdateToData, parseDate} from '../interface';
-import styleConstructor from './style';
-import dateutils from '../dateutils';
-import Calendar from '../calendar';
-import CalendarListItem from './item';
+import { xdateToData, parseDate } from "../interface";
+import styleConstructor from "./style";
+import dateutils from "../dateutils";
+import Calendar from "../calendar";
+import CalendarListItem from "./item";
 
-const {width} = Dimensions.get('window');
+const { width } = Dimensions.get("window");
 
 class CalendarList extends Component {
   static propTypes = {
@@ -41,7 +39,7 @@ class CalendarList extends Component {
     // Whether the scroll is horizontal
     horizontal: PropTypes.bool,
     // Dynamic calendar height
-    calendarHeight: PropTypes.number,
+    calendarHeight: PropTypes.number
   };
 
   static defaultProps = {
@@ -53,8 +51,8 @@ class CalendarList extends Component {
     showScrollIndicator: false,
     scrollEnabled: true,
     scrollsToTop: false,
-    removeClippedSubviews: Platform.OS === 'android' ? false : true,
-  }
+    removeClippedSubviews: Platform.OS === "android" ? false : true
+  };
 
   constructor(props) {
     super(props);
@@ -63,15 +61,25 @@ class CalendarList extends Component {
     const rows = [];
     const texts = [];
     const date = parseDate(props.current) || XDate();
-    for (let i = 0; i <= this.props.pastScrollRange + this.props.futureScrollRange; i++) {
-      const rangeDate = date.clone().addMonths(i - this.props.pastScrollRange, true);
-      const rangeDateStr = rangeDate.toString('MMM yyyy');
+    for (
+      let i = 0;
+      i <= this.props.pastScrollRange + this.props.futureScrollRange;
+      i++
+    ) {
+      const rangeDate = date
+        .clone()
+        .addMonths(i - this.props.pastScrollRange, true);
+      const rangeDateStr = rangeDate.toString("MMM yyyy");
       texts.push(rangeDateStr);
       /*
        * This selects range around current shown month [-0, +2] or [-1, +1] month for detail calendar rendering.
        * If `this.pastScrollRange` is `undefined` it's equal to `false` or 0 in next condition.
        */
-      if (this.props.pastScrollRange - 1 <= i && i <= this.props.pastScrollRange + 1 || !this.props.pastScrollRange && i <= this.props.pastScrollRange + 2) {
+      if (
+        (this.props.pastScrollRange - 1 <= i &&
+          i <= this.props.pastScrollRange + 1) ||
+        (!this.props.pastScrollRange && i <= this.props.pastScrollRange + 2)
+      ) {
         rows.push(rangeDate);
       } else {
         rows.push(rangeDateStr);
@@ -98,9 +106,17 @@ class CalendarList extends Component {
 
   scrollToDay(d, offset, animated) {
     const day = parseDate(d);
-    const diffMonths = Math.round(this.state.openDate.clone().setDate(1).diffMonths(day.clone().setDate(1)));
-    const size = this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight;
-    let scrollAmount = (size * this.props.pastScrollRange) + (diffMonths * size) + (offset || 0);
+    const diffMonths = Math.round(
+      this.state.openDate
+        .clone()
+        .setDate(1)
+        .diffMonths(day.clone().setDate(1))
+    );
+    const size = this.props.horizontal
+      ? this.props.calendarWidth
+      : this.props.calendarHeight;
+    let scrollAmount =
+      size * this.props.pastScrollRange + diffMonths * size + (offset || 0);
     if (!this.props.horizontal) {
       let week = 0;
       const days = dateutils.page(day, this.props.firstDay);
@@ -112,21 +128,28 @@ class CalendarList extends Component {
         }
       }
     }
-    this.listView.scrollToOffset({offset: scrollAmount, animated});
+    this.listView.scrollToOffset({ offset: scrollAmount, animated });
   }
 
   scrollToMonth(m) {
     const month = parseDate(m);
     const scrollTo = month || this.state.openDate;
-    let diffMonths = Math.round(this.state.openDate.clone().setDate(1).diffMonths(scrollTo.clone().setDate(1)));
-    const size = this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight;
-    const scrollAmount = (size * this.props.pastScrollRange) + (diffMonths * size);
+    let diffMonths = Math.round(
+      this.state.openDate
+        .clone()
+        .setDate(1)
+        .diffMonths(scrollTo.clone().setDate(1))
+    );
+    const size = this.props.horizontal
+      ? this.props.calendarWidth
+      : this.props.calendarHeight;
+    const scrollAmount = size * this.props.pastScrollRange + diffMonths * size;
     //console.log(month, this.state.openDate);
     //console.log(scrollAmount, diffMonths);
-    this.listView.scrollToOffset({offset: scrollAmount, animated: false});
+    this.listView.scrollToOffset({ offset: scrollAmount, animated: false });
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     const current = parseDate(this.props.current);
     const nextCurrent = parseDate(props.current);
     if (nextCurrent && current && nextCurrent.getTime() !== current.getTime()) {
@@ -148,7 +171,7 @@ class CalendarList extends Component {
     });
   }
 
-  onViewableItemsChanged({viewableItems}) {
+  onViewableItemsChanged({ viewableItems }) {
     function rowIsCloseToViewable(index, distance) {
       for (let i = 0; i < viewableItems.length; i++) {
         if (Math.abs(index - parseInt(viewableItems[i].index)) <= distance) {
@@ -165,7 +188,9 @@ class CalendarList extends Component {
       let val = rowclone[i];
       const rowShouldBeRendered = rowIsCloseToViewable(i, 1);
       if (rowShouldBeRendered && !rowclone[i].getTime) {
-        val = this.state.openDate.clone().addMonths(i - this.props.pastScrollRange, true);
+        val = this.state.openDate
+          .clone()
+          .addMonths(i - this.props.pastScrollRange, true);
       } else if (!rowShouldBeRendered) {
         val = this.state.texts[i];
       }
@@ -182,16 +207,35 @@ class CalendarList extends Component {
     });
   }
 
-  renderCalendar({item}) {
-    return (<CalendarListItem item={item} calendarHeight={this.props.calendarHeight} calendarWidth={this.props.horizontal ? this.props.calendarWidth : undefined  } {...this.props} />);
+  renderCalendar({ item }) {
+    return (
+      <CalendarListItem
+        item={item}
+        calendarHeight={this.props.calendarHeight}
+        calendarWidth={
+          this.props.horizontal ? this.props.calendarWidth : undefined
+        }
+        {...this.props}
+      />
+    );
   }
 
   getItemLayout(data, index) {
-    return {length: this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight, offset: (this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight) * index, index};
+    return {
+      length: this.props.horizontal
+        ? this.props.calendarWidth
+        : this.props.calendarHeight,
+      offset:
+        (this.props.horizontal
+          ? this.props.calendarWidth
+          : this.props.calendarHeight) * index,
+      index
+    };
   }
 
   getMonthIndex(month) {
-    let diffMonths = this.state.openDate.diffMonths(month) + this.props.pastScrollRange;
+    let diffMonths =
+      this.state.openDate.diffMonths(month) + this.props.pastScrollRange;
     return diffMonths;
   }
 
@@ -199,7 +243,7 @@ class CalendarList extends Component {
     return (
       <FlatList
         onLayout={this.onLayout}
-        ref={(c) => this.listView = c}
+        ref={c => (this.listView = c)}
         //scrollEventThrottle={1000}
         style={[this.style.container, this.props.style]}
         initialListSize={this.pastScrollRange + this.futureScrollRange + 1}
@@ -216,7 +260,9 @@ class CalendarList extends Component {
         showsHorizontalScrollIndicator={this.props.showScrollIndicator}
         scrollEnabled={this.props.scrollingEnabled}
         keyExtractor={(item, index) => String(index)}
-        initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
+        initialScrollIndex={
+          this.state.openDate ? this.getMonthIndex(this.state.openDate) : false
+        }
         getItemLayout={this.getItemLayout}
         scrollsToTop={this.props.scrollsToTop}
       />

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -113,7 +113,7 @@ class CalendarHeader extends Component {
       indicator = <ActivityIndicator />;
     }
     return (
-      <View>
+      <React.Fragment>
         <View style={this.style.header}>
           {leftArrow}
           <View style={{ flexDirection: 'row' }}>
@@ -133,7 +133,7 @@ class CalendarHeader extends Component {
             ))}
           </View>
         }
-      </View>
+      </React.Fragment>
     );
   }
 }

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -1,21 +1,18 @@
-import React, {Component} from 'react';
-import {
-  View,
-  ViewPropTypes
-} from 'react-native';
-import PropTypes from 'prop-types';
+import React, { Component } from "react";
+import { View, ViewPropTypes } from "react-native";
+import PropTypes from "prop-types";
 
-import XDate from 'xdate';
-import dateutils from '../dateutils';
-import {xdateToData, parseDate} from '../interface';
-import styleConstructor from './style';
-import Day from './day/basic';
-import UnitDay from './day/period';
-import MultiDotDay from './day/multi-dot';
-import MultiPeriodDay from './day/multi-period';
-import SingleDay from './day/custom';
-import CalendarHeader from './header';
-import shouldComponentUpdate from './updater';
+import XDate from "xdate";
+import dateutils from "../dateutils";
+import { xdateToData, parseDate } from "../interface";
+import styleConstructor from "./style";
+import Day from "./day/basic";
+import UnitDay from "./day/period";
+import MultiDotDay from "./day/multi-dot";
+import MultiPeriodDay from "./day/multi-period";
+import SingleDay from "./day/custom";
+import CalendarHeader from "./header";
+import shouldComponentUpdate from "./updater";
 
 //Fallback when RN version is < 0.44
 const viewPropTypes = ViewPropTypes || View.propTypes;
@@ -41,7 +38,7 @@ class Calendar extends Component {
     // If firstDay=1 week starts from Monday. Note that dayNames and dayNamesShort should still start from Sunday.
     firstDay: PropTypes.number,
 
-    // Date marking style [simple/period/multi-dot/multi-period]. Default = 'simple' 
+    // Date marking style [simple/period/multi-dot/multi-period]. Default = 'simple'
     markingType: PropTypes.string,
 
     // Hide month navigation arrows. Default = false
@@ -98,9 +95,13 @@ class Calendar extends Component {
     this.shouldComponentUpdate = shouldComponentUpdate;
   }
 
-  componentWillReceiveProps(nextProps) {
-    const current= parseDate(nextProps.current);
-    if (current && current.toString('yyyy MM') !== this.state.currentMonth.toString('yyyy MM')) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const current = parseDate(nextProps.current);
+    if (
+      current &&
+      current.toString("yyyy MM") !==
+        this.state.currentMonth.toString("yyyy MM")
+    ) {
       this.setState({
         currentMonth: current.clone()
       });
@@ -108,30 +109,40 @@ class Calendar extends Component {
   }
 
   updateMonth(day, doNotTriggerListeners) {
-    if (day.toString('yyyy MM') === this.state.currentMonth.toString('yyyy MM')) {
+    if (
+      day.toString("yyyy MM") === this.state.currentMonth.toString("yyyy MM")
+    ) {
       return;
     }
-    this.setState({
-      currentMonth: day.clone()
-    }, () => {
-      if (!doNotTriggerListeners) {
-        const currMont = this.state.currentMonth.clone();
-        if (this.props.onMonthChange) {
-          this.props.onMonthChange(xdateToData(currMont));
-        }
-        if (this.props.onVisibleMonthsChange) {
-          this.props.onVisibleMonthsChange([xdateToData(currMont)]);
+    this.setState(
+      {
+        currentMonth: day.clone()
+      },
+      () => {
+        if (!doNotTriggerListeners) {
+          const currMont = this.state.currentMonth.clone();
+          if (this.props.onMonthChange) {
+            this.props.onMonthChange(xdateToData(currMont));
+          }
+          if (this.props.onVisibleMonthsChange) {
+            this.props.onVisibleMonthsChange([xdateToData(currMont)]);
+          }
         }
       }
-    });
+    );
   }
 
   _handleDayInteraction(date, interaction) {
     const day = parseDate(date);
     const minDate = parseDate(this.props.minDate);
     const maxDate = parseDate(this.props.maxDate);
-    if (!(minDate && !dateutils.isGTE(day, minDate)) && !(maxDate && !dateutils.isLTE(day, maxDate))) {
-      const shouldUpdateMonth = this.props.disableMonthChange === undefined || !this.props.disableMonthChange;
+    if (
+      !(minDate && !dateutils.isGTE(day, minDate)) &&
+      !(maxDate && !dateutils.isLTE(day, maxDate))
+    ) {
+      const shouldUpdateMonth =
+        this.props.disableMonthChange === undefined ||
+        !this.props.disableMonthChange;
       if (shouldUpdateMonth) {
         this.updateMonth(day);
       }
@@ -156,22 +167,28 @@ class Calendar extends Component {
   renderDay(day, id) {
     const minDate = parseDate(this.props.minDate);
     const maxDate = parseDate(this.props.maxDate);
-    let state = '';
+    let state = "";
     if (this.props.disabledByDefault) {
-      state = 'disabled';
-    } else if ((minDate && !dateutils.isGTE(day, minDate)) || (maxDate && !dateutils.isLTE(day, maxDate))) {
-      state = 'disabled';
+      state = "disabled";
+    } else if (
+      (minDate && !dateutils.isGTE(day, minDate)) ||
+      (maxDate && !dateutils.isLTE(day, maxDate))
+    ) {
+      state = "disabled";
     } else if (!dateutils.sameMonth(day, this.state.currentMonth)) {
-      state = 'disabled';
+      state = "disabled";
     } else if (dateutils.sameDate(day, XDate())) {
-      state = 'today';
+      state = "today";
     }
     let dayComp;
-    if (!dateutils.sameMonth(day, this.state.currentMonth) && this.props.hideExtraDays) {
-      if (['period', 'multi-period'].includes(this.props.markingType)) {
-        dayComp = (<View key={id} style={{flex: 1}}/>);
+    if (
+      !dateutils.sameMonth(day, this.state.currentMonth) &&
+      this.props.hideExtraDays
+    ) {
+      if (["period", "multi-period"].includes(this.props.markingType)) {
+        dayComp = <View key={id} style={{ flex: 1 }} />;
       } else {
-        dayComp = (<View key={id} style={this.style.dayContainer}/>);
+        dayComp = <View key={id} style={this.style.dayContainer} />;
       }
     } else {
       const DayComp = this.getDayComponent();
@@ -199,16 +216,16 @@ class Calendar extends Component {
     }
 
     switch (this.props.markingType) {
-    case 'period':
-      return UnitDay;
-    case 'multi-dot':
-      return MultiDotDay;
-    case 'multi-period':
-      return MultiPeriodDay;
-    case 'custom':
-      return SingleDay;
-    default:
-      return Day;
+      case "period":
+        return UnitDay;
+      case "multi-dot":
+        return MultiDotDay;
+      case "multi-period":
+        return MultiPeriodDay;
+      case "custom":
+        return SingleDay;
+      default:
+        return Day;
     }
   }
 
@@ -216,7 +233,8 @@ class Calendar extends Component {
     if (!this.props.markedDates) {
       return false;
     }
-    const dates = this.props.markedDates[day.toString('yyyy-MM-dd')] || EmptyArray;
+    const dates =
+      this.props.markedDates[day.toString("yyyy-MM-dd")] || EmptyArray;
     if (dates.length || dates) {
       return dates;
     } else {
@@ -224,8 +242,17 @@ class Calendar extends Component {
     }
   }
 
-  renderWeekNumber (weekNumber) {
-    return <Day key={`week-${weekNumber}`} theme={this.props.theme} marking={{disableTouchEvent: true}} state='disabled'>{weekNumber}</Day>;
+  renderWeekNumber(weekNumber) {
+    return (
+      <Day
+        key={`week-${weekNumber}`}
+        theme={this.props.theme}
+        marking={{ disableTouchEvent: true }}
+        state="disabled"
+      >
+        {weekNumber}
+      </Day>
+    );
   }
 
   renderWeek(days, id) {
@@ -238,7 +265,11 @@ class Calendar extends Component {
       week.unshift(this.renderWeekNumber(days[days.length - 1].getWeek()));
     }
 
-    return (<View style={this.style.week} key={id}>{week}</View>);
+    return (
+      <View style={this.style.week} key={id}>
+        {week}
+      </View>
+    );
   }
 
   render() {
@@ -250,9 +281,16 @@ class Calendar extends Component {
     let indicator;
     const current = parseDate(this.props.current);
     if (current) {
-      const lastMonthOfDay = current.clone().addMonths(1, true).setDate(1).addDays(-1).toString('yyyy-MM-dd');
-      if (this.props.displayLoadingIndicator &&
-          !(this.props.markedDates && this.props.markedDates[lastMonthOfDay])) {
+      const lastMonthOfDay = current
+        .clone()
+        .addMonths(1, true)
+        .setDate(1)
+        .addDays(-1)
+        .toString("yyyy-MM-dd");
+      if (
+        this.props.displayLoadingIndicator &&
+        !(this.props.markedDates && this.props.markedDates[lastMonthOfDay])
+      ) {
         indicator = true;
       }
     }
@@ -273,7 +311,8 @@ class Calendar extends Component {
           onPressArrowRight={this.props.onPressArrowRight}
         />
         <View style={this.style.monthView}>{weeks}</View>
-      </View>);
+      </View>
+    );
   }
 }
 


### PR DESCRIPTION
I'm not sure why, but this change eliminates animation glitches for us when we wrap the calendar with `react-native-collapsible`. `react-native-collapsible` is just a `View` with `overflow:hidden` and an animated `height` style property, so I don't know why this change would do anything but it definitely does. I feel like it's indirectly helping out the react internal Yoga layout engine somehow.

Anyway, maybe you'll merge it because React.Fragment is the new way to do views that only exist to return multiple components.

https://reactjs.org/docs/fragments.html

Thanks for looking at this!

- Mike