### PR TITLE
feat(agenda) add scroll pad style to theme #558

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -429,7 +429,7 @@ export default class AgendaView extends Component {
           overScrollMode='never'
           showsHorizontalScrollIndicator={false}
           showsVerticalScrollIndicator={false}
-          style={scrollPadStyle}
+          style={[scrollPadStyle, this.styles.scrollPadStyle]}
           scrollEventThrottle={1}
           scrollsToTop={false}
           onTouchStart={this.onTouchStart}


### PR DESCRIPTION
I needed to style the scroll pad style as my users were complaining that the knob active area on de Agenda was too narrow.

I added the scrollPadStyle on the ScrollArea element so that I could pass style property through the theme prop.