### PR TITLE
Always display all items in Agenda component to allow scrolling up

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -66,6 +66,8 @@ export default class AgendaView extends Component {
     selected: PropTypes.any,
     // earliest possible day
     earliest: PropTypes.any,
+    // latest possible day
+    latest: PropTypes.any,
     // Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined
     minDate: PropTypes.any,
     // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
@@ -107,6 +109,7 @@ export default class AgendaView extends Component {
       calendarScrollable: false,
       firstResevationLoad: false,
       earliestDay: parseDate(this.props.earliest) || XDate(true),
+      latestDay: parseDate(this.props.latest) || XDate(true),
       selectedDay: parseDate(this.props.selected) || XDate(true),
       topDay: parseDate(this.props.selected) || XDate(true),
     };

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -64,6 +64,8 @@ export default class AgendaView extends Component {
 
     // initially selected day
     selected: PropTypes.any,
+    // earliest possible day
+    earliest: PropTypes.any,
     // Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined
     minDate: PropTypes.any,
     // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
@@ -104,6 +106,7 @@ export default class AgendaView extends Component {
       calendarIsReady: false,
       calendarScrollable: false,
       firstResevationLoad: false,
+      earliestDay: parseDate(this.props.earliest) || XDate(true),
       selectedDay: parseDate(this.props.selected) || XDate(true),
       topDay: parseDate(this.props.selected) || XDate(true),
     };
@@ -284,6 +287,7 @@ export default class AgendaView extends Component {
         renderEmptyDate={this.props.renderEmptyDate}
         reservations={this.props.items}
         selectedDay={this.state.selectedDay}
+        earliestDay={this.state.earliestDay}
         renderEmptyData={this.props.renderEmptyData}
         topDay={this.state.topDay}
         onDayChange={this.onDayChange.bind(this)}

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -291,6 +291,7 @@ export default class AgendaView extends Component {
         reservations={this.props.items}
         selectedDay={this.state.selectedDay}
         earliestDay={this.state.earliestDay}
+        latestDay={this.state.latestDay}
         renderEmptyData={this.props.renderEmptyData}
         topDay={this.state.topDay}
         onDayChange={this.onDayChange.bind(this)}

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -32,6 +32,7 @@ class ReactComp extends Component {
 
     selectedDay: PropTypes.instanceOf(XDate),
     earliestDay: PropTypes.instanceOf(XDate),
+    latestDay: PropTypes.instanceOf(XDate),
     topDay: PropTypes.instanceOf(XDate),
     refreshControl: PropTypes.element,
     refreshing: PropTypes.bool,
@@ -47,6 +48,7 @@ class ReactComp extends Component {
     this.heights=[];
     this.selectedDay = this.props.selectedDay;
     this.earliestDay = this.props.earliestDay;
+    this.latestDay = this.props.latestDay;
     this.scrollOver = true;
   }
 
@@ -157,8 +159,10 @@ class ReactComp extends Component {
     }
     let reservations = [];
     if (this.state.reservations && this.state.reservations.length) {
-      const iterator = this.state.reservations[0].day.clone();
-      while (iterator.getTime() < props.selectedDay.getTime()) {
+      const reservations = this.state.reservations
+      const iterator = reservations[0].day.clone();
+      const lastIterator = reservations[(reservations.length-1)].day.clone()
+      while (iterator.getTime() <= lastIterator.getTime()) {
         const res = this.getReservationsForDay(iterator, props);
         if (!res) {
           reservations = [];
@@ -171,7 +175,8 @@ class ReactComp extends Component {
     }
 
     const iterator = this.earliestDay.clone();
-    for (let i = 0; i < 31; i++) {
+    const lastIterator = this.latestDay.clone();
+    while (iterator.getTime() <= lastIterator.getTime()) {
       const res = this.getReservationsForDay(iterator, props);
       if (res) {
         reservations = reservations.concat(res);

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -31,6 +31,7 @@ class ReactComp extends Component {
     reservations: PropTypes.object,
 
     selectedDay: PropTypes.instanceOf(XDate),
+    earliestDay: PropTypes.instanceOf(XDate),
     topDay: PropTypes.instanceOf(XDate),
     refreshControl: PropTypes.element,
     refreshing: PropTypes.bool,
@@ -45,6 +46,7 @@ class ReactComp extends Component {
     };
     this.heights=[];
     this.selectedDay = this.props.selectedDay;
+    this.earliestDay = this.props.earliestDay;
     this.scrollOver = true;
   }
 
@@ -59,8 +61,9 @@ class ReactComp extends Component {
   }
 
   updateReservations(props) {
+    this.selectedDay = props.selectedDay;
     const reservations = this.getReservations(props);
-    if (this.list && !dateutils.sameDate(props.selectedDay, this.selectedDay)) {
+    if (this.list) {
       let scrollPosition = 0;
       for (let i = 0; i < reservations.scrollPosition; i++) {
         scrollPosition += this.heights[i] || 0;
@@ -68,7 +71,6 @@ class ReactComp extends Component {
       this.scrollOver = false;
       this.list.scrollToOffset({offset: scrollPosition, animated: true});
     }
-    this.selectedDay = props.selectedDay;
     this.updateDataSource(reservations.reservations);
   }
 
@@ -167,8 +169,8 @@ class ReactComp extends Component {
         iterator.addDays(1);
       }
     }
-    const scrollPosition = reservations.length;
-    const iterator = props.selectedDay.clone();
+
+    const iterator = this.earliestDay.clone();
     for (let i = 0; i < 31; i++) {
       const res = this.getReservationsForDay(iterator, props);
       if (res) {
@@ -176,8 +178,25 @@ class ReactComp extends Component {
       }
       iterator.addDays(1);
     }
-
+    const scrollPosition = this.calculateScrollPosition(reservations);
     return {reservations, scrollPosition};
+  }
+
+  /**
+   * Will iterate thru all reservations to see how
+   * long it takes to get to the selected day. Will
+   * add the height of each day we need to scroll
+   * past to get to the selected day.
+   */
+  calculateScrollPosition(reservations) {
+    let scrollPosition = 0;
+    for (reservation of reservations) {
+      if (JSON.stringify(this.selectedDay[0]) === JSON.stringify(reservation.date[0])) {
+        break;
+      }
+      scrollPosition++;
+    }
+    return scrollPosition;
   }
 
   render() {

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -47,7 +47,7 @@ class ReactComp extends Component {
       reservations: []
     };
     this.heights=[];
-    this.theHeight=117;
+    this.theHeight=142;
     this.selectedDay = this.props.selectedDay;
     this.earliestDay = this.props.earliestDay;
     this.latestDay = this.props.latestDay;

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -12,6 +12,7 @@ import dateutils from '../../dateutils';
 import styleConstructor from './style';
 
 class ReactComp extends Component {
+
   static propTypes = {
     // specify your item comparison function for increased performance
     rowHasChanged: PropTypes.func,
@@ -46,14 +47,17 @@ class ReactComp extends Component {
       reservations: []
     };
     this.heights=[];
+    this.theHeight=117;
     this.selectedDay = this.props.selectedDay;
     this.earliestDay = this.props.earliestDay;
     this.latestDay = this.props.latestDay;
     this.scrollOver = true;
+    this.firstScroll = true;
   }
 
   componentWillMount() {
-    this.updateDataSource(this.getReservations(this.props).reservations);
+    const response = this.getReservations(this.props)
+    this.updateDataSource(response);
   }
 
   updateDataSource(reservations) {
@@ -67,10 +71,8 @@ class ReactComp extends Component {
     const reservations = this.getReservations(props);
     if (this.list) {
       let scrollPosition = 0;
-      for (let i = 0; i < reservations.scrollPosition; i++) {
-        scrollPosition += this.heights[i] || 0;
-      }
       this.scrollOver = false;
+      scrollPosition = (reservations.scrollPosition * this.theHeight);
       this.list.scrollToOffset({offset: scrollPosition, animated: true});
     }
     this.updateDataSource(reservations.reservations);
@@ -93,12 +95,14 @@ class ReactComp extends Component {
     this.props.onScroll(yOffset);
     let topRowOffset = 0;
     let topRow;
-    for (topRow = 0; topRow < this.heights.length; topRow++) {
-      if (topRowOffset + this.heights[topRow] / 2 >= yOffset) {
+
+    for (topRow = 0; topRow < this.state.reservations.length; topRow++) {
+      if (topRowOffset + this.theHeight / 2 >= yOffset) {
         break;
       }
-      topRowOffset += this.heights[topRow];
+      topRowOffset += this.theHeight;
     }
+
     const row = this.state.reservations[topRow];
     if (!row) return;
     const day = row.day;
@@ -201,6 +205,7 @@ class ReactComp extends Component {
       }
       scrollPosition++;
     }
+    this.startIndex = scrollPosition;
     return scrollPosition;
   }
 
@@ -226,9 +231,14 @@ class ReactComp extends Component {
         refreshControl={this.props.refreshControl}
         refreshing={this.props.refreshing || false}
         onRefresh={this.props.onRefresh}
+        getItemLayout={(data, index) => (
+          {length: this.theHeight, offset: this.theHeight * index, index}
+        )}
+        initialScrollIndex={this.startIndex}
       />
     );
   }
+
 }
 
 export default ReactComp;

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -234,7 +234,6 @@ class ReactComp extends Component {
         getItemLayout={(data, index) => (
           {length: this.theHeight, offset: this.theHeight * index, index}
         )}
-        initialScrollIndex={this.startIndex}
       />
     );
   }

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -159,9 +159,9 @@ class ReactComp extends Component {
     }
     let reservations = [];
     if (this.state.reservations && this.state.reservations.length) {
-      const reservations = this.state.reservations
+      const reservations = this.state.reservations;
       const iterator = reservations[0].day.clone();
-      const lastIterator = reservations[(reservations.length-1)].day.clone()
+      const lastIterator = reservations[(reservations.length-1)].day.clone();
       while (iterator.getTime() <= lastIterator.getTime()) {
         const res = this.getReservationsForDay(iterator, props);
         if (!res) {

--- a/src/agenda/reservation-list/style.js
+++ b/src/agenda/reservation-list/style.js
@@ -11,6 +11,7 @@ export default function styleConstructor(theme = {}) {
     },
     dayNum: {
       fontSize: 28,
+      marginBottom: 4,
       fontWeight: '200',
       fontFamily: appStyle.textMonthFontFamily,
       color: appStyle.agendaDayNumColor

--- a/src/agenda/reservation-list/style.js
+++ b/src/agenda/reservation-list/style.js
@@ -11,17 +11,14 @@ export default function styleConstructor(theme = {}) {
     },
     dayNum: {
       fontSize: 28,
-      marginBottom: 4,
-      fontWeight: '200',
       fontFamily: appStyle.textMonthFontFamily,
       color: appStyle.agendaDayNumColor
     },
     dayText: {
       fontSize: 14,
-      fontWeight: '300',
       color: appStyle.agendaDayTextColor,
       fontFamily: appStyle.textDayFontFamily,
-      marginTop: 0,
+      marginTop: -8,
       backgroundColor: 'rgba(0,0,0,0)'
     },
     day: {

--- a/src/agenda/reservation-list/style.js
+++ b/src/agenda/reservation-list/style.js
@@ -21,7 +21,7 @@ export default function styleConstructor(theme = {}) {
       fontWeight: '300',
       color: appStyle.agendaDayTextColor,
       fontFamily: appStyle.textDayFontFamily,
-      marginTop: -5,
+      marginTop: 0,
       backgroundColor: 'rgba(0,0,0,0)'
     },
     day: {

--- a/src/agenda/reservation-list/style.js
+++ b/src/agenda/reservation-list/style.js
@@ -12,12 +12,14 @@ export default function styleConstructor(theme = {}) {
     dayNum: {
       fontSize: 28,
       fontWeight: '200',
+      fontFamily: appStyle.textMonthFontFamily,
       color: appStyle.agendaDayNumColor
     },
     dayText: {
       fontSize: 14,
       fontWeight: '300',
       color: appStyle.agendaDayTextColor,
+      fontFamily: appStyle.textDayFontFamily,
       marginTop: -5,
       backgroundColor: 'rgba(0,0,0,0)'
     },

--- a/src/calendar/day/basic/style.js
+++ b/src/calendar/day/basic/style.js
@@ -15,7 +15,6 @@ export default function styleConstructor(theme={}) {
       marginTop: Platform.OS === 'android' ? 4 : 6,
       fontSize: appStyle.textDayFontSize,
       fontFamily: appStyle.textDayFontFamily,
-      fontWeight: '300',
       color: appStyle.dayTextColor,
       backgroundColor: 'rgba(255, 255, 255, 0)'
     },
@@ -39,8 +38,8 @@ export default function styleConstructor(theme={}) {
       color: appStyle.textDisabledColor
     },
     dot: {
-      width: 4,
-      height: 4,
+      width: 8,
+      height: 8,
       marginTop: 1,
       borderRadius: 2,
       opacity: 0

--- a/src/calendar/day/custom/style.js
+++ b/src/calendar/day/custom/style.js
@@ -15,7 +15,6 @@ export default function styleConstructor(theme={}) {
       marginTop: Platform.OS === 'android' ? 4 : 6,
       fontSize: appStyle.textDayFontSize,
       fontFamily: appStyle.textDayFontFamily,
-      fontWeight: '300',
       color: appStyle.dayTextColor,
       backgroundColor: 'rgba(255, 255, 255, 0)'
     },

--- a/src/calendar/day/multi-dot/style.js
+++ b/src/calendar/day/multi-dot/style.js
@@ -15,7 +15,6 @@ export default function styleConstructor(theme={}) {
       marginTop: 4,
       fontSize: appStyle.textDayFontSize,
       fontFamily: appStyle.textDayFontFamily,
-      fontWeight: '300',
       color: appStyle.dayTextColor,
       backgroundColor: 'rgba(255, 255, 255, 0)'
     },
@@ -41,7 +40,7 @@ export default function styleConstructor(theme={}) {
     dot: {
       width: 4,
       height: 4,
-      marginTop: 1,
+      marginTop: -4,
       marginLeft: 1,
       marginRight: 1,
       borderRadius: 2,

--- a/src/calendar/day/multi-dot/style.js
+++ b/src/calendar/day/multi-dot/style.js
@@ -5,8 +5,10 @@ const STYLESHEET_ID = 'stylesheet.day.multiDot';
 
 export default function styleConstructor(theme={}) {
   const appStyle = {...defaultStyle, ...theme};
+  const margin = (Platform.OS === 'android') ? 2 : 0
   return StyleSheet.create({
     base: {
+      marginTop: margin,
       width: 32,
       height: 32,
       alignItems: 'center'

--- a/src/calendar/day/multi-period/style.js
+++ b/src/calendar/day/multi-period/style.js
@@ -15,7 +15,6 @@ export default function styleConstructor(theme = {}) {
       marginTop: Platform.OS === 'android' ? 4 : 6,
       fontSize: appStyle.textDayFontSize,
       fontFamily: appStyle.textDayFontFamily,
-      fontWeight: '300',
       color: appStyle.dayTextColor,
       backgroundColor: 'rgba(255, 255, 255, 0)',
     },

--- a/src/calendar/day/period/style.js
+++ b/src/calendar/day/period/style.js
@@ -39,7 +39,6 @@ export default function styleConstructor(theme={}) {
       marginTop: 7,
       fontSize: appStyle.textDayFontSize,
       fontFamily: appStyle.textDayFontFamily,
-      fontWeight: '300',
       color: appStyle.dayTextColor || '#2d4150',
       backgroundColor: 'rgba(255, 255, 255, 0)'
     },
@@ -47,7 +46,7 @@ export default function styleConstructor(theme={}) {
       backgroundColor: appStyle.todayBackgroundColor
     },
     todayText: {
-      fontWeight: '500',
+      fontFamily: appStyle.textDayFontFamily,
       color: theme.todayTextColor || appStyle.dayTextColor,
       //color: appStyle.textLinkColor
     },

--- a/src/calendar/header/style.js
+++ b/src/calendar/header/style.js
@@ -16,7 +16,6 @@ export default function(theme={}) {
     monthText: {
       fontSize: appStyle.textMonthFontSize,
       fontFamily: appStyle.textMonthFontFamily,
-      fontWeight: appStyle.textMonthFontWeight,
       color: appStyle.monthTextColor,
       margin: 10
     },
@@ -40,7 +39,6 @@ export default function(theme={}) {
     },
     dayHeader: {
       marginTop: 2,
-      marginBottom: 7,
       width: 32,
       textAlign: 'center',
       fontSize: appStyle.textDayHeaderFontSize,

--- a/src/calendar/style.js
+++ b/src/calendar/style.js
@@ -1,4 +1,6 @@
-import {StyleSheet} from 'react-native';
+import {
+  StyleSheet
+} from 'react-native';
 import * as defaultStyle from '../style';
 
 const STYLESHEET_ID = 'stylesheet.calendar.main';
@@ -9,6 +11,7 @@ export default function getStyle(theme={}) {
     container: {
       paddingLeft: 5,
       paddingRight: 5,
+      paddingTop: 8,
       backgroundColor: appStyle.calendarBackground
     },
     monthView: {

--- a/src/style.js
+++ b/src/style.js
@@ -8,14 +8,14 @@ export const processedColor = '#a7e0a3';
 export const processingColor = '#ffce5c';
 export const failedColor = 'rgba(246, 126, 126,1)';
 
-export const textDefaultColor = '#485A67';
-export const textColor = '#485A67';
-export const textLinkColor = '#485A67';
-export const textSecondaryColor = '#7a92a5';
+export const textDefaultColor = '#262626';
+export const textColor = '#262626';
+export const textLinkColor = '#262626';
+export const textSecondaryColor = '#262626';
 
-export const textDayFontFamily = 'WhitneyHTF-Book';
-export const textMonthFontFamily = 'WhitneyHTF-SemiBold';
-export const textDayHeaderFontFamily = 'WhitneyHTF-Book';
+export const textDayFontFamily = 'Avenir-Heavy';
+export const textMonthFontFamily = 'Avenir-Heavy';
+export const textDayHeaderFontFamily = 'Avenir-Heavy';
 
 export const textMonthFontWeight = '300';
 
@@ -24,18 +24,18 @@ export const textMonthFontSize = 16;
 export const textDayHeaderFontSize = 13;
 
 export const calendarBackground = foregroundColor;
-export const textSectionTitleColor = '#b6c1cd';
-export const selectedDayBackgroundColor = '#123A68';
+export const textSectionTitleColor = '#999999';
+export const selectedDayBackgroundColor = '#46B877';
 export const selectedDayTextColor = foregroundColor;
 export const todayBackgroundColor = undefined;
 export const todayTextColor = textLinkColor;
 export const dayTextColor = textDefaultColor;
 export const textDisabledColor = '#d9e1e8';
-export const dotColor = '#123A68';
+export const dotColor = '#46B877';
 export const selectedDotColor = foregroundColor;
 export const arrowColor = textLinkColor;
 export const monthTextColor = textDefaultColor;
-export const agendaDayTextColor = '#485A67';
-export const agendaDayNumColor = '#485A67';
+export const agendaDayTextColor = '#262626';
+export const agendaDayNumColor = '#262626';
 export const agendaTodayColor = textLinkColor;
 export const agendaKnobColor = '#f2F4f5';

--- a/src/style.js
+++ b/src/style.js
@@ -13,9 +13,9 @@ export const textColor = '#262626';
 export const textLinkColor = '#262626';
 export const textSecondaryColor = '#262626';
 
-export const textDayFontFamily = 'Avenir-Heavy';
-export const textMonthFontFamily = 'Avenir-Heavy';
-export const textDayHeaderFontFamily = 'Avenir-Heavy';
+export const textDayFontFamily = 'Avenir-Book';
+export const textMonthFontFamily = 'Avenir-Book';
+export const textDayHeaderFontFamily = 'Avenir-Book';
 
 export const textMonthFontWeight = '300';
 

--- a/src/style.js
+++ b/src/style.js
@@ -10,7 +10,7 @@ export const failedColor = 'rgba(246, 126, 126,1)';
 
 export const textDefaultColor = '#485A67';
 export const textColor = '#485A67';
-export const textLinkColor = '#00adf5';
+export const textLinkColor = '#485A67';
 export const textSecondaryColor = '#7a92a5';
 
 export const textDayFontFamily = 'WhitneyHTF-Book';
@@ -19,7 +19,7 @@ export const textDayHeaderFontFamily = 'WhitneyHTF-Book';
 
 export const textMonthFontWeight = '300';
 
-export const textDayFontSize = 16;
+export const textDayFontSize = 14;
 export const textMonthFontSize = 16;
 export const textDayHeaderFontSize = 13;
 
@@ -38,4 +38,4 @@ export const monthTextColor = textDefaultColor;
 export const agendaDayTextColor = '#485A67';
 export const agendaDayNumColor = '#485A67';
 export const agendaTodayColor = textLinkColor;
-export const agendaKnobColor = Platform.OS === 'ios' ? '#f2F4f5' : '#4ac4f7';
+export const agendaKnobColor = '#f2F4f5';

--- a/src/style.js
+++ b/src/style.js
@@ -1,21 +1,21 @@
 import {Platform} from 'react-native';
 
 export const foregroundColor = '#ffffff';
-export const backgroundColor = '#f4f4f4';
+export const backgroundColor = '#ffffff';
 export const separatorColor = '#e8e9ec';
 
 export const processedColor = '#a7e0a3';
 export const processingColor = '#ffce5c';
 export const failedColor = 'rgba(246, 126, 126,1)';
 
-export const textDefaultColor = '#2d4150';
-export const textColor = '#43515c';
+export const textDefaultColor = '#485A67';
+export const textColor = '#485A67';
 export const textLinkColor = '#00adf5';
 export const textSecondaryColor = '#7a92a5';
 
-export const textDayFontFamily = 'System';
-export const textMonthFontFamily = 'System';
-export const textDayHeaderFontFamily = 'System';
+export const textDayFontFamily = 'WhitneyHTF-Book';
+export const textMonthFontFamily = 'WhitneyHTF-SemiBold';
+export const textDayHeaderFontFamily = 'WhitneyHTF-Book';
 
 export const textMonthFontWeight = '300';
 
@@ -25,17 +25,17 @@ export const textDayHeaderFontSize = 13;
 
 export const calendarBackground = foregroundColor;
 export const textSectionTitleColor = '#b6c1cd';
-export const selectedDayBackgroundColor = textLinkColor;
+export const selectedDayBackgroundColor = '#123A68';
 export const selectedDayTextColor = foregroundColor;
 export const todayBackgroundColor = undefined;
 export const todayTextColor = textLinkColor;
 export const dayTextColor = textDefaultColor;
 export const textDisabledColor = '#d9e1e8';
-export const dotColor = textLinkColor;
+export const dotColor = '#123A68';
 export const selectedDotColor = foregroundColor;
 export const arrowColor = textLinkColor;
 export const monthTextColor = textDefaultColor;
-export const agendaDayTextColor = '#7a92a5';
-export const agendaDayNumColor = '#7a92a5';
+export const agendaDayTextColor = '#485A67';
+export const agendaDayNumColor = '#485A67';
 export const agendaTodayColor = textLinkColor;
 export const agendaKnobColor = Platform.OS === 'ios' ? '#f2F4f5' : '#4ac4f7';


### PR DESCRIPTION
Added a potential fix for this issue - https://github.com/wix/react-native-calendars/issues/259

This may be against the intended behavior of the Agenda Component but it fixes the issue of not being able to scroll back up to previous calendar items by keeping all of the reservations around at all times.