### PR TITLE
Fix agenda wrong render when orientation changes.

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -394,6 +394,7 @@ export default class AgendaView extends Component {
               onLayout={() => {
                 this.calendar.scrollToDay(this.state.selectedDay.clone(), this.calendarOffset(), false);
               }}
+              calendarWidth={this.viewWidth}
               theme={this.props.theme}
               onVisibleMonthsChange={this.onVisibleMonthsChange.bind(this)}
               ref={(c) => this.calendar = c}


### PR DESCRIPTION
The calendar list rendered by the agenda has the initial width as the default prop,
on orientation change, a wrong width is used to render the calendar list, the fix
explicitly adds the calendarWidth prop based on agenda's `this.viewWidth`

Examples of wrong renders that are solved with this:
![img_0590](https://user-images.githubusercontent.com/2893909/43091098-7e8cce2e-8e66-11e8-8ee1-e59468c3b68a.jpg)
![img_0588](https://user-images.githubusercontent.com/2893909/43091100-7ed3e25a-8e66-11e8-9b6e-541436330339.jpg)
![img_0592](https://user-images.githubusercontent.com/2893909/43091315-fe9cb944-8e66-11e8-9235-67e51e1aaf77.jpg)
![img_0591](https://user-images.githubusercontent.com/2893909/43091316-febe0112-8e66-11e8-8e56-71817dc0c551.jpg)
