### PR TITLE
Fixed key conflicts in Agenda

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -421,8 +421,8 @@ export default class AgendaView extends Component {
         </Animated.View>
         <Animated.View style={weekdaysStyle}>
           {this.props.showWeekNumbers && <Text allowFontScaling={false} style={this.styles.weekday} numberOfLines={1}></Text>}
-          {weekDaysNames.map((day) => (
-            <Text allowFontScaling={false} key={day} style={this.styles.weekday} numberOfLines={1}>{day}</Text>
+          {weekDaysNames.map((day, index) => (
+            <Text allowFontScaling={false} key={day + index} style={this.styles.weekday} numberOfLines={1}>{day}</Text>
           ))}
         </Animated.View>
         <Animated.ScrollView


### PR DESCRIPTION
We are experiencing this issue frequently while using `<Agenda>` component:
```
Warning: Encountered two children with the same key, `S`. Keys should be unique so that components maintain their identity across updates.
```
which is caused by having the same key 'S' on Saturday and Sunday by default (also occurs on Tuesday and Thursday - same key 'T'). Fixed by concatenating index to ensure the keys are always unique.