### PR TITLE
fixed #606 - in the agenda component, the CalendarList was missing th…

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -415,6 +415,7 @@ export default class AgendaView extends Component {
               disabledByDefault={this.props.disabledByDefault}
               displayLoadingIndicator={this.props.displayLoadingIndicator}
               showWeekNumbers={this.props.showWeekNumbers}
+              calendarWidth={this.viewWidth}
             />
           </Animated.View>
           {knob}


### PR DESCRIPTION
…e calendarWidth prop.  View width changes were therefore not communicated to the CalendarList when rotation changed.  Assigned the calendarWidth prop to the viewWidth variable for the Agenda Component.