### PR TITLE
Fix typo that causes empty dates to only render ActivityIndicator

### DIFF
--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -182,8 +182,8 @@ class ReactComp extends Component {
 
   render() {
     if (!this.props.reservations || !this.props.reservations[this.props.selectedDay.toString('yyyy-MM-dd')]) {
-      if (this.props.renderEmptyData) {
-        return this.props.renderEmptyData();
+      if (this.props.renderEmptyDate) {
+        return this.props.renderEmptyDate();
       }
       return (<ActivityIndicator style={{marginTop: 80}}/>);
     }


### PR DESCRIPTION
The Agenda component does not render empty dates correctly. This is due to a typo in the render function of "reservation-list/index.js". After I fixed the typo, the Agenda component rendered the function I passed to the renderEmptyDate prop correctly.