### PR TITLE
Avoid Duplicate Key warnings in AgendaView 

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -421,8 +421,8 @@ export default class AgendaView extends Component {
         </Animated.View>
         <Animated.View style={weekdaysStyle}>
           {this.props.showWeekNumbers && <Text allowFontScaling={false} style={this.styles.weekday} numberOfLines={1}></Text>}
-          {weekDaysNames.map((day) => (
-            <Text allowFontScaling={false} key={day} style={this.styles.weekday} numberOfLines={1}>{day}</Text>
+          {weekDaysNames.map((day, index) => (
+            <Text allowFontScaling={false} key={day+index} style={this.styles.weekday} numberOfLines={1}>{day}</Text>
           ))}
         </Animated.View>
         <Animated.ScrollView


### PR DESCRIPTION
## Description

weekDaysNames have an array of days in abbreviated letters, e.g. "S" for Sunday, and "S" for Saturday. React Native does not like that the key element have duplicates of the same key. This causes the "Encountered two children with the same key" warning. 

## Expected Behavior

No warnings appear in AgendaView.

## Observed Behavior

What actually happened when you performed the above actions?

If there's an error message, please paste the *full terminal output and error message* in this code block:

```
Encountered two children with the same key, `T`...
Encountered two children with the same key, `S`...
```

## Proposed Resolution
Added the index of the weekDaysNames array avoids duplicates, removing the warning.