### PR TITLE
On the fly changing of style prop for Calendar.

### DIFF
--- a/src/calendar/updater.js
+++ b/src/calendar/updater.js
@@ -1,3 +1,4 @@
+import isEqual from 'lodash.isequal';
 import {parseDate} from '../interface';
 
 export default function shouldComponentUpdate(nextProps, nextState) {
@@ -17,6 +18,16 @@ export default function shouldComponentUpdate(nextProps, nextState) {
       return {
         update: true,
         field: next
+      };
+    }
+    return prev;
+  }, shouldUpdate);
+
+  shouldUpdate = ['style'].reduce((prev, next) => {
+    if (!isEqual(!prev.update && nextProps[next], this.props[next])) {
+      return {
+        update: true,
+        field: next,
       };
     }
     return prev;


### PR DESCRIPTION
Reason: I want to have a dynamic styling after the parent component finishes layout so I can compute the exact width I need to pass to the calendarWidth or style.width props

Changes: Added style prop to shouldComponentUpdate.

This feature is helpful for styling calendar layout every time the device orientation changes.