### PR TITLE
[Fix Bug] 'scrollEnabled' props doesn't work

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -214,7 +214,7 @@ class CalendarList extends Component {
         renderItem={this.renderCalendarBound}
         showsVerticalScrollIndicator={this.props.showScrollIndicator}
         showsHorizontalScrollIndicator={this.props.showScrollIndicator}
-        scrollEnabled={this.props.scrollingEnabled}
+        scrollEnabled={this.props.scrollEnabled}
         keyExtractor={(item, index) => String(index)}
         initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
         getItemLayout={this.getItemLayout}


### PR DESCRIPTION
You had a mistake on CalendarList's props 'scrollEnabled'.