### PR TITLE
Add initialNumToRender prop to CalendarList 

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -54,6 +54,7 @@ class CalendarList extends Component {
     scrollEnabled: true,
     scrollsToTop: false,
     removeClippedSubviews: Platform.OS === 'android' ? false : true,
+    initialNumToRender: 12,
   }
 
   constructor(props) {
@@ -219,6 +220,7 @@ class CalendarList extends Component {
         initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
         getItemLayout={this.getItemLayout}
         scrollsToTop={this.props.scrollsToTop}
+        initialNumToRender={this.props.initialNumToRender}
       />
     );
   }


### PR DESCRIPTION
Not sure if this is actually needed, just passing the `initialNumToRender` prop to the `FlatList` component so we can control how many months are pre-rendered.