### PR TITLE
Fix borderRadius on Period for Android

### DIFF
--- a/src/calendar/day/period/index.js
+++ b/src/calendar/day/period/index.js
@@ -129,7 +129,8 @@ class Day extends Component {
 
     if (this.props.marking) {
       containerStyle.push({
-        borderRadius: 17
+        borderRadius: 17,
+        overflow: 'hidden',
       });
 
       const flags = this.markingStyle;


### PR DESCRIPTION
Fix #642

Add the missing `overflow: 'hidden'` for Android to allow borderRadius to work on  *startingDay* and *endingDay*