### PR TITLE
Add disabledByDefault props to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ An advanced agenda component that can display interactive listings for calendar 
     '2012-05-18': {disabled: true}
   }}
   // If disabledByDefaut={true} dates flaged as not disabled will be enabled. Default = false
-  disableByDefault={true}
+  disabledByDefault={true}
   // If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the refreshing prop correctly.
   onRefresh={() => console.log('refreshing...')}
   // Set this true while waiting for new data from a refresh

--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ An advanced agenda component that can display interactive listings for calendar 
     '2012-05-17': {marked: true},
     '2012-05-18': {disabled: true}
   }}
+  // If disabledByDefaut={true} dates flaged as not disabled will be enabled. Default = false
+  disableByDefault={true}
   // If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the refreshing prop correctly.
   onRefresh={() => console.log('refreshing...')}
   // Set this true while waiting for new data from a refresh


### PR DESCRIPTION
If you wan't to whitelist specific dates you can use the "disabledByDefault" prop to disable all dates and then explicitly add disabled: false to the dates that should be enabled. I found this to be very useful.

<Calendar
  markedDates={{  'YYYY-MM-DD': { disabled: false }}
  disableByDefault={false}
/>