### PR TITLE
Add theme color for indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,19 +195,19 @@ CAUTION: This marking is only fully supported by the `<Calendar />` component be
 
 ```javascript
 <Calendar
-  markedDates={{  
-    '2017-12-14': {  
-      periods: [  
-        {startingDay: false, endingDay: true, color: '#5f9ea0'},
-        {startingDay: false, endingDay: true, color: '#ffa500'},
-        {startingDay: true, endingDay: false, color: '#f0e68c'}
+  markedDates={{
+    '2017-12-14': {
+      periods: [
+        { startingDay: false, endingDay: true, color: '#5f9ea0' },
+        { startingDay: false, endingDay: true, color: '#ffa500' },
+        { startingDay: true, endingDay: false, color: '#f0e68c' },
       ]
     },
-    '2017-12-15': {  
-      periods: [  
-        {startingDay: true, endingDay: false, color: '#ffa500'},
-        {color: 'transparent'},
-        {startingDay: false, endingDay: false, color: '#f0e68c'}
+    '2017-12-15': {
+      periods: [
+        { startingDay: true, endingDay: false, color: '#ffa500' },
+        { color: 'transparent' },
+        { startingDay: false, endingDay: false, color: '#f0e68c' },
       ]
     },
   }}
@@ -287,6 +287,7 @@ The loading indicator next to month name will be displayed if `<Calendar />` has
     selectedDotColor: '#ffffff',
     arrowColor: 'orange',
     monthTextColor: 'blue',
+    indicatorColor: 'blue',
     textDayFontFamily: 'monospace',
     textMonthFontFamily: 'monospace',
     textDayHeaderFontFamily: 'monospace',

--- a/example/src/screens/calendars.js
+++ b/example/src/screens/calendars.js
@@ -62,6 +62,7 @@ export default class CalendarsScreen extends Component {
             todayTextColor: 'white',
             selectedDayTextColor: 'white',
             monthTextColor: 'white',
+            indicatorColor: 'white',
             selectedDayBackgroundColor: '#333248',
             arrowColor: 'white',
             // textDisabledColor: 'red',
@@ -101,22 +102,22 @@ export default class CalendarsScreen extends Component {
           style={styles.calendar}
           current={'2012-05-16'}
           markingType={'multi-period'}
-          markedDates={{  
-            '2012-05-16': {  
-              periods: [  
+          markedDates={{
+            '2012-05-16': {
+              periods: [
                 { startingDay: true, endingDay: false, color: '#5f9ea0' },
                 { startingDay: true, endingDay: false, color: '#ffa500' },
               ]
             },
-            '2012-05-17': {  
-              periods: [  
+            '2012-05-17': {
+              periods: [
                 { startingDay: false, endingDay: true, color: '#5f9ea0' },
                 { startingDay: false, endingDay: true, color: '#ffa500' },
                 { startingDay: true, endingDay: false, color: '#f0e68c' },
               ]
             },
-            '2012-05-18': {  
-              periods: [  
+            '2012-05-18': {
+              periods: [
                 { startingDay: true, endingDay: true, color: '#ffa500' },
                 { color: 'transparent' },
                 { startingDay: false, endingDay: false, color: '#f0e68c' },

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -185,7 +185,9 @@ class ReactComp extends Component {
       if (this.props.renderEmptyData) {
         return this.props.renderEmptyData();
       }
-      return (<ActivityIndicator style={{marginTop: 80}}/>);
+      return (
+        <ActivityIndicator style={{marginTop: 80}} color={this.props.theme.indicatorColor} />
+      );
     }
     return (
       <FlatList

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -116,7 +116,7 @@ class CalendarHeader extends Component {
     }
     let indicator;
     if (this.props.showIndicator) {
-      indicator = <ActivityIndicator />;
+      indicator = <ActivityIndicator color={this.props.theme.indicatorColor} />;
     }
     return (
       <View>

--- a/src/style.js
+++ b/src/style.js
@@ -1,4 +1,4 @@
-import {Platform} from 'react-native';
+import { Platform } from 'react-native';
 
 export const foregroundColor = '#ffffff';
 export const backgroundColor = '#f4f4f4';
@@ -35,6 +35,7 @@ export const dotColor = textLinkColor;
 export const selectedDotColor = foregroundColor;
 export const arrowColor = textLinkColor;
 export const monthTextColor = textDefaultColor;
+export const indicatorColor = undefined; // use the default color of React Native ActivityIndicator
 export const agendaDayTextColor = '#7a92a5';
 export const agendaDayNumColor = '#7a92a5';
 export const agendaTodayColor = textLinkColor;


### PR DESCRIPTION
The indicator color was not editable.
The default color of React Native ActivityIndicator is gray:
  https://facebook.github.io/react-native/docs/activityindicator#color

- added indicatorColor to the default theme styles
- added color prop for both ActivityIndicator renderings
- included indicatorColor in README and example

![Bildschirmfoto 2019-03-20 um 17 19 39](https://user-images.githubusercontent.com/1942953/54701058-797b0a00-4b34-11e9-853e-c04aedfc586c.png)
