### PR TITLE
Added enableOptimisticScroll boolean property to Agenda

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -89,7 +89,7 @@ export default class AgendaView extends Component {
     refreshing: PropTypes.bool,
     // Display loading indicador. Default = false
     displayLoadingIndicator: PropTypes.bool,
-    
+    //Disable the scroll in the calendar view.    
     enableOptimisticScroll: PropTypes.bool,
   };
 

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -89,6 +89,8 @@ export default class AgendaView extends Component {
     refreshing: PropTypes.bool,
     // Display loading indicador. Default = false
     displayLoadingIndicator: PropTypes.bool,
+    
+    enableOptimisticScroll: PropTypes.bool,
   };
 
   constructor(props) {
@@ -245,7 +247,8 @@ export default class AgendaView extends Component {
   }
 
   _chooseDayFromCalendar(d) {
-    this.chooseDay(d, !this.state.calendarScrollable);
+    const { enableOptimisticScroll } = this.props;
+    this.chooseDay(d, !this.state.calendarScrollable && ( enableOptimisticScroll !== undefined && enableOptimisticScroll ));
   }
 
   chooseDay(d, optimisticScroll) {


### PR DESCRIPTION
When the day's events start to become many (~200), the scroll works badly.