### PR TITLE
Allow passing style to calendarListItem

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -42,7 +42,10 @@ class CalendarList extends Component {
     horizontal: PropTypes.bool,
     // Dynamic calendar height
     calendarHeight: PropTypes.number,
-  };
+
+    // Style for the List (style prop is passed to the List item - the calendar)
+    containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number])
+  }
 
   static defaultProps = {
     horizontal: false,
@@ -201,7 +204,7 @@ class CalendarList extends Component {
         onLayout={this.onLayout}
         ref={(c) => this.listView = c}
         //scrollEventThrottle={1000}
-        style={[this.style.container, this.props.style]}
+        style={[this.style.container, this.props.containerStyle]}
         initialListSize={this.props.pastScrollRange + this.props.futureScrollRange + 1}
         data={this.state.rows}
         //snapToAlignment='start'

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -186,7 +186,15 @@ class CalendarList extends Component {
   }
 
   renderCalendar({item}) {
-    return (<CalendarListItem item={item} calendarHeight={this.props.calendarHeight} calendarWidth={this.props.horizontal ? this.props.calendarWidth : undefined} style={this.props.calendarStyle} {...this.props}/>);
+    return (
+      <CalendarListItem 
+        item={item} 
+        calendarHeight={this.props.calendarHeight} 
+        calendarWidth={this.props.horizontal ? this.props.calendarWidth : undefined} 
+        {...this.props} 
+        style={this.props.calendarStyle}
+      />
+    );
   }
 
   getItemLayout(data, index) {

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -43,8 +43,8 @@ class CalendarList extends Component {
     // Dynamic calendar height
     calendarHeight: PropTypes.number,
 
-    // Style for the List (style prop is passed to the List item - the calendar)
-    containerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number])
+    // Style for the List item (the calendar)
+    calendarStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number])
   }
 
   static defaultProps = {
@@ -186,7 +186,7 @@ class CalendarList extends Component {
   }
 
   renderCalendar({item}) {
-    return (<CalendarListItem item={item} calendarHeight={this.props.calendarHeight} calendarWidth={this.props.horizontal ? this.props.calendarWidth : undefined  } {...this.props} />);
+    return (<CalendarListItem item={item} calendarHeight={this.props.calendarHeight} calendarWidth={this.props.horizontal ? this.props.calendarWidth : undefined} style={this.props.calendarStyle} {...this.props}/>);
   }
 
   getItemLayout(data, index) {
@@ -204,7 +204,7 @@ class CalendarList extends Component {
         onLayout={this.onLayout}
         ref={(c) => this.listView = c}
         //scrollEventThrottle={1000}
-        style={[this.style.container, this.props.containerStyle]}
+        style={[this.style.container, this.props.style]}
         initialListSize={this.props.pastScrollRange + this.props.futureScrollRange + 1}
         data={this.state.rows}
         //snapToAlignment='start'

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -26,7 +26,7 @@ class CalendarListItem extends Component {
       return (
         <Calendar
           theme={this.props.theme}
-          style={[{height: this.props.calendarHeight, width: this.props.calendarWidth}, this.style.calendar]}
+          style={[{height: this.props.calendarHeight, width: this.props.calendarWidth}, this.style.calendar, this.props.style]}
           current={row}
           hideArrows={this.props.hideArrows}
           hideExtraDays={this.props.hideExtraDays}

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -3,10 +3,11 @@ import {Text, View} from 'react-native';
 import Calendar from '../calendar';
 import styleConstructor from './style';
 
+
 class CalendarListItem extends Component {
   static defaultProps = {
     hideArrows: true,
-    hideExtraDays: true,
+    hideExtraDays: true
   };
 
   constructor(props) {
@@ -22,6 +23,7 @@ class CalendarListItem extends Component {
 
   render() {
     const row = this.props.item;
+    
     if (row.getTime) {
       return (
         <Calendar
@@ -47,6 +49,7 @@ class CalendarListItem extends Component {
         />);
     } else {
       const text = row.toString();
+      
       return (
         <View style={[{height: this.props.calendarHeight, width: this.props.calendarWidth}, this.style.placeholder]}>
           <Text allowFontScaling={false} style={this.style.placeholderText}>{text}</Text>


### PR DESCRIPTION
this.props.style to be passed to the list item (that holds the Calendar), while the FlatList will be passed this.props.containerStyle instead. Thus separating the style passed to the CalendarListItem from the styles passed to the FlatList.