### PR TITLE
Fix: Navigation arrows not navigating along 'CalendarList'

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -192,7 +192,8 @@ class CalendarList extends Component {
 
   renderCalendar({item}) {
     return (
-      <CalendarListItem 
+      <CalendarListItem
+        calendarListContainer={this}
         item={item} 
         calendarHeight={this.props.calendarHeight} 
         calendarWidth={this.props.horizontal ? this.props.calendarWidth : undefined} 

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -193,7 +193,7 @@ class CalendarList extends Component {
   renderCalendar({item}) {
     return (
       <CalendarListItem
-        calendarListContainer={this}
+        scrollToMonth={this.scrollToMonth.bind(this)}
         item={item} 
         calendarHeight={this.props.calendarHeight} 
         calendarWidth={this.props.horizontal ? this.props.calendarWidth : undefined} 

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -48,14 +48,14 @@ class CalendarListItem extends Component {
           showWeekNumbers={this.props.showWeekNumbers}
           renderArrow={this.props.renderArrow}
           onPressArrowLeft={this.props.onPressArrowLeft ? this.props.onPressArrowLeft : (_,month)=>{
-            month = month.clone()
-            month.addMonths(-1)
-            this.props.calendarListContainer.scrollToMonth(month)
+            month = month.clone();
+            month.addMonths(-1);
+            this.props.calendarListContainer.scrollToMonth(month);
           }}
           onPressArrowRight={this.props.onPressArrowRight ? this.props.onPressArrowRight : (_,month)=>{
-            month = month.clone()
-            month.addMonths(1)
-            this.props.calendarListContainer.scrollToMonth(month)
+            month = month.clone();
+            month.addMonths(1);
+            this.props.calendarListContainer.scrollToMonth(month);
           }}
           headerStyle={this.props.headerStyle}
         />);

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -23,7 +23,7 @@ class CalendarListItem extends Component {
 
   render() {
     const row = this.props.item;
-    
+
     if (row.getTime) {
       return (
         <Calendar
@@ -47,13 +47,21 @@ class CalendarListItem extends Component {
           disabledByDefault={this.props.disabledByDefault}
           showWeekNumbers={this.props.showWeekNumbers}
           renderArrow={this.props.renderArrow}
-          onPressArrowLeft={this.props.onPressArrowLeft}
-          onPressArrowRight={this.props.onPressArrowRight}
+          onPressArrowLeft={this.props.onPressArrowLeft ? this.props.onPressArrowLeft : (_,month)=>{
+            month = month.clone()
+            month.addMonths(-1)
+            this.props.calendarListContainer.scrollToMonth(month)
+          }}
+          onPressArrowRight={this.props.onPressArrowRight ? this.props.onPressArrowRight : (_,month)=>{
+            month = month.clone()
+            month.addMonths(1)
+            this.props.calendarListContainer.scrollToMonth(month)
+          }}
           headerStyle={this.props.headerStyle}
         />);
     } else {
       const text = row.toString();
-      
+
       return (
         <View style={[{height: this.props.calendarHeight, width: this.props.calendarWidth}, this.style.placeholder]}>
           <Text allowFontScaling={false} style={this.style.placeholderText}>{text}</Text>

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -71,8 +71,8 @@ class CalendarListItem extends Component {
           disabledByDefault={this.props.disabledByDefault}
           showWeekNumbers={this.props.showWeekNumbers}
           renderArrow={this.props.renderArrow}
-          onPressArrowLeft={this.onPressArrowLeft}
-          onPressArrowRight={this.onPressArrowRight}
+          onPressArrowLeft={this.props.horizontal ? this.onPressArrowLeft : this.props.onPressArrowLeft}
+          onPressArrowRight={this.props.horizontal ? this.onPressArrowRight : this.props.onPressArrowRight}
           headerStyle={this.props.headerStyle}
         />);
     } else {

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -21,7 +21,7 @@ class CalendarListItem extends Component {
     return r1.toString('yyyy MM') !== r2.toString('yyyy MM') || !!(r2.propbump && r2.propbump !== r1.propbump);
   }
 
-  onPressArrowLeft(_,month){
+  onPressArrowLeft = (_,month) => {
 
     const monthClone = month.clone();
 
@@ -33,7 +33,7 @@ class CalendarListItem extends Component {
     }
   }
 
-  onPressArrowRight(_,month){
+  onPressArrowRight = (_,month) => {
 
     const monthClone = month.clone();
 
@@ -71,8 +71,8 @@ class CalendarListItem extends Component {
           disabledByDefault={this.props.disabledByDefault}
           showWeekNumbers={this.props.showWeekNumbers}
           renderArrow={this.props.renderArrow}
-          onPressArrowLeft={this.onPressArrowLeft.bind(this)}
-          onPressArrowRight={this.onPressArrowRight.bind(this)}
+          onPressArrowLeft={this.onPressArrowLeft}
+          onPressArrowRight={this.onPressArrowRight}
           headerStyle={this.props.headerStyle}
         />);
     } else {

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -21,6 +21,30 @@ class CalendarListItem extends Component {
     return r1.toString('yyyy MM') !== r2.toString('yyyy MM') || !!(r2.propbump && r2.propbump !== r1.propbump);
   }
 
+  onPressArrowLeft(_,month){
+
+    const monthClone = month.clone();
+
+    if(this.props.onPressArrowLeft){
+      this.props.onPressArrowLeft(_,monthClone);
+    }else if(this.props.scrollToMonth){
+      monthClone.addMonths(-1);
+      this.props.scrollToMonth(monthClone);
+    }
+  }
+
+  onPressArrowRight(_,month){
+
+    const monthClone = month.clone();
+
+    if(this.props.onPressArrowRight){
+      this.props.onPressArrowRight(_,monthClone);
+    }else if(this.props.scrollToMonth){
+      monthClone.addMonths(1);
+      this.props.scrollToMonth(monthClone);
+    }
+  }
+
   render() {
     const row = this.props.item;
 
@@ -47,16 +71,8 @@ class CalendarListItem extends Component {
           disabledByDefault={this.props.disabledByDefault}
           showWeekNumbers={this.props.showWeekNumbers}
           renderArrow={this.props.renderArrow}
-          onPressArrowLeft={this.props.onPressArrowLeft ? this.props.onPressArrowLeft : (_,month)=>{
-            month = month.clone();
-            month.addMonths(-1);
-            this.props.calendarListContainer.scrollToMonth(month);
-          }}
-          onPressArrowRight={this.props.onPressArrowRight ? this.props.onPressArrowRight : (_,month)=>{
-            month = month.clone();
-            month.addMonths(1);
-            this.props.calendarListContainer.scrollToMonth(month);
-          }}
+          onPressArrowLeft={this.onPressArrowLeft.bind(this)}
+          onPressArrowRight={this.onPressArrowRight.bind(this)}
           headerStyle={this.props.headerStyle}
         />);
     } else {

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -60,7 +60,7 @@ class CalendarHeader extends Component {
   onPressLeft() {
     const {onPressArrowLeft} = this.props;
     if (typeof onPressArrowLeft === 'function') {
-      return onPressArrowLeft(this.substractMonth);
+      return onPressArrowLeft(this.substractMonth,this.props.month);
     }
     return this.substractMonth();
   }
@@ -68,7 +68,7 @@ class CalendarHeader extends Component {
   onPressRight() {
     const {onPressArrowRight} = this.props;
     if (typeof onPressArrowRight === 'function') {
-      return onPressArrowRight(this.addMonth);
+      return onPressArrowRight(this.addMonth,this.props.month);
     }
     return this.addMonth();
   }
@@ -77,7 +77,7 @@ class CalendarHeader extends Component {
     let leftArrow = <View />;
     let rightArrow = <View />;
     let weekDaysNames = weekDayNames(this.props.firstDay);
-    
+
     if (!this.props.hideArrows) {
       leftArrow = (
         <TouchableOpacity


### PR DESCRIPTION
Replaces #631 

Before fix:
![before_fix](https://user-images.githubusercontent.com/27283110/57581018-04c7aa80-74a9-11e9-8043-3923f447b1da.gif)

After fix:
![after_fix](https://user-images.githubusercontent.com/27283110/57581019-098c5e80-74a9-11e9-80e0-20f2a50be0b1.gif)

These gifs can be explained by [this comment:](https://github.com/wix/react-native-calendars/pull/631#discussion_r279191482)

> Also, If I remember correctly, this is **needed** for navigating months in `CalendarList`.
> 
> This is because `CalendarList` renders a list of `CalendarListItem` which renders a `Calendar` which includes a `CalendarHeader`, when the left/right navigation arrows of the `CalendarHeader` are pressed, instead of navigating along the `CalendarList`, the `Calendar` is updated in place to show the month navigated to.
> 
> So for example, if `CalendarList` looked like:
> 
> ```
> -------+-------+-------+-------+
>  Index |   0   |   1   |   2   |
> -------+-------|-------|-------|
>  Month |  Jan  |  Feb  |  Mar  |
> -------+-------+-------+-------+
> ```
> 
> When `Jan` is shown, if the right arrow is pressed, instead of moving to the next `CalendarItem` in the `CalendarList` at `1`, The `CalendarItem` at `0` updates itself to show `Feb`. So now, `CalendarList` looks like:
> 
> ```
> -------+-------+-------+-------+
>  Index |   0   |   1   |   2   |
> -------+-------|-------|-------|
>  Month |  Feb  |  Feb  |  Mar  |
> -------+-------+-------+-------+
> ```
> 
> This is happening because in `CalendarHeader`:
> 
> ```
> onPressLeft() {
>     const {onPressArrowLeft} = this.props;
>     if(typeof onPressArrowLeft === 'function') {
>         return onPressArrowLeft(this.substractMonth);
>     }
>     return this.substractMonth();
> }
> 
> onPressRight() {
>     const {onPressArrowRight} = this.props;
>     if(typeof onPressArrowRight === 'function') {
>         return onPressArrowRight(this.addMonth);
>     }
>     return this.addMonth();
> }
> ```
> 
> which uses:
> 
> ```
> addMonth() {
>     this.props.addMonth(1);
> }
> 
> substractMonth() {
>     this.props.addMonth(-1);
> }
> ```
> 
> which uses `addMonth` in `Calendar`:
> 
> ```
> addMonth(count) {
>     this.updateMonth(this.state.currentMonth.clone().addMonths(count, true));
> }
> ```
> 
> which **replaces** the month displayed by `Calendar`.
> 
> This behaviour is incorrect when `Calendar` is used **inside** a `CalenderList`. When the left/right navigation arrows of `CalendarHeader` are pressed, we need to **move along** the `CalendarList` and display the previous/next `CalendarItem`, not update the month of the displayed `Calendar` item held by `CalendarList`.
> 
> To fix this, I added the following code to `CalendarList` which uses the changes in this MR:
> 
> ```
> onPressArrowLeft={(_,month)=>{
>     month = month.clone()
>     month.addMonths(-1)
>     this.refs.calendarList.scrollToMonth(month)
> }}
> onPressArrowRight={(_,month)=>{
>     month = month.clone()
>     month.addMonths(1)
>     this.refs.calendarList.scrollToMonth(month)
> }}
> ```
> 
> Where `calendarList` is a reference to the `CalendarList`.

@Inbal-Tish New MR
