### PR TITLE
Selected day should have background color

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -218,6 +218,9 @@ class CalendarList extends Component {
         //snapToAlignment='start'
         //snapToInterval={this.calendarHeight}
         removeClippedSubviews={this.props.removeClippedSubviews}
+        viewabilityConfig={{
+          itemVisiblePercentThreshold: 100,
+        }}
         pageSize={1}
         horizontal={this.props.horizontal}
         pagingEnabled={this.props.pagingEnabled}


### PR DESCRIPTION
Currently days in the period markingStyle do not set a backgroundColor
on the container. I updated the `getDrawingStyle` method in
_period/index.js_ to set containerStyle.backgroundColor for when
the marking has `selected: true`