### PR TITLE
six rows of month, last line will not displayed

### DIFF
--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -28,7 +28,7 @@ class CalendarListItem extends Component {
       return (
         <Calendar
           theme={this.props.theme}
-          style={[{height: this.props.calendarHeight, width: this.props.calendarWidth}, this.style.calendar, this.props.style]}
+          style={[{minHeight: this.props.calendarHeight, width: this.props.calendarWidth}, this.style.calendar, this.props.style]}
           current={row}
           hideArrows={this.props.hideArrows}
           hideExtraDays={this.props.hideExtraDays}


### PR DESCRIPTION
If six rows are occupied that month, the last line will not be displayed.

As shown, June 30 is hidden

![image](https://user-images.githubusercontent.com/12482817/58528473-2ba41180-8209-11e9-9fed-2374ae44dba9.png)

