### PR TITLE
CalendarList does not implement `onMonthChange` #659

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -283,6 +283,9 @@ class CalendarList extends Component {
           data={this.state.rows}
           //snapToAlignment='start'
           //snapToInterval={this.calendarHeight}
+          viewabilityConfig={{
+            itemVisiblePercentThreshold: 50
+          }}
           removeClippedSubviews={this.props.removeClippedSubviews}
           pageSize={1}
           horizontal={this.props.horizontal}


### PR DESCRIPTION
https://github.com/wix/react-native-calendars/issues/659 solve this problem