### PR TITLE
shouldOpenCalendar prop for Agenda

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ An advanced agenda component that can display interactive listings for calendar 
   }}
   // callback that gets called when items for a certain month should be loaded (month became visible)
   loadItemsForMonth={(month) => {console.log('trigger items loading')}}
+  // If true, open calendar. Default = false
+  shouldOpenCalendar
   // callback that fires when the calendar is opened or closed
   onCalendarToggled={(calendarOpened) => {console.log(calendarOpened)}}
   // callback that gets called on day press

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -89,6 +89,8 @@ export default class AgendaView extends Component {
     refreshing: PropTypes.bool,
     // Display loading indicador. Default = false
     displayLoadingIndicator: PropTypes.bool,
+    // If true, open calendar
+    shouldOpenCalendar: PropTypes.bool,
   };
 
   constructor(props) {
@@ -135,7 +137,9 @@ export default class AgendaView extends Component {
     // When user touches knob, the actual component that receives touch events is a ScrollView.
     // It needs to be scrolled to the bottom, so that when user moves finger downwards,
     // scroll position actually changes (it would stay at 0, when scrolled to the top).
-    this.setScrollPadPosition(this.initialScrollPadPosition(), false);
+    if (!this.props.shouldOpenCalendar) {
+      this.setScrollPadPosition(this.initialScrollPadPosition(), false);
+    }
     // delay rendering calendar in full height because otherwise it still flickers sometimes
     setTimeout(() => this.setState({calendarIsReady: true}), 0);
   }
@@ -224,6 +228,19 @@ export default class AgendaView extends Component {
     } else {
       this.loadReservations(props);
     }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.shouldOpenCalendar !== this.props.shouldOpenCalendar) {
+      this.toggleCalendar(!!this.props.shouldOpenCalendar);
+    }
+  }
+
+  toggleCalendar(shouldOpenCalendar) {
+    const scrollTo = shouldOpenCalendar ? 0 : this.initialScrollPadPosition();
+    this.setScrollPadPosition(scrollTo, true);
+    this.setState({ calendarScrollable: shouldOpenCalendar });
+    this.props.onCalendarToggled && this.props.onCalendarToggled(shouldOpenCalendar);
   }
 
   enableCalendarScrolling() {


### PR DESCRIPTION
## enhancement for `<Agenda />`
### added `shouldOpenCalendar` prop for `<Agenda />`
this allows you to control a flag to show CalendarView by passing a prop to `<Agenda />`

it makes more sense to toggle CalendarView depending on `shouldOpenCalendar` prop rather than calling `chooseDay()`.

related to #333 #277 #227 

## use cases
- for the simple case like #277 
if you wanna show calendar view only at initial render,
you can just pass `shouldOpenCalendar: true` to `<Agenda />`

- for the case like #333 
suppose you're using [react-native-navigation](https://github.com/wix/react-native-navigation) 
and you wanna show CalendarView not just when the component is mounted, but also whenever the user comes back to the screen where `<Agenda />` is rendered.

``` js
import { Navigation } from 'react-native-navigation'

constructor() {
    this.state = { shouldOpenCalendar: false }
    Navigation.events().bindComponent(this);
}

componentDidAppear() {
    this.setState({ shouldOpenCalendar: true })
}

<Agenda shouldOpenCalendar={this.state.shouldOpenCalendar} />

```
