### PR TITLE
implemented custom style on Calendar type: period

### DIFF
--- a/src/calendar/day/period/index.js
+++ b/src/calendar/day/period/index.js
@@ -109,10 +109,10 @@ class Day extends Component {
         prev.textStyle.color = next.textColor;
       }
       if (marking.customTextStyle) {
-      	defaultStyle.textStyle = marking.customTextStyle;
+        defaultStyle.textStyle = marking.customTextStyle;
       }
       if (marking.customContainerStyle) {
-      	defaultStyle.containerStyle = marking.customContainerStyle;
+        defaultStyle.containerStyle = marking.customContainerStyle;
       }
       return prev;
     }, defaultStyle);

--- a/src/calendar/day/period/index.js
+++ b/src/calendar/day/period/index.js
@@ -57,7 +57,7 @@ class Day extends Component {
   }
 
   getDrawingStyle(marking) {
-    const defaultStyle = {textStyle: {}};
+    const defaultStyle = {textStyle: {}, containerStyle: {}};
     if (!marking) {
       return defaultStyle;
     }
@@ -107,6 +107,12 @@ class Day extends Component {
       }
       if (next.textColor) {
         prev.textStyle.color = next.textColor;
+      }
+      if (marking.customTextStyle) {
+      	defaultStyle.textStyle = marking.customTextStyle;
+      }
+      if (marking.customContainerStyle) {
+      	defaultStyle.containerStyle = marking.customContainerStyle;
       }
       return prev;
     }, defaultStyle);


### PR DESCRIPTION
implemented custom container and text style on Calendar, markingType: period.
Is now possible to customize text and container style of each day of Calendar markingType={'period'} by adding to a day in markedDates customTextStyle={} and/or customContainerStyle={}.