### PR TITLE
Adds a `keyExtractor` prop to CalendarList

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -47,7 +47,9 @@ class CalendarList extends Component {
     /** Style for the List item (the calendar) */
     calendarStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     /** Whether to use static header that will not scroll with the list (horizontal only) */
-    staticHeader: PropTypes.bool
+    staticHeader: PropTypes.bool,
+    /** A custom key extractor for the generated calendar months */
+    keyExtractor: PropTypes.func
   }
 
   static defaultProps = {
@@ -59,7 +61,8 @@ class CalendarList extends Component {
     showScrollIndicator: false,
     scrollEnabled: true,
     scrollsToTop: false,
-    removeClippedSubviews: Platform.OS === 'android' ? false : true
+    removeClippedSubviews: Platform.OS === 'android' ? false : true,
+    keyExtractor: (item, index) => String(index)
   }
 
   constructor(props) {
@@ -306,7 +309,7 @@ class CalendarList extends Component {
           showsVerticalScrollIndicator={this.props.showScrollIndicator}
           showsHorizontalScrollIndicator={this.props.showScrollIndicator}
           scrollEnabled={this.props.scrollEnabled}
-          keyExtractor={(item, index) => String(index)}
+          keyExtractor={this.props.keyExtractor}
           initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
           getItemLayout={this.getItemLayout}
           scrollsToTop={this.props.scrollsToTop}


### PR DESCRIPTION
Most of the other props used by `FlatList` delegate to `CalendarList`'s props anyway so it makes sense that `keyExtractor` should be accessible this way too. In our use case we need to refresh the calendar because of dynamically loaded data so being able to control the keys is useful.