### PR TITLE
Re-render the header when the renderArrow function changes

### DIFF
--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -65,6 +65,9 @@ class CalendarHeader extends Component {
     if (nextProps.monthFormat !== this.props.monthFormat) {
       return true;
     }
+    if (nextProps.renderArrow !== this.props.renderArrow) {
+      return true;
+    }
     return false;
   }
 


### PR DESCRIPTION
Problem:
If you have a custom logic to render the arrows on the calendar header, those changes won't trigger a re-render on the calendar header component due to some restrictions on the `shouldComponentUpdate` of the Header component.

Use case:
```js
const canNavigateForward = useMemo(() => ...logic, [deps])
const canNavigateForward = useMemo(() => ...logic, [deps])

const onRenderArrow = useCallback(
  direction => (
    <MyCustomArrow
      direction={direction}
      enabled={direction === 'left' ? canNavigateBackward : canNavigateForward}
    />
  ),
  [canNavigateForward, canNavigateBackward]
)

return (
  <CalendarList
    {...baseProps}
    renderArrow={onRenderArrow}
  />
)
```

Solution:
Check if the function has changed from the previous props and it all works.