### PR TITLE
UPD Agenda scrollEventThrottle from 1 to 16

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -442,7 +442,7 @@ export default class AgendaView extends Component {
           showsHorizontalScrollIndicator={false}
           showsVerticalScrollIndicator={false}
           style={scrollPadStyle}
-          scrollEventThrottle={1}
+          scrollEventThrottle={8}
           scrollsToTop={false}
           onTouchStart={this.onTouchStart}
           onTouchEnd={this.onTouchEnd}


### PR DESCRIPTION
Fix for "Scroll Throttle too slow for Agenda scrolling"  [#441](https://github.com/wix/react-native-calendars/issues/441)