### PR TITLE
Modify typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ LocaleConfig.defaultLocale = 'fr';
   showWeekNumbers={true}
   // Handler which gets executed when press arrow icon left. It receive a callback can go back month
   onPressArrowLeft={substractMonth => substractMonth()}
-  // Handler which gets executed when press arrow icon left. It receive a callback can go next month
+  // Handler which gets executed when press arrow icon right. It receive a callback can go next month
   onPressArrowRight={addMonth => addMonth()}
 />
 ```

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -74,7 +74,7 @@ class Calendar extends Component {
     showWeekNumbers: PropTypes.bool,
     /** Handler which gets executed when press arrow icon left. It receive a callback can go back month */
     onPressArrowLeft: PropTypes.func,
-    /** Handler which gets executed when press arrow icon left. It receive a callback can go next month */
+    /** Handler which gets executed when press arrow icon right. It receive a callback can go next month */
     onPressArrowRight: PropTypes.func,
     /** Style passed to the header */
     headerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array])


### PR DESCRIPTION
`left`-> `right`
This is the right expression.

The eating hand is in the right direction, and the other hand is in the left direction.
**JUST JOKE**😉