### PR TITLE
Fix displayLoadingIndicator when no others props changes.

### DIFF
--- a/src/calendar/updater.js
+++ b/src/calendar/updater.js
@@ -12,7 +12,7 @@ export default function shouldComponentUpdate(nextProps, nextState) {
     return prev;
   }, {update: false});
 
-  shouldUpdate = ['markedDates', 'hideExtraDays'].reduce((prev, next) => {
+  shouldUpdate = ['markedDates', 'hideExtraDays', 'displayLoadingIndicator'].reduce((prev, next) => {
     if (!prev.update && nextProps[next] !== this.props[next]) {
       return {
         update: true,


### PR DESCRIPTION
This fix is needed to update the Calendar when only the `displayLoadingIndicator` has changed.