### PR TITLE
Move prop spreading to the end of SectionList to enable overriding it's props

### DIFF
--- a/src/expandableCalendar/agendaList.js
+++ b/src/expandableCalendar/agendaList.js
@@ -135,7 +135,6 @@ class AgendaList extends Component {
   render() {
     return (
       <SectionList
-        {...this.props}
         ref={this.list}
         keyExtractor={this.keyExtractor}
         showsVerticalScrollIndicator={false}
@@ -148,6 +147,7 @@ class AgendaList extends Component {
         onMomentumScrollEnd={this.onMomentumScrollEnd}
         // onScrollToIndexFailed={(info) => { console.warn('onScrollToIndexFailed info: ', info); }}
         // getItemLayout={this.getItemLayout} // onViewableItemsChanged is not updated when list scrolls!!!
+        {...this.props}
       />
     );
   }


### PR DESCRIPTION
I ran into a situation where I wanted to modify the default section header without hard copying the whole agendaList component to my project and was unable to override the method handler for it (renderSectionHeader).