### PR TITLE
Changed Calendar Offset

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -118,7 +118,7 @@ export default class AgendaView extends Component {
   }
 
   calendarOffset() {
-    return 90 - (this.viewHeight / 2);
+    return 100 - (this.viewHeight / 2);
   }
 
   initialScrollPadPosition() {


### PR DESCRIPTION
The calendar offset which was 90 - (this.viewHeight / 2) previously is causing a lot of issues to many people by hiding the lower portion of the calendar's dates in week view. This problem will be eliminated by changing the offset to 100 - (this.viewHeight / 2).