### PR TITLE
DRY in agenaHeight, reuse initialScrollPadPosition

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -332,7 +332,7 @@ export default class AgendaView extends Component {
   }
 
   render() {
-    const agendaHeight = Math.max(0, this.viewHeight - HEADER_HEIGHT);
+    const agendaHeight = this.initialScrollPadPosition();
     const weekDaysNames = dateutils.weekDayNames(this.props.firstDay);
     
     const weekdaysStyle = [this.styles.weekdays, {


### PR DESCRIPTION
The line 335 use the exactly Math.max calculation of the method initialScrollPadPosition()