### PR TITLE
Update incorrectly named prop scrollingEnabled

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -416,7 +416,7 @@ export default class AgendaView extends Component {
               markingType={this.props.markingType}
               removeClippedSubviews={this.props.removeClippedSubviews}
               onDayPress={this._chooseDayFromCalendar.bind(this)}
-              scrollingEnabled={this.state.calendarScrollable}
+              scrollEnabled={this.state.calendarScrollable}
               hideExtraDays={this.state.calendarScrollable}
               firstDay={this.props.firstDay}
               monthFormat={this.props.monthFormat}


### PR DESCRIPTION
Agenda is passing prop scrollingEnabled to CalendarList, which expects scrollEnabled. This fixes that