### PR TITLE
Fixed CalendarList not rendering when flex:1 is used

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -286,7 +286,7 @@ class CalendarList extends Component {
 
   render() {
     return (
-      <View>
+      <React.Fragment>
         <FlatList
           onLayout={this.onLayout}
           ref={(c) => this.listView = c}
@@ -312,7 +312,7 @@ class CalendarList extends Component {
           scrollsToTop={this.props.scrollsToTop}
         />
         {this.renderStaticHeader()}
-      </View>
+      </React.Fragment>
     );
   }
 }

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {FlatList, Platform, Dimensions, ActivityIndicator, View} from 'react-native';
+import {FlatList, Platform, Dimensions, ActivityIndicator} from 'react-native';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 


### PR DESCRIPTION
Hi! This PR fixes a problem with the `<CalendarList>` component which does not layout correctly when a style like `flex: 1` is used. This is because the used parent View does not propagate the flex style correctly. It has been changed to a `React.Fragment`, which fixes the problem.

So in short, it fixes this:

```jsx
<CalendarList style={{flex: 1}} .../>
```

Interestingly, this problem did not show its head in <= RN59, but only after upgrading to RN61. Which may indicate that Yoga has become a bit stricter in RN60+.

cheers!
