### PR TITLE
Fix error with missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "lodash": "^4.0.0",
     "prop-types": "^15.5.10",
-    "xdate": "^0.8.0"
+    "xdate": "^0.8.0",
+    "hoist-non-react-statics": "3.3.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
@@ -34,7 +35,6 @@
     "semver": "5.x.x",
     "shell-utils": "1.x.x",
     "react": "16.8.3",
-    "react-native": "0.59.3",
-    "react-native-navigation": "2.13.1"
+    "react-native": "0.59.3"
   }
 }


### PR DESCRIPTION
This PR fixes error on #900 
It also removes `react-native-navigation` dev dependency from the `package.json`.