### PR TITLE
Added custom styles for left and right arrows

### DIFF
--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -10,7 +10,7 @@ import {CHANGE_MONTH_LEFT_ARROW, CHANGE_MONTH_RIGHT_ARROW} from '../../testIDs';
 
 class CalendarHeader extends Component {
   static displayName = 'IGNORE';
-  
+
   static propTypes = {
     theme: PropTypes.object,
     hideArrows: PropTypes.bool,
@@ -94,7 +94,7 @@ class CalendarHeader extends Component {
       leftArrow = (
         <TouchableOpacity
           onPress={this.onPressLeft}
-          style={this.style.arrow}
+          style={{...this.style.arrow, ...this.style.leftArrow}}
           hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
           testID={testID ? `${CHANGE_MONTH_LEFT_ARROW}-${testID}`: CHANGE_MONTH_LEFT_ARROW}
         >
@@ -109,7 +109,7 @@ class CalendarHeader extends Component {
       rightArrow = (
         <TouchableOpacity
           onPress={this.onPressRight}
-          style={this.style.arrow}
+          style={{...this.style.arrow, ...this.style.rightArrow}}
           hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
           testID={testID ? `${CHANGE_MONTH_RIGHT_ARROW}-${testID}`: CHANGE_MONTH_RIGHT_ARROW}
         >
@@ -145,12 +145,12 @@ class CalendarHeader extends Component {
           <View style={this.style.week}>
             {this.props.weekNumbers && <Text allowFontScaling={false} style={this.style.dayHeader}></Text>}
             {weekDaysNames.map((day, idx) => (
-              <Text 
-                allowFontScaling={false} 
-                key={idx} 
-                accessible={false} 
-                style={this.style.dayHeader} 
-                numberOfLines={1} 
+              <Text
+                allowFontScaling={false}
+                key={idx}
+                accessible={false}
+                style={this.style.dayHeader}
+                numberOfLines={1}
                 importantForAccessibility='no'
               >
                 {day}

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -94,7 +94,7 @@ class CalendarHeader extends Component {
       leftArrow = (
         <TouchableOpacity
           onPress={this.onPressLeft}
-          style={{...this.style.arrow, ...this.style.leftArrow}}
+          style={[this.style.arrow, this.style.leftArrow]}
           hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
           testID={testID ? `${CHANGE_MONTH_LEFT_ARROW}-${testID}`: CHANGE_MONTH_LEFT_ARROW}
         >
@@ -109,7 +109,7 @@ class CalendarHeader extends Component {
       rightArrow = (
         <TouchableOpacity
           onPress={this.onPressRight}
-          style={{...this.style.arrow, ...this.style.rightArrow}}
+          style={[this.style.arrow, this.style.rightArrow]}
           hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
           testID={testID ? `${CHANGE_MONTH_RIGHT_ARROW}-${testID}`: CHANGE_MONTH_RIGHT_ARROW}
         >

--- a/src/calendar/header/style.js
+++ b/src/calendar/header/style.js
@@ -5,10 +5,6 @@ const STYLESHEET_ID = 'stylesheet.calendar.header';
 
 export default function(theme={}) {
   const appStyle = {...defaultStyle, ...theme};
-  const arrowStyles = {
-    padding: 10,
-    ...appStyle.arrowStyle
-  }
   return StyleSheet.create({
     header: {
       flexDirection: 'row',
@@ -25,7 +21,10 @@ export default function(theme={}) {
       color: appStyle.monthTextColor,
       margin: 10
     },
-    arrow: arrowStyles,
+    arrow: {
+      padding: 10,
+      ...appStyle.arrowStyle
+    },
     leftArrow: {},
     rightArrow: {},
     arrowImage: {

--- a/src/calendar/header/style.js
+++ b/src/calendar/header/style.js
@@ -5,6 +5,10 @@ const STYLESHEET_ID = 'stylesheet.calendar.header';
 
 export default function(theme={}) {
   const appStyle = {...defaultStyle, ...theme};
+  const arrowStyles = {
+    padding: 10,
+    ...appStyle.arrowStyle
+  }
   return StyleSheet.create({
     header: {
       flexDirection: 'row',
@@ -21,10 +25,9 @@ export default function(theme={}) {
       color: appStyle.monthTextColor,
       margin: 10
     },
-    arrow: {
-      padding: 10,
-      ...appStyle.arrowStyle
-    },
+    arrow: arrowStyles,
+    leftArrow: {},
+    rightArrow: {},
     arrowImage: {
       ...Platform.select({
         ios: {


### PR DESCRIPTION
Hi, after searching some custom styles for right or left icon, I understand that there is no such possibility. Am I mistaken? 

So, I would like to suggest this method for adding custom styles for left and right arrow components

for example:

```
'stylesheet.calendar.header': {
    arrow: {
      width: 100,
    },
    rightArrow: {
      some styles,
      alignItems: 'flex-end',
    },
    leftArrow: {
      some styles,
      alignItems: 'flex-start',
    }
  },
```

@ethanshar ?