### PR TITLE
Fixed: getDateMarking returns empty array even if no marking specified

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -18,7 +18,6 @@ import {SELECT_DATE_SLOT} from '../testIDs';
 
 //Fallback when RN version is < 0.44
 const viewPropTypes = ViewPropTypes || View.propTypes;
-const EmptyArray = [];
 
 /**
  * @description: Calendar component
@@ -82,9 +81,9 @@ class Calendar extends Component {
 
   constructor(props) {
     super(props);
-    
+
     this.style = styleConstructor(this.props.theme);
-    
+
     this.state = {
       currentMonth: props.current ? parseDate(props.current) : XDate()
     };
@@ -214,11 +213,14 @@ class Calendar extends Component {
       return false;
     }
 
-    const dates = this.props.markedDates[day.toString('yyyy-MM-dd')] || EmptyArray;
-    if (dates.length || dates) {
-      return dates;
-    } else {
+    const dates = this.props.markedDates[day.toString('yyyy-MM-dd')];
+
+    if(!dates) {
       return false;
+    } else if( Array.isArray(dates) && dates.length === 0 ) {
+      return false;
+    } else {
+      return dates;
     }
   }
 


### PR DESCRIPTION
Fixed: getDateMarking returns empty array even if no marking specified for day, causing day/period to have borderRadius style set even on not marked days, i.e. on all days.

Empty array treated as true here:
https://github.com/wix/react-native-calendars/blob/master/src/calendar/day/period/index.js#L131
makes all days to be rounded event if not selected. It is not visible at all but it is a root cause of another bug in "period" marking type on android: when initially deselected day becomes selected it is not rounded:

Initially unmarked and marked after render
![Screenshot from 2019-11-07 21-09-39](https://user-images.githubusercontent.com/1592231/68416875-60e46080-01a6-11ea-820c-0da91006ef57.png)

Initially marked
![Screenshot from 2019-11-07 21-34-40](https://user-images.githubusercontent.com/1592231/68416889-6c378c00-01a6-11ea-9b1a-387e2efb0a59.png)

Now rounding works if marker was initially unmarked.
