### PR TITLE
Added ref to CalendarHeader

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -259,6 +259,7 @@ class Calendar extends Component {
     return (
       <View style={[this.style.container, this.props.style]}>
         <CalendarHeader
+          ref={c => this.header = c}
           style={this.props.headerStyle}
           theme={this.props.theme}
           hideArrows={this.props.hideArrows}


### PR DESCRIPTION
I can understand why this PR might not get accepted but I needed a reference to the header for a project. Reason being we had custom arrows placed to the side of the calendar so I wanted to programmatically call the onPressLeft/onPressRight functions on the header i.e. `this.calendar.header.onPressLeft()`