### PR TITLE
Support option; onlySelectedDataList

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -82,7 +82,9 @@ export default class AgendaView extends Component {
     /** Set this true while waiting for new data from a refresh. */
     refreshing: PropTypes.bool,
     /** Display loading indicador. Default = false */
-    displayLoadingIndicator: PropTypes.bool
+    displayLoadingIndicator: PropTypes.bool,
+    /** Display only agendas selected on list. Default = false */
+    onlySelectedDateList: PropTypes.bool
   };
 
   constructor(props) {
@@ -280,6 +282,18 @@ export default class AgendaView extends Component {
   }
 
   renderReservations() {
+    let items = this.props.items;
+    if (this.props.onlySelectedDataList) {
+      let _select4ed = this.state.selectedDay.getFullYear() + '-' +
+                       (Number(this.state.selectedDay.getMonth())+1) + '-' +
+                       this.state.selectedDay.getDate();
+      items = {};
+      Object.keys(this.props.items).forEach((key) => {
+        if (_selected == key) {
+          items[key] = this.props.items[key];
+        }
+      });
+    }
     return (
       <ReservationsList
         refreshControl={this.props.refreshControl}
@@ -289,7 +303,7 @@ export default class AgendaView extends Component {
         renderItem={this.props.renderItem}
         renderDay={this.props.renderDay}
         renderEmptyDate={this.props.renderEmptyDate}
-        reservations={this.props.items}
+        reservations={items}
         selectedDay={this.state.selectedDay}
         renderEmptyData={this.props.renderEmptyData}
         topDay={this.state.topDay}

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -284,7 +284,7 @@ export default class AgendaView extends Component {
   renderReservations() {
     let items = this.props.items;
     if (this.props.onlySelectedDataList) {
-      let _select4ed = this.state.selectedDay.getFullYear() + '-' +
+      let _selected = this.state.selectedDay.getFullYear() + '-' +
                        (Number(this.state.selectedDay.getMonth())+1) + '-' +
                        this.state.selectedDay.getDate();
       items = {};

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -84,7 +84,7 @@ export default class AgendaView extends Component {
     /** Display loading indicador. Default = false */
     displayLoadingIndicator: PropTypes.bool,
     /** Display only agendas selected on list. Default = false */
-    onlySelectedDateList: PropTypes.bool
+    onlySelectedDataList: PropTypes.bool
   };
 
   constructor(props) {


### PR DESCRIPTION
When I use your calendar as agenda, I need the list to show entries about the selected date only.

So I add the option onlySelectedDataList to Agenda.

I'd like to merge it.

if I write the codes using wrong way or you don't like it,
Could you fix this?

Thanks in advance!