### PR TITLE
Support override stickySectionHeadersEnabled

### DIFF
--- a/src/expandableCalendar/agendaList.js
+++ b/src/expandableCalendar/agendaList.js
@@ -29,7 +29,8 @@ class AgendaList extends Component {
   }
 
   static defaultProps = {
-    dayFormat: 'dddd, MMM d'
+    dayFormat: 'dddd, MMM d',
+    stickySectionHeadersEnabled: true
   }
 
   constructor(props) {
@@ -139,7 +140,6 @@ class AgendaList extends Component {
         ref={this.list}
         keyExtractor={this.keyExtractor}
         showsVerticalScrollIndicator={false}
-        stickySectionHeadersEnabled
         onViewableItemsChanged={this.onViewableItemsChanged}
         viewabilityConfig={this.viewabilityConfig}
         renderSectionHeader={this.renderSectionHeader}


### PR DESCRIPTION
I would like to disable stickySectionHeadersEnabled but I can't do it.
I've looked into the code and found that It hard code stickySectionHeadersEnabled props. So, I think we should delete it and define the default value instead.