### PR TITLE
Feat/expandable week scroll android fix

### DIFF
--- a/src/expandableCalendar/week.js
+++ b/src/expandableCalendar/week.js
@@ -14,6 +14,7 @@ import MultiDotDay from '../calendar/day/multi-dot';
 import MultiPeriodDay from '../calendar/day/multi-period';
 import SingleDay from '../calendar/day/custom';
 import Calendar from '../calendar';
+import * as commons from './commons';
 
 
 const EmptyArray = [];
@@ -160,7 +161,7 @@ class Week extends Component {
 
     return (
       <View style={this.style.container}>
-        <View style={[this.style.week, this.props.style]}>{week}</View>
+        <View style={[this.style.week, this.props.style, {width: commons.screenWidth}]}>{week}</View>
       </View>
     );
   }

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -8,16 +8,15 @@ import styleConstructor from './style';
 import CalendarList from '../calendar-list';
 import Week from '../expandableCalendar/week';
 
-
 const commons = require('./commons');
 const UPDATE_SOURCES = commons.UPDATE_SOURCES;
-const NUMBER_OF_PAGES = 1; // must be a positive number
+const NUMBER_OF_PAGES = 2; // must be a positive number
 
 class WeekCalendar extends Component {
   static propTypes = {
     ...CalendarList.propTypes,
     // the current date
-    current: PropTypes.any
+    current: PropTypes.any,
   };
 
   constructor(props) {
@@ -25,19 +24,24 @@ class WeekCalendar extends Component {
     this.style = styleConstructor(props.theme);
 
     this.viewabilityConfig = {
-      itemVisiblePercentThreshold: 90
+      itemVisiblePercentThreshold: 90,
     };
     this.visibleItem = undefined;
-    this.items = this.getDatesArray();
+    // this.items = this.getDatesArray();
     this.list = React.createRef();
+    this.page = NUMBER_OF_PAGES;
+
+    this.state = {
+      items: this.getDatesArray(),
+    };
   }
 
-  componentDidUpdate() {
-    if (this.props.context.updateSource === UPDATE_SOURCES.WEEK_SCROLL) {
-      // to avoid new items render from changing the visible week
-      this.list.current.scrollToIndex({animated: false, index: NUMBER_OF_PAGES});
-    }
-  }
+  // componentDidUpdate() {
+  //   if (this.props.context.updateSource === UPDATE_SOURCES.WEEK_SCROLL) {
+  //     // to avoid new items render from changing the visible week
+  //     // this.list.current.scrollToIndex({animated: false, index: NUMBER_OF_PAGES});
+  //   }
+  // }
 
   getDatesArray() {
     const array = [];
@@ -48,7 +52,7 @@ class WeekCalendar extends Component {
     return array;
   }
 
-  getDate(index) {
+  getDate(weekIndex) {
     const {current, firstDay} = this.props;
     const d = XDate(current);
     // get the first day of the week as date (for the on scroll mark)
@@ -57,44 +61,109 @@ class WeekCalendar extends Component {
       dayOfTheWeek = 7 + dayOfTheWeek;
     }
     // leave the current date in the visible week as is
-    const dd = index === 0 ? d : d.addDays(firstDay - dayOfTheWeek);
-    const newDate = dd.addWeeks(index);
+    const dd = weekIndex === 0 ? d : d.addDays(firstDay - dayOfTheWeek);
+    const newDate = dd.addWeeks(weekIndex);
     const dateString = newDate.toString('yyyy-MM-dd');
     return dateString;
   }
 
-  onViewableItemsChanged = ({viewableItems}) => {
-    // NOTE: gets called only on week scroll (so might be un-synced with displayed week) !!!
-    if (viewableItems.length > 0) {
-      const viweableItem = _.first(viewableItems);
-      if (viweableItem.isViewable && this.visibleItem !== viweableItem.item) {
-        if (this.visibleItem) { // to avoid invoke on first init
-          _.invoke(this.props.context, 'setDate', viweableItem.item, UPDATE_SOURCES.WEEK_SCROLL); 
+  onScroll = ({
+    nativeEvent: {
+      contentOffset: {x},
+    },
+  }) => {
+    const newPage = Math.round(x / commons.screenWidth);
+    if (this.page !== newPage) {
+      const {items} = this.state;
+      this.page = newPage;
+
+      _.invoke(
+        this.props.context,
+        'setDate',
+        items[this.page],
+        UPDATE_SOURCES.WEEK_SCROLL,
+      );
+
+      if (this.page === items.length - 1) {
+        for (let i = 0; i <= NUMBER_OF_PAGES; i++) {
+          items[i] = items[i + NUMBER_OF_PAGES];
         }
-        this.visibleItem = viweableItem.item;
+        this.setState({items: [...items]});
+      } else if (this.page === 0) {
+
+        for (let i = NUMBER_OF_PAGES; i < items.length; i++) {
+          items[i] = items[i - NUMBER_OF_PAGES];
+        }
+
+        this.setState({items: [...items]});
       }
     }
-  }
+  };
+
+  onMomentumScrollEnd = () => {
+    const {items} = this.state;
+    const isFirstPage = this.page === 0;
+    const isLastPage = this.page === items.length - 1;
+
+    if (isFirstPage || isLastPage) {
+      this.list.current.scrollToIndex({
+        animated: false,
+        index: NUMBER_OF_PAGES,
+      });
+      this.page = NUMBER_OF_PAGES;
+      const newWeekArray = this.getDatesArray();
+
+      if (isLastPage) {
+
+        for (let i = NUMBER_OF_PAGES + 1; i < items.length; i++) {
+          items[i] = newWeekArray[i];
+        }
+      } else {
+        for (let i = 0 + 1; i < NUMBER_OF_PAGES; i++) {
+          items[i] = newWeekArray[i];
+        }
+      }
+
+      setTimeout(() => {
+        this.setState({items: [...items]});
+      }, 100);
+    }
+  };
+
+  // onViewableItemsChanged = ({viewableItems}) => {
+  //   // NOTE: gets called only on week scroll (so might be un-synced with displayed week) !!!
+  //   if (viewableItems.length > 0) {
+  //     const viweableItem = _.first(viewableItems);
+  //     if (viweableItem.isViewable && this.visibleItem !== viweableItem.item) {
+  //       if (this.visibleItem) {
+  //         // to avoid invoke on first init
+  //         _.invoke(
+  //           this.props.context,
+  //           'setDate',
+  //           viweableItem.item,
+  //           UPDATE_SOURCES.WEEK_SCROLL,
+  //         );
+  //       }
+  //       this.visibleItem = viweableItem.item;
+  //     }
+  //   }
+  // };
 
   renderItem = ({item}) => {
-    return (
-      <Week
-        {...this.props}
-        current={item}
-        key={item}
-      />
-    );
-  }
+    return <Week {...this.props} current={item} key={item} />;
+  };
 
-  keyExtractor = (item, index) => String(index);
+  keyExtractor = (item, index) => index.toString();
 
-  render() {  
-    this.items = this.getDatesArray();
-  
+  render() {
+    // this.items = this.getDatesArray();
+    // const items = this.getDatesArray();
+    const {items} = this.state;
+
     return (
       <FlatList
         ref={this.list}
-        data={this.items}
+        data={items}
         style={this.style.container}
         horizontal
         showsHorizontalScrollIndicator={false}
@@ -102,17 +171,23 @@ class WeekCalendar extends Component {
         scrollEnabled
         renderItem={this.renderItem}
         keyExtractor={this.keyExtractor}
-        onViewableItemsChanged={this.onViewableItemsChanged}
-        viewabilityConfig={this.viewabilityConfig}
+        // onViewableItemsChanged={this.onViewableItemsChanged}
+        // viewabilityConfig={this.viewabilityConfig}
         initialScrollIndex={NUMBER_OF_PAGES}
         getItemLayout={this.getItemLayout}
+        onScroll={this.onScroll}
+        onMomentumScrollEnd={this.onMomentumScrollEnd}
       />
     );
   }
 
   getItemLayout = (data, index) => {
-    return {length: commons.screenWidth, offset: commons.screenWidth  * index, index};
-  }
+    return {
+      length: commons.screenWidth,
+      offset: commons.screenWidth * index,
+      index,
+    };
+  };
 }
 
 export default WeekCalendar;

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -134,6 +134,7 @@ class WeekCalendar extends Component {
         getItemLayout={this.getItemLayout}
         onScroll={this.onScroll}
         onMomentumScrollEnd={this.onMomentumScrollEnd}
+        extraData={this.props.current}
       />
     );
   }

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -22,12 +22,6 @@ class WeekCalendar extends Component {
   constructor(props) {
     super(props);
     this.style = styleConstructor(props.theme);
-
-    this.viewabilityConfig = {
-      itemVisiblePercentThreshold: 90,
-    };
-    this.visibleItem = undefined;
-    // this.items = this.getDatesArray();
     this.list = React.createRef();
     this.page = NUMBER_OF_PAGES;
 
@@ -35,13 +29,6 @@ class WeekCalendar extends Component {
       items: this.getDatesArray(),
     };
   }
-
-  // componentDidUpdate() {
-  //   if (this.props.context.updateSource === UPDATE_SOURCES.WEEK_SCROLL) {
-  //     // to avoid new items render from changing the visible week
-  //     // this.list.current.scrollToIndex({animated: false, index: NUMBER_OF_PAGES});
-  //   }
-  // }
 
   getDatesArray() {
     const array = [];
@@ -67,22 +54,13 @@ class WeekCalendar extends Component {
     return dateString;
   }
 
-  onScroll = ({
-    nativeEvent: {
-      contentOffset: {x},
-    },
-  }) => {
+  onScroll = ({nativeEvent: {contentOffset: {x}}}) => {
     const newPage = Math.round(x / commons.screenWidth);
     if (this.page !== newPage) {
       const {items} = this.state;
       this.page = newPage;
 
-      _.invoke(
-        this.props.context,
-        'setDate',
-        items[this.page],
-        UPDATE_SOURCES.WEEK_SCROLL,
-      );
+      _.invoke(this.props.context, 'setDate', items[this.page], UPDATE_SOURCES.WEEK_SCROLL);
 
       if (this.page === items.length - 1) {
         for (let i = 0; i <= NUMBER_OF_PAGES; i++) {
@@ -104,15 +82,11 @@ class WeekCalendar extends Component {
     const isLastPage = this.page === items.length - 1;
 
     if (isFirstPage || isLastPage) {
-      this.list.current.scrollToIndex({
-        animated: false,
-        index: NUMBER_OF_PAGES,
-      });
+      this.list.current.scrollToIndex({animated: false, index: NUMBER_OF_PAGES});
       this.page = NUMBER_OF_PAGES;
       const newWeekArray = this.getDatesArray();
 
       if (isLastPage) {
-
         for (let i = NUMBER_OF_PAGES + 1; i < items.length; i++) {
           items[i] = newWeekArray[i];
         }
@@ -128,34 +102,21 @@ class WeekCalendar extends Component {
     }
   };
 
-  // onViewableItemsChanged = ({viewableItems}) => {
-  //   // NOTE: gets called only on week scroll (so might be un-synced with displayed week) !!!
-  //   if (viewableItems.length > 0) {
-  //     const viweableItem = _.first(viewableItems);
-  //     if (viweableItem.isViewable && this.visibleItem !== viweableItem.item) {
-  //       if (this.visibleItem) {
-  //         // to avoid invoke on first init
-  //         _.invoke(
-  //           this.props.context,
-  //           'setDate',
-  //           viweableItem.item,
-  //           UPDATE_SOURCES.WEEK_SCROLL,
-  //         );
-  //       }
-  //       this.visibleItem = viweableItem.item;
-  //     }
-  //   }
-  // };
-
   renderItem = ({item}) => {
     return <Week {...this.props} current={item} key={item} />;
+  };
+
+  getItemLayout = (data, index) => {
+    return {
+      length: commons.screenWidth,
+      offset: commons.screenWidth * index,
+      index,
+    };
   };
 
   keyExtractor = (item, index) => index.toString();
 
   render() {
-    // this.items = this.getDatesArray();
-    // const items = this.getDatesArray();
     const {items} = this.state;
 
     return (
@@ -169,8 +130,6 @@ class WeekCalendar extends Component {
         scrollEnabled
         renderItem={this.renderItem}
         keyExtractor={this.keyExtractor}
-        // onViewableItemsChanged={this.onViewableItemsChanged}
-        // viewabilityConfig={this.viewabilityConfig}
         initialScrollIndex={NUMBER_OF_PAGES}
         getItemLayout={this.getItemLayout}
         onScroll={this.onScroll}
@@ -178,14 +137,6 @@ class WeekCalendar extends Component {
       />
     );
   }
-
-  getItemLayout = (data, index) => {
-    return {
-      length: commons.screenWidth,
-      offset: commons.screenWidth * index,
-      index,
-    };
-  };
 }
 
 export default WeekCalendar;

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -30,6 +30,16 @@ class WeekCalendar extends Component {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    const {updateSource, date} = this.props.context;
+    if (date !== prevProps.context.date && updateSource !== UPDATE_SOURCES.WEEK_SCROLL) {
+      this.setState({
+        items: this.getDatesArray()
+      });
+      this.list.current.scrollToIndex({animated: false, index: NUMBER_OF_PAGES});
+    }
+  }
+
   getDatesArray() {
     const array = [];
     for (let index = -NUMBER_OF_PAGES; index <= NUMBER_OF_PAGES; index++) {

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -90,11 +90,9 @@ class WeekCalendar extends Component {
         }
         this.setState({items: [...items]});
       } else if (this.page === 0) {
-
-        for (let i = NUMBER_OF_PAGES; i < items.length; i++) {
+        for (let i = items.length - 1; i >= NUMBER_OF_PAGES; i--) {
           items[i] = items[i - NUMBER_OF_PAGES];
         }
-
         this.setState({items: [...items]});
       }
     }
@@ -119,7 +117,7 @@ class WeekCalendar extends Component {
           items[i] = newWeekArray[i];
         }
       } else {
-        for (let i = 0 + 1; i < NUMBER_OF_PAGES; i++) {
+        for (let i = 0; i < NUMBER_OF_PAGES; i++) {
           items[i] = newWeekArray[i];
         }
       }


### PR DESCRIPTION
I added the fix. please take a look.
 
In general there's still a very minor issue in both platforms, when u scroll really fast you might get stuck because the FlatList didn't got a chance to scroll back to the middle.
(on Android it's a little more noticeable) 

Another issue I noticed, not sure if it was there before, when I scroll a week, the first day doesn't always get marked. (only the edge pages). Possible I created this issue, I assume it's fixable. 

anyway, please go over and let me know if there're other issues, it would never be perfect on Android, just because it's Android, but at least it doesn't have the flicker. 