### PR TITLE
Fix ExpandableCalendar arrow override not working

### DIFF
--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -446,7 +446,7 @@ class ExpandableCalendar extends Component {
 
   renderArrow = (direction) => {
     if (_.isFunction(this.props.renderArrow)) {
-      this.props.renderArrow(direction);
+      return this.props.renderArrow(direction);
     }
 
     return (


### PR DESCRIPTION
Just missed a return statement which made the `renderArrow` override useless on the exandableCalendar