### PR TITLE
Fix React Native v0.62 issue

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -126,7 +126,7 @@ export default class AgendaView extends Component {
   }
 
   setScrollPadPosition(y, animated) {
-    this.scrollPad.scrollTo({x: 0, y, animated});
+    this.scrollPad.getNode().scrollTo({x: 0, y, animated});
   }
 
   onScrollPadLayout() {

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -126,7 +126,7 @@ export default class AgendaView extends Component {
   }
 
   setScrollPadPosition(y, animated) {
-    this.scrollPad._component.scrollTo({x: 0, y, animated});
+    this.scrollPad.scrollTo({x: 0, y, animated});
   }
 
   onScrollPadLayout() {


### PR DESCRIPTION
The error is:
TypeError: undefined is not an object (evaluating 'this.scrollPad._component.scrollTo') AgendaView#setScrollPadPosition index.js:129:27

By removing "_component" and leaving this.scrollPad.scrollTo seems to fix it