### PR TITLE
Fix undefined height in expandableCalendar

### DIFF
--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -81,7 +81,7 @@ class ExpandableCalendar extends Component {
     
     const startHeight = props.initialPosition === POSITIONS.CLOSED ? this.closedHeight : this.openHeight;
     this._height = startHeight;
-    this._wrapperStyles = {style: {}};
+    this._wrapperStyles = {style: {height: startHeight}};
     this._headerStyles = {style: {top: this.props.initialPosition === POSITIONS.CLOSED ? 0 : -HEADER_HEIGHT}};
     this._weekCalendarStyles = {style: {}};
     this.wrapper = undefined;


### PR DESCRIPTION
See my comment here: https://github.com/wix/react-native-calendars/issues/874#issuecomment-576696278


Whether it is the right fix, I don't know. But due to an (unexpected?) order in panResponder callbacks the height will be set to NaN, causing native issues.

if 'panResponderEnd' gets called before 'handlePanResponderMove', `this._height` will be set to `undefined`, which will lead to NaN's coming out of Math.[min|max] calls.