### PR TITLE
[FIX] Adding test id in Calendar Component

### DIFF
--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -25,7 +25,8 @@ class CalendarHeader extends Component {
     onPressArrowRight: PropTypes.func,
     disableArrowLeft: PropTypes.bool,
     disableArrowRight: PropTypes.bool,
-    webAriaLevel: PropTypes.number
+    webAriaLevel: PropTypes.number,
+    testID: PropTypes.string
   };
 
   static defaultProps = {

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -25,8 +25,7 @@ class CalendarHeader extends Component {
     onPressArrowRight: PropTypes.func,
     disableArrowLeft: PropTypes.bool,
     disableArrowRight: PropTypes.bool,
-    webAriaLevel: PropTypes.number,
-    testID: PropTypes.string
+    webAriaLevel: PropTypes.number
   };
 
   static defaultProps = {

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -84,9 +84,7 @@ class Calendar extends Component {
     /** Style passed to the header */
     headerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     /** Provide aria-level for calendar heading for proper accessibility when used with web (react-native-web) */
-    webAriaLevel: PropTypes.number,
-    /** Provide Calendar Test ID. Default = undefined */
-    testID: PropTypes.string
+    webAriaLevel: PropTypes.number
   };
 
   constructor(props) {

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -85,7 +85,7 @@ class Calendar extends Component {
     headerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     /** Provide aria-level for calendar heading for proper accessibility when used with web (react-native-web) */
     webAriaLevel: PropTypes.number,
-    /** Provide Calendar Test ID for user. Default = undefined */
+    /** Provide Calendar Test ID. Default = undefined */
     testID: PropTypes.string
   };
 

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -84,7 +84,9 @@ class Calendar extends Component {
     /** Style passed to the header */
     headerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     /** Provide aria-level for calendar heading for proper accessibility when used with web (react-native-web) */
-    webAriaLevel: PropTypes.number
+    webAriaLevel: PropTypes.number,
+    /** Provide Calendar Test ID for user. Default = undefined */
+    testID: PropTypes.string
   };
 
   constructor(props) {
@@ -310,6 +312,7 @@ class Calendar extends Component {
         importantForAccessibility={this.props.importantForAccessibility} // Android
       >
         <CalendarHeader
+          testID={this.props.testID}
           ref={c => this.header = c}
           style={this.props.headerStyle}
           theme={this.props.theme}


### PR DESCRIPTION
So I found out that **HeaderCalendar** Component is using `testID` from `this.props`

But... PropTypes didn't ask for a `testID` and **Calendar** Component didn't pass `testID` to **HeaderCalendar** Component.

So I made this PR to fix that.

Related PR: #865 #882 