### PR TITLE
Add renderMonth prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ LocaleConfig.defaultLocale = 'fr';
   hideArrows={true}
   // Replace default arrows with custom ones (direction can be 'left' or 'right')
   renderArrow={(direction) => (<Arrow/>)}
+  // Replace default month component with a custom one (month is of type XDate). 
+  // Formatting values: http://arshaw.com/xdate/#Formatting
+  renderMonth={(month) => (<Month/>)}
   // Do not show days of other months in month page. Default = false
   hideExtraDays={true}
   // If hideArrows=false and hideExtraDays=false do not switch month when tapping on greyed out
@@ -366,6 +369,23 @@ The `dayComponent` prop has to receive a RN component or a function that receive
 **Tip**: Don't forget to implement `shouldComponentUpdate()` for your custom day component to make the calendar perform better
 
 If you implement an awesome day component please make a PR so that other people could use it :)
+
+#### Overriding month component
+
+If you need custom styling or functionality not supported by the default month component, you can pass your own custom month component to the calendar.
+
+```javascript
+<Calendar
+  renderMonth={(month) => (
+    <View style={{flexDirection: 'column', alignItems: 'center', justifyContent: 'center'}}>
+      <Text style={{fontSize: 18, marginBottom: 5}}>{month.toString('MMMM')}</Text>
+      <Text style={{fontSize: 12, color: '#AAA'}}>{month.toString('yyyy')}</Text>
+    </View>
+  )}
+/>
+```
+
+The `renderMonth` prop is very similar to the `renderArrow` prop. It must be a function that receives a `month` parameter and returns a React Native component. The `month` prop is of type `XDate`. [Take a look at the date formatting options available here](https://arshaw.com/xdate/#Formatting).
 
 ### CalendarList
 

--- a/example/src/screens/calendars.js
+++ b/example/src/screens/calendars.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {StyleSheet, View, ScrollView, Text} from 'react-native';
+import {StyleSheet, View, ScrollView, Text, TouchableOpacity} from 'react-native';
 import {Calendar} from 'react-native-calendars';
 
 
@@ -284,6 +284,33 @@ export default class CalendarsScreen extends Component {
               <Text style={{fontSize: 18, marginBottom: 5}}>{month.toString('MMMM')}</Text>
               <Text style={{fontSize: 12, color: '#AAA'}}>{month.toString('yyyy')}</Text>
             </View>
+          )}
+        />
+
+        <Text style={styles.text}>Calendar with custom arrow component</Text>
+        <Calendar
+          style={styles.calendar}
+          theme={{
+            'stylesheet.calendar.header': {
+              header: {
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                paddingLeft: 10,
+                paddingRight: 10,
+                marginTop: 6,
+                alignItems: 'center',
+                height: 80
+              }
+            }
+          }}
+          renderArrow={(direction, onPress) => (
+            <TouchableOpacity onPress={onPress}>
+              <Text style={{fontSize: 20, marginHorizontal: 20}}>
+                {
+                  direction === 'left' ? '<' : '>'
+                }
+              </Text>
+            </TouchableOpacity>
           )}
         />
 

--- a/example/src/screens/calendars.js
+++ b/example/src/screens/calendars.js
@@ -261,6 +261,32 @@ export default class CalendarsScreen extends Component {
             );
           }}
         />
+
+
+        <Text style={styles.text}>Calendar with custom month component</Text>
+        <Calendar
+          style={styles.calendar}
+          theme={{
+            'stylesheet.calendar.header': {
+              header: {
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                paddingLeft: 10,
+                paddingRight: 10,
+                marginTop: 6,
+                alignItems: 'center',
+                height: 80
+              }
+            }
+          }}
+          renderMonth={(month) => (
+            <View style={{flexDirection: 'column', alignItems: 'center', justifyContent: 'center'}}>
+              <Text style={{fontSize: 18, marginBottom: 5}}>{month.toString('MMMM')}</Text>
+              <Text style={{fontSize: 12, color: '#AAA'}}>{month.toString('yyyy')}</Text>
+            </View>
+          )}
+        />
+
       </ScrollView>
     );
   }

--- a/example/src/screens/calendars.js
+++ b/example/src/screens/calendars.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {StyleSheet, View, ScrollView, Text, TouchableOpacity} from 'react-native';
+import {StyleSheet, View, ScrollView, Text} from 'react-native';
 import {Calendar} from 'react-native-calendars';
 
 
@@ -284,33 +284,6 @@ export default class CalendarsScreen extends Component {
               <Text style={{fontSize: 18, marginBottom: 5}}>{month.toString('MMMM')}</Text>
               <Text style={{fontSize: 12, color: '#AAA'}}>{month.toString('yyyy')}</Text>
             </View>
-          )}
-        />
-
-        <Text style={styles.text}>Calendar with custom arrow component</Text>
-        <Calendar
-          style={styles.calendar}
-          theme={{
-            'stylesheet.calendar.header': {
-              header: {
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                paddingLeft: 10,
-                paddingRight: 10,
-                marginTop: 6,
-                alignItems: 'center',
-                height: 80
-              }
-            }
-          }}
-          renderArrow={(direction, onPress) => (
-            <TouchableOpacity onPress={onPress}>
-              <Text style={{fontSize: 20, marginHorizontal: 20}}>
-                {
-                  direction === 'left' ? '<' : '>'
-                }
-              </Text>
-            </TouchableOpacity>
           )}
         />
 

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -19,6 +19,7 @@ class CalendarHeader extends Component {
     showIndicator: PropTypes.bool,
     firstDay: PropTypes.number,
     renderArrow: PropTypes.func,
+    renderMonth: PropTypes.func,
     hideDayNames: PropTypes.bool,
     weekNumbers: PropTypes.bool,
     onPressArrowLeft: PropTypes.func,
@@ -70,6 +71,9 @@ class CalendarHeader extends Component {
       return true;
     }
     if (nextProps.renderArrow !== this.props.renderArrow) {
+      return true;
+    }
+    if (nextProps.renderMonth !== this.props.renderMonth) {
       return true;
     }
     if (nextProps.disableArrowLeft !== this.props.disableArrowLeft) {
@@ -138,6 +142,20 @@ class CalendarHeader extends Component {
       );
     }
 
+    let renderMonth;
+    if (this.props.renderMonth) {
+      renderMonth = this.props.renderMonth;
+    } else {
+      renderMonth = (month) => (
+        <Text
+          allowFontScaling={false}
+          style={this.style.monthText}
+          {...webProps}>
+          {month.toString(this.props.monthFormat)}
+        </Text>
+      );
+    }
+
     let indicator;
     if (this.props.showIndicator) {
       indicator = <ActivityIndicator color={this.props.theme && this.props.theme.indicatorColor}/>;
@@ -161,13 +179,7 @@ class CalendarHeader extends Component {
         <View style={this.style.header}>
           {leftArrow}
           <View style={{flexDirection: 'row'}}>
-            <Text
-              allowFontScaling={false}
-              style={this.style.monthText}
-              {...webProps}
-            >
-              {this.props.month.toString(this.props.monthFormat)}
-            </Text>
+            {renderMonth(this.props.month)}
             {indicator}
           </View>
           {rightArrow}

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -109,48 +109,36 @@ class CalendarHeader extends Component {
 
     if (!this.props.hideArrows) {
       leftArrow = (
-        <View>
-          {
-            this.props.renderArrow
-              ? this.props.renderArrow('left', this.onPressLeft)
-              : (
-                <TouchableOpacity
-                  onPress={this.onPressLeft}
-                  disabled={this.props.disableArrowLeft}
-                  style={this.style.arrow}
-                  hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
-                  testID={testID ? `${CHANGE_MONTH_LEFT_ARROW}-${testID}`: CHANGE_MONTH_LEFT_ARROW}
-                >
-                  <Image
-                    source={require('../img/previous.png')}
-                    style={this.props.disableArrowLeft ? this.style.disabledArrowImage : this.style.arrowImage}
-                  />
-                </TouchableOpacity>
-              )
-          }
-        </View>
+        <TouchableOpacity
+          onPress={this.onPressLeft}
+          disabled={this.props.disableArrowLeft}
+          style={this.style.arrow}
+          hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
+          testID={testID ? `${CHANGE_MONTH_LEFT_ARROW}-${testID}`: CHANGE_MONTH_LEFT_ARROW}
+        >
+          {this.props.renderArrow
+            ? this.props.renderArrow('left')
+            : <Image
+              source={require('../img/previous.png')}
+              style={this.props.disableArrowLeft ? this.style.disabledArrowImage : this.style.arrowImage}
+            />}
+        </TouchableOpacity>
       );
       rightArrow = (
-        <View>
-          {
-            this.props.renderArrow 
-              ? this.props.renderArrow('right',  this.onPressRight) 
-              : (
-                <TouchableOpacity
-                  onPress={this.onPressRight}
-                  disabled={this.props.disableArrowRight}
-                  style={this.style.arrow}
-                  hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
-                  testID={testID ? `${CHANGE_MONTH_RIGHT_ARROW}-${testID}`: CHANGE_MONTH_RIGHT_ARROW}
-                >
-                  <Image
-                    source={require('../img/next.png')}
-                    style={this.props.disableArrowRight ? this.style.disabledArrowImage : this.style.arrowImage}
-                  />
-                </TouchableOpacity>
-              )
-          }
-        </View>
+        <TouchableOpacity
+          onPress={this.onPressRight}
+          disabled={this.props.disableArrowRight}
+          style={this.style.arrow}
+          hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
+          testID={testID ? `${CHANGE_MONTH_RIGHT_ARROW}-${testID}`: CHANGE_MONTH_RIGHT_ARROW}
+        >
+          {this.props.renderArrow
+            ? this.props.renderArrow('right')
+            : <Image
+              source={require('../img/next.png')}
+              style={this.props.disableArrowRight ? this.style.disabledArrowImage : this.style.arrowImage}
+            />}
+        </TouchableOpacity>
       );
     }
 

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -109,36 +109,48 @@ class CalendarHeader extends Component {
 
     if (!this.props.hideArrows) {
       leftArrow = (
-        <TouchableOpacity
-          onPress={this.onPressLeft}
-          disabled={this.props.disableArrowLeft}
-          style={this.style.arrow}
-          hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
-          testID={testID ? `${CHANGE_MONTH_LEFT_ARROW}-${testID}`: CHANGE_MONTH_LEFT_ARROW}
-        >
-          {this.props.renderArrow
-            ? this.props.renderArrow('left')
-            : <Image
-              source={require('../img/previous.png')}
-              style={this.props.disableArrowLeft ? this.style.disabledArrowImage : this.style.arrowImage}
-            />}
-        </TouchableOpacity>
+        <View>
+          {
+            this.props.renderArrow
+              ? this.props.renderArrow('left', this.onPressLeft)
+              : (
+                <TouchableOpacity
+                  onPress={this.onPressLeft}
+                  disabled={this.props.disableArrowLeft}
+                  style={this.style.arrow}
+                  hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
+                  testID={testID ? `${CHANGE_MONTH_LEFT_ARROW}-${testID}`: CHANGE_MONTH_LEFT_ARROW}
+                >
+                  <Image
+                    source={require('../img/previous.png')}
+                    style={this.props.disableArrowLeft ? this.style.disabledArrowImage : this.style.arrowImage}
+                  />
+                </TouchableOpacity>
+              )
+          }
+        </View>
       );
       rightArrow = (
-        <TouchableOpacity
-          onPress={this.onPressRight}
-          disabled={this.props.disableArrowRight}
-          style={this.style.arrow}
-          hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
-          testID={testID ? `${CHANGE_MONTH_RIGHT_ARROW}-${testID}`: CHANGE_MONTH_RIGHT_ARROW}
-        >
-          {this.props.renderArrow
-            ? this.props.renderArrow('right')
-            : <Image
-              source={require('../img/next.png')}
-              style={this.props.disableArrowRight ? this.style.disabledArrowImage : this.style.arrowImage}
-            />}
-        </TouchableOpacity>
+        <View>
+          {
+            this.props.renderArrow 
+              ? this.props.renderArrow('right',  this.onPressRight) 
+              : (
+                <TouchableOpacity
+                  onPress={this.onPressRight}
+                  disabled={this.props.disableArrowRight}
+                  style={this.style.arrow}
+                  hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
+                  testID={testID ? `${CHANGE_MONTH_RIGHT_ARROW}-${testID}`: CHANGE_MONTH_RIGHT_ARROW}
+                >
+                  <Image
+                    source={require('../img/next.png')}
+                    style={this.props.disableArrowRight ? this.style.disabledArrowImage : this.style.arrowImage}
+                  />
+                </TouchableOpacity>
+              )
+          }
+        </View>
       );
     }
 

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -61,7 +61,7 @@ class Calendar extends Component {
     onVisibleMonthsChange: PropTypes.func,
     /** Replace default arrows with custom ones (direction can be 'left' or 'right') */
     renderArrow: PropTypes.func,
-    /** Replace default month renderer with custom ones (recieves Date()) */
+    /** Replace default month renderer with custom ones (receives XDate()) */
     renderMonth: PropTypes.func,
     /** Provide custom day rendering component */
     dayComponent: PropTypes.any,

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -61,6 +61,8 @@ class Calendar extends Component {
     onVisibleMonthsChange: PropTypes.func,
     /** Replace default arrows with custom ones (direction can be 'left' or 'right') */
     renderArrow: PropTypes.func,
+    /** Replace default month renderer with custom ones (recieves Date()) */
+    renderMonth: PropTypes.func,
     /** Provide custom day rendering component */
     dayComponent: PropTypes.any,
     /** Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting */
@@ -320,6 +322,7 @@ class Calendar extends Component {
           showIndicator={indicator}
           firstDay={this.props.firstDay}
           renderArrow={this.props.renderArrow}
+          renderMonth={this.props.renderMonth}
           monthFormat={this.props.monthFormat}
           hideDayNames={this.props.hideDayNames}
           weekNumbers={this.props.showWeekNumbers}


### PR DESCRIPTION
I received a design similar to this one (notice the centered month/year):

![Screenshot_1585585833](https://user-images.githubusercontent.com/28730324/78036507-c2b58a80-7340-11ea-9439-6cd21ae36781.png)

I tried implementing this using only calendar style and themes, but didn't have much luck. I also saw there were some issues open requesting a custom header, but that seemed like more than I needed. A custom month component works well here.

I ran `npm run lint` and `npm run test`.