### PR TITLE
Updateing index.js

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -135,7 +135,7 @@ export default class AgendaView extends Component {
   }
 
   setScrollPadPosition(y, animated) {
-    this.scrollPad.getNode().scrollTo({x: 0, y, animated});
+    this.scrollPad.scrollTo({x: 0, y, animated});
   }
 
   onScrollPadLayout() {


### PR DESCRIPTION
Removing getNode() to Support RN 62.0. This fixes warning "Calling `getNode()` on the ref of an Animated component is no longer necessary. You can now directly use the ref instead"