### PR TITLE
Update style props for week day names container

### DIFF
--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -191,7 +191,7 @@ class WeekCalendar extends Component {
     return (
       <View testID={this.props.testID} style={[allowShadow && this.style.containerShadow, !hideDayNames && {paddingBottom: 6}]}>
         {!hideDayNames &&
-          <View style={[this.style.week, {marginTop: 12, marginBottom: -2}]}>
+          <View style={[{marginTop: 12, marginBottom: -2},this.style.week]}>
             {/* {this.props.weekNumbers && <Text allowFontScaling={false} style={this.style.dayHeader}></Text>} */}
             {weekDaysNames.map((day, idx) => (
               <Text 


### PR DESCRIPTION
Currently, we're not able to override marginTop and marginBottom properties