### PR TITLE
Add getDayState to Calendar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ LocaleConfig.defaultLocale = 'fr';
   // Disable right arrow. Default = false
   disableArrowRight={true},
   // Handler which gets executed when determining the day state
-  getDayState={day => "disabled"}
+  getDayState={(day, state) => "disabled"}
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ LocaleConfig.defaultLocale = 'fr';
   disableArrowLeft={true}
   // Disable right arrow. Default = false
   disableArrowRight={true},
-  // Handle which gets executed when determining the day state
-  getDayState: PropTypes.func
+  // Handler which gets executed when determining the day state
+  getDayState={day => "disabled"}
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ LocaleConfig.defaultLocale = 'fr';
   // Disable left arrow. Default = false
   disableArrowLeft={true}
   // Disable right arrow. Default = false
-  disableArrowRight={true}
+  disableArrowRight={true},
+  // Handle which gets executed when determining the day state
+  getDayState: PropTypes.func
 />
 ```
 

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -85,7 +85,7 @@ class Calendar extends Component {
     headerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     /** Provide aria-level for calendar heading for proper accessibility when used with web (react-native-web) */
     webAriaLevel: PropTypes.number,
-    /** Handler which gets executed when determining the day state */
+    /** Handler which gets executed to override the day state */
     getDayState: PropTypes.func
   };
 
@@ -164,18 +164,16 @@ class Calendar extends Component {
     const minDate = parseDate(this.props.minDate);
     const maxDate = parseDate(this.props.maxDate);
     let state = '';
-    if (this.props.getDayState) {
-      state = this.props.getDayState(day);
-    } else {
-      if (this.props.disabledByDefault) {
-        state = 'disabled';
-      } else if ((minDate && !dateutils.isGTE(day, minDate)) || (maxDate && !dateutils.isLTE(day, maxDate))) {
-        state = 'disabled';
-      } else if (!dateutils.sameMonth(day, this.state.currentMonth)) {
-        state = 'disabled';
-      } else if (dateutils.sameDate(day, XDate())) {
-        state = 'today';
-      }
+    if (this.props.disabledByDefault) {
+      state = 'disabled';
+    } else if ((minDate && !dateutils.isGTE(day, minDate)) || (maxDate && !dateutils.isLTE(day, maxDate))) {
+      state = 'disabled';
+    } else if (!dateutils.sameMonth(day, this.state.currentMonth)) {
+      state = 'disabled';
+    } else if (dateutils.sameDate(day, XDate())) {
+      state = 'today';
+    } else if (this.props.getDayState) {
+      state = this.props.getDayState(day, state);
     }
 
     if (!dateutils.sameMonth(day, this.state.currentMonth) && this.props.hideExtraDays) {

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -165,7 +165,7 @@ class Calendar extends Component {
     const maxDate = parseDate(this.props.maxDate);
     let state = '';
     if (this.props.getDayState) {
-      state = this.props.getDayState()
+      state = this.props.getDayState(day)
     } else {
       if (this.props.disabledByDefault) {
         state = 'disabled';

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -85,7 +85,7 @@ class Calendar extends Component {
     headerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     /** Provide aria-level for calendar heading for proper accessibility when used with web (react-native-web) */
     webAriaLevel: PropTypes.number,
-    // Handle which gets executed when determining the day state
+    /** Handler which gets executed when determining the day state */
     getDayState: PropTypes.func
   };
 

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -165,7 +165,7 @@ class Calendar extends Component {
     const maxDate = parseDate(this.props.maxDate);
     let state = '';
     if (this.props.getDayState) {
-      state = this.props.getDayState(day)
+      state = this.props.getDayState(day);
     } else {
       if (this.props.disabledByDefault) {
         state = 'disabled';

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -84,7 +84,9 @@ class Calendar extends Component {
     /** Style passed to the header */
     headerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     /** Provide aria-level for calendar heading for proper accessibility when used with web (react-native-web) */
-    webAriaLevel: PropTypes.number
+    webAriaLevel: PropTypes.number,
+    // Handle which gets executed when determining the day state
+    getDayState: PropTypes.func
   };
 
   constructor(props) {
@@ -162,14 +164,18 @@ class Calendar extends Component {
     const minDate = parseDate(this.props.minDate);
     const maxDate = parseDate(this.props.maxDate);
     let state = '';
-    if (this.props.disabledByDefault) {
-      state = 'disabled';
-    } else if ((minDate && !dateutils.isGTE(day, minDate)) || (maxDate && !dateutils.isLTE(day, maxDate))) {
-      state = 'disabled';
-    } else if (!dateutils.sameMonth(day, this.state.currentMonth)) {
-      state = 'disabled';
-    } else if (dateutils.sameDate(day, XDate())) {
-      state = 'today';
+    if (this.props.getDayState) {
+      state = this.props.getDayState()
+    } else {
+      if (this.props.disabledByDefault) {
+        state = 'disabled';
+      } else if ((minDate && !dateutils.isGTE(day, minDate)) || (maxDate && !dateutils.isLTE(day, maxDate))) {
+        state = 'disabled';
+      } else if (!dateutils.sameMonth(day, this.state.currentMonth)) {
+        state = 'disabled';
+      } else if (dateutils.sameDate(day, XDate())) {
+        state = 'today';
+      }
     }
 
     if (!dateutils.sameMonth(day, this.state.currentMonth) && this.props.hideExtraDays) {


### PR DESCRIPTION
Add the `getDayState` prop to be able to override the native logic that determines the state of a day component. This would allow one to disable particular days of the week.