### PR TITLE
Customize disable days

### DIFF
--- a/example/src/screens/calendars.js
+++ b/example/src/screens/calendars.js
@@ -73,6 +73,7 @@ export default class CalendarsScreen extends Component {
           theme={{
             calendarBackground: '#333248',
             textSectionTitleColor: 'white',
+            textSectionTitleDisabledColor: 'gray',
             dayTextColor: 'red',
             todayTextColor: 'white',
             selectedDayTextColor: 'white',
@@ -89,6 +90,7 @@ export default class CalendarsScreen extends Component {
               }
             }
           }}
+          disabledDaysIndexes={[0, 6]}
           markedDates={{
             '2012-05-17': {disabled: true},
             '2012-05-08': {textColor: 'pink'},

--- a/example/src/screens/calendars.js
+++ b/example/src/screens/calendars.js
@@ -102,6 +102,24 @@ export default class CalendarsScreen extends Component {
           }}
         />
 
+        <Text style={styles.text}>Calendar with period marking and dot marking</Text>
+        <Calendar
+          current={'2012-05-16'}
+          minDate={'2012-05-01'}
+          markingType={'period'}
+          markedDates={{
+            '2012-05-15': {marked: true, dotColor: '#50cebb'},
+            '2012-05-16': {marked: true, dotColor: '#50cebb'},
+            '2012-05-20': {startingDay: true, color: '#50cebb', textColor: 'white'},
+            '2012-05-21': {color: '#70d7c7', textColor: 'white'},
+            '2012-05-22': {color: '#70d7c7', textColor: 'white'},
+            '2012-05-23': {color: '#70d7c7', textColor: 'white', marked: true, dotColor: 'white'},
+            '2012-05-24': {color: '#70d7c7', textColor: 'white'},
+            '2012-05-25': {color: '#70d7c7', textColor: 'white'},
+            '2012-05-26': {endingDay: true, color: '#50cebb', textColor: 'white'}
+          }}
+        />
+
         <Text style={styles.text}>Calendar with multi-dot marking</Text>
         <Calendar
           style={styles.calendar}
@@ -111,7 +129,7 @@ export default class CalendarsScreen extends Component {
             '2012-05-08': {
               selected: true,
               dots: [
-                {key: 'vacation', color: 'blue', selectedDotColor: 'white'},
+                {key: 'vacation', color: 'blue', selectedDotColor: 'red'},
                 {key: 'massage', color: 'red', selectedDotColor: 'white'}
               ]
             },

--- a/src/calendar/day/basic/index.js
+++ b/src/calendar/day/basic/index.js
@@ -1,8 +1,8 @@
 import React, {Component} from 'react';
-import {View, TouchableOpacity, Text} from 'react-native';
+import {TouchableOpacity, Text} from 'react-native';
 import PropTypes from 'prop-types';
 import {shouldUpdate} from '../../../component-updater';
-
+import Dot from '../../dot';
 import styleConstructor from './style';
 
 
@@ -22,7 +22,6 @@ class Day extends Component {
 
   constructor(props) {
     super(props);
-
     this.style = styleConstructor(props.theme);
 
     this.onDayPress = this.onDayPress.bind(this);
@@ -41,9 +40,9 @@ class Day extends Component {
   }
 
   render() {
+    const {theme} = this.props;
     const containerStyle = [this.style.base];
     const textStyle = [this.style.text];
-    const dotStyle = [this.style.dot];
 
     let marking = this.props.marking || {};
     if (marking && marking.constructor === Array && marking.length) {
@@ -53,26 +52,16 @@ class Day extends Component {
     }
 
     const isDisabled = typeof marking.disabled !== 'undefined' ? marking.disabled : this.props.state === 'disabled';
+    const isToday = this.props.state === 'today';
 
-    let dot;
-    if (marking.marked) {
-      dotStyle.push(this.style.visibleDot);
-      if (isDisabled) {
-        dotStyle.push(this.style.disabledDot);
-      }
-      if (marking.dotColor) {
-        dotStyle.push({backgroundColor: marking.dotColor});
-      }
-      dot = (<View style={dotStyle}/>);
-    }
+    const {marked, dotColor, selected, selectedColor} = marking;
 
-    if (marking.selected) {
+    if (selected) {
       containerStyle.push(this.style.selected);
-      dotStyle.push(this.style.selectedDot);
       textStyle.push(this.style.selectedText);
 
-      if (marking.selectedColor) {
-        containerStyle.push({backgroundColor: marking.selectedColor});
+      if (selectedColor) {
+        containerStyle.push({backgroundColor: selectedColor});
       }
 
       if (marking.selectedTextColor) {
@@ -81,10 +70,9 @@ class Day extends Component {
 
     } else if (isDisabled) {
       textStyle.push(this.style.disabledText);
-    } else if (this.props.state === 'today') {
+    } else if (isToday) {
       containerStyle.push(this.style.today);
       textStyle.push(this.style.todayText);
-      dotStyle.push(this.style.todayDot);
     }
 
     return (
@@ -99,7 +87,14 @@ class Day extends Component {
         accessibilityLabel={this.props.accessibilityLabel}
       >
         <Text allowFontScaling={false} style={textStyle}>{String(this.props.children)}</Text>
-        {dot}
+        <Dot
+          theme={theme}
+          isMarked={marked}
+          dotColor={dotColor}
+          isSelected={selected}
+          isToday={isToday}
+          isDisabled={isDisabled}
+        />
       </TouchableOpacity>
     );
   }

--- a/src/calendar/day/period/index.js
+++ b/src/calendar/day/period/index.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {TouchableWithoutFeedback, Text, View} from 'react-native';
 import {shouldUpdate} from '../../../component-updater';
-
+import Dot from '../../dot';
 import * as defaultStyle from '../../../style';
 import styleConstructor from './style';
 
 
 class Day extends Component {
   static displayName = 'IGNORE';
-  
+
   static propTypes = {
     // TODO: selected + disabled props should be removed
     state: PropTypes.oneOf(['selected', 'disabled', 'today', '']),
@@ -25,10 +25,10 @@ class Day extends Component {
 
   constructor(props) {
     super(props);
-    
+
     this.theme = {...defaultStyle, ...(props.theme || {})};
     this.style = styleConstructor(props.theme);
-    
+
     this.markingStyle = this.getDrawingStyle(props.marking || []);
     this.onDayPress = this.onDayPress.bind(this);
     this.onDayLongPress = this.onDayLongPress.bind(this);
@@ -189,6 +189,8 @@ class Day extends Component {
       );
     }
 
+    const {marking: {marked, dotColor}, theme} = this.props;
+
     return (
       <TouchableWithoutFeedback
         testID={this.props.testID}
@@ -203,6 +205,11 @@ class Day extends Component {
           {fillers}
           <View style={containerStyle}>
             <Text allowFontScaling={false} style={textStyle}>{String(this.props.children)}</Text>
+            <Dot
+              theme={theme}
+              isMarked={marked}
+              dotColor={dotColor}
+            />
           </View>
         </View>
       </TouchableWithoutFeedback>

--- a/src/calendar/dot/index.js
+++ b/src/calendar/dot/index.js
@@ -24,7 +24,7 @@ const Dot = ({theme, isMarked, isDisabled, dotColor, isToday, isSelected}) => {
     }
 
     if (isToday) {
-      dotStyle.push(this.style.todayDot);
+      dotStyle.push(style.todayDot);
     }
   }
 

--- a/src/calendar/dot/index.js
+++ b/src/calendar/dot/index.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import {View} from 'react-native';
+import styleConstructor from './style';
+import PropTypes from 'prop-types';
+
+const Dot = ({theme, isMarked, isDisabled, dotColor, isToday, isSelected}) => {
+
+  const style = styleConstructor(theme);
+  const dotStyle = [style.dot];
+
+  if (isMarked) {
+    dotStyle.push(style.visibleDot);
+
+    if (isDisabled) {
+      dotStyle.push(style.disabledDot);
+    }
+
+    if (isSelected) {
+      dotStyle.push(style.selectedDot);
+    }
+
+    if (dotColor) {
+      dotStyle.push({backgroundColor: dotColor});
+    }
+
+    if (isToday) {
+      dotStyle.push(this.style.todayDot);
+    }
+  }
+
+  return (
+    <View style={dotStyle}/>
+  );
+};
+
+export default Dot;
+
+Dot.propTypes = {
+  theme: PropTypes.object,
+  isMarked: PropTypes.bool,
+  dotColor: PropTypes.string,
+  isSelected: PropTypes.bool,
+  isToday: PropTypes.bool,
+  isDisabled: PropTypes.bool
+};

--- a/src/calendar/dot/style.js
+++ b/src/calendar/dot/style.js
@@ -1,0 +1,32 @@
+import {StyleSheet} from 'react-native';
+import * as defaultStyle from '../../style';
+
+const STYLESHEET_ID = 'stylesheet.dot';
+
+export default function styleConstructor(theme={}) {
+  const appStyle = {...defaultStyle, ...theme};
+  return StyleSheet.create({
+    dot: {
+      width: 4,
+      height: 4,
+      marginTop: 1,
+      borderRadius: 2,
+      opacity: 0,
+      ...appStyle.dotStyle
+    },
+    visibleDot: {
+      opacity: 1,
+      backgroundColor: appStyle.dotColor
+    },
+    selectedDot: {
+      backgroundColor: appStyle.selectedDotColor
+    },
+    disabledDot: {
+      backgroundColor: appStyle.disabledDotColor || appStyle.dotColor
+    },
+    todayDot: {
+      backgroundColor: appStyle.todayDotColor || appStyle.dotColor
+    },
+    ...(theme[STYLESHEET_ID] || {})
+  });
+}

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -105,7 +105,7 @@ class CalendarHeader extends Component {
       const dayStyle = [this.style.dayHeader];
 
       if (!_.isEmpty(disabledDaysIndexes)) {
-        if (disabledDaysIndexes.includes(idx)) {
+        if (_.includes(disabledDaysIndexes, idx)) {
           dayStyle.push(this.style.disabledDayHeader);
         }
       }

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import styleConstructor from './style';
 import {weekDayNames} from '../../dateutils';
 import {CHANGE_MONTH_LEFT_ARROW, CHANGE_MONTH_RIGHT_ARROW, HEADER_MONTH_NAME} from '../../testIDs';
+import _ from 'lodash';
 
 
 class CalendarHeader extends Component {
@@ -102,7 +103,8 @@ class CalendarHeader extends Component {
     const {disabledDaysIndexes} = this.props;
     return weekDaysNames.map((day, idx) => {
       const dayStyle = [this.style.dayHeader];
-      if (disabledDaysIndexes && disabledDaysIndexes.length) {
+
+      if (!_.isEmpty(disabledDaysIndexes)) {
         if (disabledDaysIndexes.includes(idx)) {
           dayStyle.push(this.style.disabledDayHeader);
         }

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -25,7 +25,8 @@ class CalendarHeader extends Component {
     onPressArrowRight: PropTypes.func,
     disableArrowLeft: PropTypes.bool,
     disableArrowRight: PropTypes.bool,
-    webAriaLevel: PropTypes.number
+    webAriaLevel: PropTypes.number,
+    disabledDaysIndexes: PropTypes.arrayOf(PropTypes.number)
   };
 
   static defaultProps = {
@@ -97,6 +98,29 @@ class CalendarHeader extends Component {
     return this.addMonth();
   }
 
+  renderWeekDays = (weekDaysNames) => {
+    const {disabledDaysIndexes} = this.props;
+    return weekDaysNames.map((day, idx) => {
+      const dayStyle = [this.style.dayHeader];
+      if (disabledDaysIndexes && disabledDaysIndexes.length) {
+        if (disabledDaysIndexes.includes(idx)) {
+          dayStyle.push(this.style.disabledDayHeader);
+        }
+      }
+      return (
+        <Text
+          allowFontScaling={false}
+          key={idx}
+          style={dayStyle}
+          numberOfLines={1}
+          accessibilityLabel={''}
+        >
+          {day}
+        </Text>
+      );
+    });
+  }
+
   render() {
     let leftArrow = <View/>;
     let rightArrow = <View/>;
@@ -148,11 +172,11 @@ class CalendarHeader extends Component {
     return (
       <View
         testID={testID}
-        style={this.props.style} 
+        style={this.props.style}
         accessible
         accessibilityRole={'adjustable'}
         accessibilityActions={[
-          {name: 'increment', label: 'increment'}, 
+          {name: 'increment', label: 'increment'},
           {name: 'decrement', label: 'decrement'}
         ]}
         onAccessibilityAction={this.onAccessibilityAction}
@@ -176,22 +200,10 @@ class CalendarHeader extends Component {
         </View>
         {!this.props.hideDayNames &&
           <View style={this.style.week}>
-            {this.props.weekNumbers && 
+            {this.props.weekNumbers &&
               <Text allowFontScaling={false} style={this.style.dayHeader}></Text>
             }
-            {weekDaysNames.map((day, idx) => (
-              <Text
-                allowFontScaling={false}
-                key={idx}
-                style={this.style.dayHeader}
-                numberOfLines={1}
-                accessibilityLabel={''}
-                // accessible={false} // not working
-                // importantForAccessibility='no'
-              >
-                {day}
-              </Text>
-            ))}
+            {this.renderWeekDays(weekDaysNames)}
           </View>
         }
       </View>

--- a/src/calendar/header/style.js
+++ b/src/calendar/header/style.js
@@ -46,6 +46,9 @@ export default function(theme={}) {
       fontWeight: appStyle.textDayHeaderFontWeight,
       color: appStyle.textSectionTitleColor
     },
+    disabledDayHeader: {
+      color: appStyle.textSectionTitleDisabledColor
+    },
     ...(theme[STYLESHEET_ID] || {})
   });
 }

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -318,6 +318,7 @@ class Calendar extends Component {
           webAriaLevel={this.props.webAriaLevel}
           disableArrowLeft={this.props.disableArrowLeft}
           disableArrowRight={this.props.disableArrowRight}
+          disabledDaysIndexes={this.props.disabledDaysIndexes}
         />
         <View style={this.style.monthView}>{weeks}</View>
       </View>);

--- a/src/style.js
+++ b/src/style.js
@@ -32,6 +32,7 @@ export const arrowStyle = undefined;
 
 export const calendarBackground = foregroundColor;
 export const textSectionTitleColor = '#b6c1cd';
+export const textSectionTitleDisabledColor = '#d9e1e8';
 export const selectedDayBackgroundColor = textLinkColor;
 export const selectedDayTextColor = foregroundColor;
 export const todayBackgroundColor = undefined;


### PR DESCRIPTION
Adding the option to customize style for dates.
You can pass `disabledDaysIndexes` array and customize the color with `textSectionTitleDisabledColor` using theme prop.

Please refer to:
https://github.com/wix/react-native-calendars/issues/1153
