### PR TITLE
Decrease hit slop for arrows in calendar header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,3 +307,6 @@
 
 ## [1.292.0] - 2020-6-10
 - New Feature - Show should six weeks in the calendar by passing showSixWeeks
+
+## [1.293.0] - 2020-7-6
+- Added new prop for custom hitSlop for calendar header

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -4,6 +4,8 @@ Please make our job easier by filling this template out to completion. If you're
 
 1-2 sentences describing the problem you're having or the feature you'd like to request
 
+>The hitSlop was fixed to 20, this was too rigid. I faced issues where arrow buttons were overlaying any other button above the calendar header. Added a property to *headerArrowsHitSlop* so that it can be set to 0 (or any other custom value)
+
 ## Expected Behavior
 
 What action did you perform, and what did you expect to happen?
@@ -23,7 +25,9 @@ Error text goes here!
 Please run these commands in the project folder and fill in their results:
 
 * `npm ls react-native-calendars`:
+>└── (empty)
 * `npm ls react-native`:
+>└── react-native@0.62.2 
 
 Also specify:
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ LocaleConfig.defaultLocale = 'fr';
   disableAllTouchEventsForDisabledDays={true}
   /** Replace default month and year title with custom one. the function receive a date as parameter. */
   renderHeader={(date) => {/*Return JSX*/}}
+  // Custom hit slop for arrows (left / right) in calendar header. Default = 20
+  headerArrowsHitSlop={0}
 />
 ```
 

--- a/example/src/screens/index.js
+++ b/example/src/screens/index.js
@@ -1,12 +1,11 @@
 import {Navigation} from 'react-native-navigation';
 
-import MenuScreen from './menu';
-import CalendarsScreen from './calendars';
 import AgendaScreen from './agenda';
+import CalendarsScreen from './calendars';
 import CalendarsList from './calendarsList';
-import HorizontalCalendarList from './horizontalCalendarList';
 import ExpandableCalendar from './expandableCalendar';
-
+import HorizontalCalendarList from './horizontalCalendarList';
+import MenuScreen from './menu';
 
 export function registerScreens() {
   Navigation.registerComponent('Menu', () => MenuScreen);
@@ -15,4 +14,5 @@ export function registerScreens() {
   Navigation.registerComponent('CalendarsList', () => CalendarsList);
   Navigation.registerComponent('HorizontalCalendarList', () => HorizontalCalendarList);
   Navigation.registerComponent('ExpandableCalendar', () => ExpandableCalendar);
+
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -241,7 +241,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - ReactNativeNavigation (6.7.1):
+  - ReactNativeNavigation (6.8.0):
     - React
     - React-RCTImage
     - React-RCTText
@@ -362,9 +362,9 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  ReactNativeNavigation: dd4a4a76d2deb5130d809ec4a6f7f2b182fa1a11
+  ReactNativeNavigation: 2d10f0059506c69795683f525369baa7d0e9536c
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
 
 PODFILE CHECKSUM: 736ae5d97366cafe64d8f42d3217dbe89c451791
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.9.1

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -1,16 +1,15 @@
-import React, {Component} from 'react';
-import {FlatList, Platform, Dimensions, ActivityIndicator, View} from 'react-native';
 import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import {ActivityIndicator, Dimensions, FlatList, Platform, View} from 'react-native';
 import XDate from 'xdate';
 
-import {xdateToData, parseDate} from '../interface';
-import styleConstructor from './style';
-import dateutils from '../dateutils';
 import Calendar from '../calendar';
-import CalendarListItem from './item';
 import CalendarHeader from '../calendar/header/index';
+import dateutils from '../dateutils';
+import {parseDate, xdateToData} from '../interface';
 import {STATIC_HEADER} from '../testIDs';
-
+import CalendarListItem from './item';
+import styleConstructor from './style';
 
 const {width} = Dimensions.get('window');
 
@@ -284,6 +283,7 @@ class CalendarList extends Component {
           weekNumbers={this.props.showWeekNumbers}
           onPressArrowLeft={this.props.onPressArrowLeft}
           onPressArrowRight={this.props.onPressArrowRight}
+          hitSlop={this.props.hitSlop}
           testID={STATIC_HEADER}
           accessibilityElementsHidden={true} // iOS
           importantForAccessibility={'no-hide-descendants'} // Android

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -155,7 +155,7 @@ class CalendarHeader extends Component {
           onPress={this.onPressLeft}
           disabled={this.props.disableArrowLeft}
           style={this.style.arrow}
-          hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
+          hitSlop={{left: 4, right: 4, top: 4, bottom: 4}}
           testID={testID ? `${CHANGE_MONTH_LEFT_ARROW}-${testID}`: CHANGE_MONTH_LEFT_ARROW}
         >
           {this.props.renderArrow
@@ -171,7 +171,7 @@ class CalendarHeader extends Component {
           onPress={this.onPressRight}
           disabled={this.props.disableArrowRight}
           style={this.style.arrow}
-          hitSlop={{left: 20, right: 20, top: 20, bottom: 20}}
+          hitSlop={{left: 4, right: 4, top: 4, bottom: 4}}
           testID={testID ? `${CHANGE_MONTH_RIGHT_ARROW}-${testID}`: CHANGE_MONTH_RIGHT_ARROW}
         >
           {this.props.renderArrow

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -1,13 +1,17 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React, {Component, Fragment} from 'react';
 import {ActivityIndicator, Platform} from 'react-native';
-import {View, Text, TouchableOpacity, Image} from 'react-native';
+import {Image, Text, TouchableOpacity, View} from 'react-native';
 import XDate from 'xdate';
-import PropTypes from 'prop-types';
-import styleConstructor from './style';
-import {weekDayNames} from '../../dateutils';
-import {CHANGE_MONTH_LEFT_ARROW, CHANGE_MONTH_RIGHT_ARROW, HEADER_MONTH_NAME} from '../../testIDs';
-import _ from 'lodash';
 
+import {weekDayNames} from '../../dateutils';
+import {
+  CHANGE_MONTH_LEFT_ARROW,
+  CHANGE_MONTH_RIGHT_ARROW,
+  HEADER_MONTH_NAME
+} from '../../testIDs';
+import styleConstructor from './style';
 
 class CalendarHeader extends Component {
   static displayName = 'IGNORE';
@@ -28,12 +32,14 @@ class CalendarHeader extends Component {
     disableArrowRight: PropTypes.bool,
     webAriaLevel: PropTypes.number,
     disabledDaysIndexes: PropTypes.arrayOf(PropTypes.number),
-    renderHeader: PropTypes.any
+    renderHeader: PropTypes.any,
+    hitSlop: PropTypes.number
   };
 
   static defaultProps = {
     monthFormat: 'MMMM yyyy',
-    webAriaLevel: 1
+    webAriaLevel: 1,
+    hitSlop: 20
   };
 
   constructor(props) {
@@ -44,15 +50,18 @@ class CalendarHeader extends Component {
   addMonth = () => {
     const {addMonth} = this.props;
     addMonth(1);
-  }
+  };
 
   subtractMonth = () => {
     const {addMonth} = this.props;
     addMonth(-1);
-  }
+  };
 
   shouldComponentUpdate(nextProps) {
-    if (nextProps.month.toString('yyyy MM') !== this.props.month.toString('yyyy MM')) {
+    if (
+      nextProps.month.toString('yyyy MM') !==
+      this.props.month.toString('yyyy MM')
+    ) {
       return true;
     }
     if (nextProps.showIndicator !== this.props.showIndicator) {
@@ -88,7 +97,7 @@ class CalendarHeader extends Component {
       return onPressArrowLeft(this.subtractMonth, month);
     }
     return this.subtractMonth();
-  }
+  };
 
   onPressRight = () => {
     const {onPressArrowRight, month} = this.props;
@@ -96,7 +105,7 @@ class CalendarHeader extends Component {
       return onPressArrowRight(this.addMonth, month);
     }
     return this.addMonth();
-  }
+  };
 
   renderWeekDays = (weekDaysNames) => {
     const {disabledDaysIndexes} = this.props;
@@ -113,17 +122,17 @@ class CalendarHeader extends Component {
           key={idx}
           style={dayStyle}
           numberOfLines={1}
-          accessibilityLabel={''}
-        >
+          accessibilityLabel={''}>
           {day}
         </Text>
       );
     });
-  }
+  };
 
   renderHeader = () => {
     const {renderHeader, month, monthFormat, testID} = this.props;
-    const webProps = Platform.OS === 'web' ? {'aria-level': this.props.webAriaLevel} : {};
+    const webProps =
+      Platform.OS === 'web' ? {'aria-level': this.props.webAriaLevel} : {};
 
     if (renderHeader) {
       return renderHeader(month);
@@ -134,9 +143,8 @@ class CalendarHeader extends Component {
         <Text
           allowFontScaling={false}
           style={this.style.monthText}
-          testID={testID ? `${HEADER_MONTH_NAME}-${testID}`: HEADER_MONTH_NAME}
-          {...webProps}
-        >
+          testID={testID ? `${HEADER_MONTH_NAME}-${testID}` : HEADER_MONTH_NAME}
+          {...webProps}>
           {month.toString(monthFormat)}
         </Text>
       </Fragment>
@@ -155,15 +163,29 @@ class CalendarHeader extends Component {
           onPress={this.onPressLeft}
           disabled={this.props.disableArrowLeft}
           style={this.style.arrow}
-          hitSlop={{left: 4, right: 4, top: 4, bottom: 4}}
-          testID={testID ? `${CHANGE_MONTH_LEFT_ARROW}-${testID}`: CHANGE_MONTH_LEFT_ARROW}
-        >
-          {this.props.renderArrow
-            ? this.props.renderArrow('left')
-            : <Image
+          hitSlop={{
+            left: this.props.hitSlop,
+            right: this.props.hitSlop,
+            top: this.props.hitSlop,
+            bottom: this.props.hitSlop
+          }}
+          testID={
+            testID
+              ? `${CHANGE_MONTH_LEFT_ARROW}-${testID}`
+              : CHANGE_MONTH_LEFT_ARROW
+          }>
+          {this.props.renderArrow ? (
+            this.props.renderArrow('left')
+          ) : (
+            <Image
               source={require('../img/previous.png')}
-              style={this.props.disableArrowLeft ? this.style.disabledArrowImage : this.style.arrowImage}
-            />}
+              style={
+                this.props.disableArrowLeft
+                  ? this.style.disabledArrowImage
+                  : this.style.arrowImage
+              }
+            />
+          )}
         </TouchableOpacity>
       );
       rightArrow = (
@@ -171,22 +193,40 @@ class CalendarHeader extends Component {
           onPress={this.onPressRight}
           disabled={this.props.disableArrowRight}
           style={this.style.arrow}
-          hitSlop={{left: 4, right: 4, top: 4, bottom: 4}}
-          testID={testID ? `${CHANGE_MONTH_RIGHT_ARROW}-${testID}`: CHANGE_MONTH_RIGHT_ARROW}
-        >
-          {this.props.renderArrow
-            ? this.props.renderArrow('right')
-            : <Image
+          hitSlop={{
+            left: this.props.hitSlop,
+            right: this.props.hitSlop,
+            top: this.props.hitSlop,
+            bottom: this.props.hitSlop
+          }}
+          testID={
+            testID
+              ? `${CHANGE_MONTH_RIGHT_ARROW}-${testID}`
+              : CHANGE_MONTH_RIGHT_ARROW
+          }>
+          {this.props.renderArrow ? (
+            this.props.renderArrow('right')
+          ) : (
+            <Image
               source={require('../img/next.png')}
-              style={this.props.disableArrowRight ? this.style.disabledArrowImage : this.style.arrowImage}
-            />}
+              style={
+                this.props.disableArrowRight
+                  ? this.style.disabledArrowImage
+                  : this.style.arrowImage
+              }
+            />
+          )}
         </TouchableOpacity>
       );
     }
 
     let indicator;
     if (this.props.showIndicator) {
-      indicator = <ActivityIndicator color={this.props.theme && this.props.theme.indicatorColor}/>;
+      indicator = (
+        <ActivityIndicator
+          color={this.props.theme && this.props.theme.indicatorColor}
+        />
+      );
     }
 
     return (
@@ -211,19 +251,21 @@ class CalendarHeader extends Component {
           </View>
           {rightArrow}
         </View>
-        {!this.props.hideDayNames &&
+        {!this.props.hideDayNames && (
           <View style={this.style.week}>
-            {this.props.weekNumbers &&
-              <Text allowFontScaling={false} style={this.style.dayHeader}></Text>
-            }
+            {this.props.weekNumbers && (
+              <Text
+                allowFontScaling={false}
+                style={this.style.dayHeader}></Text>
+            )}
             {this.renderWeekDays(weekDaysNames)}
           </View>
-        }
+        )}
       </View>
     );
   }
 
-  onAccessibilityAction = event => {
+  onAccessibilityAction = (event) => {
     switch (event.nativeEvent.actionName) {
     case 'decrement':
       this.onPressLeft();
@@ -234,7 +276,7 @@ class CalendarHeader extends Component {
     default:
       break;
     }
-  }
+  };
 }
 
 export default CalendarHeader;

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -1,21 +1,20 @@
+import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import * as ReactNative from 'react-native';
-import PropTypes from 'prop-types';
+import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
 import XDate from 'xdate';
 
 import dateutils from '../dateutils';
-import {xdateToData, parseDate} from '../interface';
-import styleConstructor from './style';
+import {parseDate, xdateToData} from '../interface';
+import {SELECT_DATE_SLOT} from '../testIDs';
 import Day from './day/basic';
-import UnitDay from './day/period';
+import SingleDay from './day/custom';
 import MultiDotDay from './day/multi-dot';
 import MultiPeriodDay from './day/multi-period';
-import SingleDay from './day/custom';
+import UnitDay from './day/period';
 import CalendarHeader from './header';
+import styleConstructor from './style';
 import shouldComponentUpdate from './updater';
-import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
-import {SELECT_DATE_SLOT} from '../testIDs';
-
 
 //Fallback when RN version is < 0.44
 const {View, ViewPropTypes} = ReactNative;
@@ -94,7 +93,9 @@ class Calendar extends Component {
     /** Disable all touch events for disabled days. can be override with disableTouchEvent in markedDates*/
     disableAllTouchEventsForDisabledDays: PropTypes.bool,
     /** Replace default month and year title with custom one. the function receive a date as parameter. */
-    renderHeader: PropTypes.any
+    renderHeader: PropTypes.any,
+    /** CalendarHeader left right arrows - how many px the Touchable is extended in all directions (default is 20) */
+    headerArrowsHitSlop: PropTypes.number
   };
 
   constructor(props) {
@@ -381,6 +382,7 @@ class Calendar extends Component {
             disableArrowRight={this.props.disableArrowRight}
             disabledDaysIndexes={this.props.disabledDaysIndexes}
             renderHeader={this.props.renderHeader}
+            hitSlop={this.props.headerArrowsHitSlop}
           />
           <View style={this.style.monthView}>{weeks}</View>
         </View>


### PR DESCRIPTION
Smaller hit slop, 20 is way too much and results in overlapping any other buttons that in the close proximity of calendar header