### PR TITLE
Fix CalendarList scroll bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ LocaleConfig.defaultLocale = 'fr';
   disableAllTouchEventsForDisabledDays={true}
   /** Replace default month and year title with custom one. the function receive a date as parameter. */
   renderHeader={(date) => {/*Return JSX*/}}
+  // (Advanced) Disable calendar swipe gesture handling. Default: false
+  disableCalendarGestureRecognizer={false}
 />
 ```
 

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -69,9 +69,9 @@ class CalendarList extends Component {
 
   constructor(props) {
     super(props);
-    
+
     this.style = styleConstructor(props.theme);
-    
+
     this.viewabilityConfig = {
       itemVisiblePercentThreshold: 20
     };
@@ -79,7 +79,7 @@ class CalendarList extends Component {
     const rows = [];
     const texts = [];
     const date = parseDate(props.current) || XDate();
-    
+
     for (let i = 0; i <= this.props.pastScrollRange + this.props.futureScrollRange; i++) {
       const rangeDate = date.clone().addMonths(i - this.props.pastScrollRange, true);
       const rangeDateStr = rangeDate.toString('MMM yyyy');
@@ -119,7 +119,7 @@ class CalendarList extends Component {
     const diffMonths = Math.round(this.state.openDate.clone().setDate(1).diffMonths(day.clone().setDate(1)));
     const size = this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight;
     let scrollAmount = (size * this.props.pastScrollRange) + (diffMonths * size) + (offset || 0);
-    
+
     if (!this.props.horizontal) {
       let week = 0;
       const days = dateutils.page(day, this.props.firstDay);
@@ -147,14 +147,14 @@ class CalendarList extends Component {
   UNSAFE_componentWillReceiveProps(props) {
     const current = parseDate(this.props.current);
     const nextCurrent = parseDate(props.current);
-    
+
     if (nextCurrent && current && nextCurrent.getTime() !== current.getTime()) {
       this.scrollToMonth(nextCurrent);
     }
 
     const rowclone = this.state.rows;
     const newrows = [];
-    
+
     for (let i = 0; i < rowclone.length; i++) {
       let val = this.state.texts[i];
       if (rowclone[i].getTime) {
@@ -181,11 +181,11 @@ class CalendarList extends Component {
     const rowclone = this.state.rows;
     const newrows = [];
     const visibleMonths = [];
-    
+
     for (let i = 0; i < rowclone.length; i++) {
       let val = rowclone[i];
       const rowShouldBeRendered = rowIsCloseToViewable(i, 1);
-      
+
       if (rowShouldBeRendered && !rowclone[i].getTime) {
         val = this.state.openDate.clone().addMonths(i - this.props.pastScrollRange, true);
       } else if (!rowShouldBeRendered) {
@@ -196,7 +196,7 @@ class CalendarList extends Component {
         visibleMonths.push(xdateToData(val));
       }
     }
-    
+
     if (this.props.onVisibleMonthsChange) {
       this.props.onVisibleMonthsChange(visibleMonths);
     }
@@ -212,10 +212,10 @@ class CalendarList extends Component {
       <CalendarListItem
         testID={`${this.props.testID}_${item}`}
         scrollToMonth={this.scrollToMonth.bind(this)}
-        item={item} 
-        calendarHeight={this.props.calendarHeight} 
-        calendarWidth={this.props.horizontal ? this.props.calendarWidth : undefined} 
-        {...this.props} 
+        item={item}
+        calendarHeight={this.props.calendarHeight}
+        calendarWidth={this.props.horizontal ? this.props.calendarWidth : undefined}
+        {...this.props}
         style={this.props.calendarStyle}
       />
     );
@@ -223,7 +223,7 @@ class CalendarList extends Component {
 
   getItemLayout(data, index) {
     return {
-      length: this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight, 
+      length: this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight,
       offset: (this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight) * index, index
     };
   }
@@ -246,7 +246,7 @@ class CalendarList extends Component {
       currentMonth: day.clone()
     }, () => {
       this.scrollToMonth(this.state.currentMonth);
-      
+
       if (!doNotTriggerListeners) {
         const currMont = this.state.currentMonth.clone();
         if (this.props.onMonthChange) {
@@ -262,7 +262,7 @@ class CalendarList extends Component {
   renderStaticHeader() {
     const {staticHeader, horizontal} = this.props;
     const useStaticHeader = staticHeader && horizontal;
-    
+
     if (useStaticHeader) {
       let indicator;
       if (this.props.showIndicator) {

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -86,6 +86,7 @@ class CalendarListItem extends Component {
           accessibilityElementsHidden={this.props.accessibilityElementsHidden} // iOS
           importantForAccessibility={this.props.importantForAccessibility} // Android
           renderHeader={this.props.renderHeader}
+          disableCalendarGestureRecognizer={this.props.disableCalendarGestureRecognizer}
         />
       );
     } else {

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -96,11 +96,14 @@ class Calendar extends Component {
     /** Replace default month and year title with custom one. the function receive a date as parameter. */
     renderHeader: PropTypes.any,
     /** Enable the option to swipe between months. Default: false */
-    enableSwipeMonths: PropTypes.bool
+    enableSwipeMonths: PropTypes.bool,
+    /** Enable the option to disable calendar swipe gesture handling. Default: false */
+    disableCalendarGestureRecognizer: PropTypes.bool
   };
 
   static defaultProps = {
-    enableSwipeMonths: false
+    enableSwipeMonths: false,
+    disableCalendarGestureRecognizer: false
   };
 
   constructor(props) {
@@ -314,7 +317,8 @@ class Calendar extends Component {
 
   renderWeekNumber(weekNumber) {
     return (
-      <View style={{flex: 1, alignItems: 'center'}} key={`week-container-${weekNumber}`}>
+      <View style={{flex: 1, alignItems: 'center'}}
+        key={`week-container-${weekNumber}`}>
         <Day
           key={`week-${weekNumber}`}
           theme={this.props.theme}
@@ -361,42 +365,45 @@ class Calendar extends Component {
       }
     }
 
-    return (
-      <GestureRecognizer
-        onSwipe={(direction, state) => this.onSwipe(direction, state)}
-      >
-        <View
-          style={[this.style.container, this.props.style]}
-          accessibilityElementsHidden={this.props.accessibilityElementsHidden} // iOS
-          importantForAccessibility={this.props.importantForAccessibility} // Android
+    const coreCalendar = (<View
+      style={[this.style.container, this.props.style]}
+      accessibilityElementsHidden={this.props.accessibilityElementsHidden} // iOS
+      importantForAccessibility={this.props.importantForAccessibility} // Android
+    >
+      <CalendarHeader
+        testID={this.props.testID}
+        ref={c => this.header = c}
+        style={this.props.headerStyle}
+        theme={this.props.theme}
+        hideArrows={this.props.hideArrows}
+        month={this.state.currentMonth}
+        addMonth={this.addMonth}
+        showIndicator={indicator}
+        firstDay={this.props.firstDay}
+        showSixWeeks={this.props.showSixWeeks}
+        renderArrow={this.props.renderArrow}
+        monthFormat={this.props.monthFormat}
+        hideDayNames={this.props.hideDayNames}
+        weekNumbers={this.props.showWeekNumbers}
+        onPressArrowLeft={this.props.onPressArrowLeft}
+        onPressArrowRight={this.props.onPressArrowRight}
+        webAriaLevel={this.props.webAriaLevel}
+        disableArrowLeft={this.props.disableArrowLeft}
+        disableArrowRight={this.props.disableArrowRight}
+        disabledDaysIndexes={this.props.disabledDaysIndexes}
+        renderHeader={this.props.renderHeader}
+      />
+      <View style={this.style.monthView}>{weeks}</View>
+    </View>);
+
+    return this.props.disableCalendarGestureRecognizer ? coreCalendar :
+      (
+        <GestureRecognizer
+          onSwipe={(direction, state) => this.onSwipe(direction, state)}
         >
-          <CalendarHeader
-            testID={this.props.testID}
-            ref={c => this.header = c}
-            style={this.props.headerStyle}
-            theme={this.props.theme}
-            hideArrows={this.props.hideArrows}
-            month={this.state.currentMonth}
-            addMonth={this.addMonth}
-            showIndicator={indicator}
-            firstDay={this.props.firstDay}
-            showSixWeeks={this.props.showSixWeeks}
-            renderArrow={this.props.renderArrow}
-            monthFormat={this.props.monthFormat}
-            hideDayNames={this.props.hideDayNames}
-            weekNumbers={this.props.showWeekNumbers}
-            onPressArrowLeft={this.props.onPressArrowLeft}
-            onPressArrowRight={this.props.onPressArrowRight}
-            webAriaLevel={this.props.webAriaLevel}
-            disableArrowLeft={this.props.disableArrowLeft}
-            disableArrowRight={this.props.disableArrowRight}
-            disabledDaysIndexes={this.props.disabledDaysIndexes}
-            renderHeader={this.props.renderHeader}
-          />
-          <View style={this.style.monthView}>{weeks}</View>
-        </View>
-      </GestureRecognizer>
-    );
+          {coreCalendar}
+        </GestureRecognizer>
+      );
   }
 }
 


### PR DESCRIPTION
#### The Issue
https://www.loom.com/share/156836f07c804eadb59bef856b4b3516
Note: Each time the mouse is moving I'm clicking and trying to scroll. 

The video above details an issue trying to scroll the _CalendarList_ component. I eventually found out it was related to [react-native-swipe-gestures](https://github.com/glepur/react-native-swipe-gestures) returning a null value when swiping and causing the _Calendar_ component to hijack the gesture handling (see [null issue](https://github.com/glepur/react-native-swipe-gestures/issues/40) )

#### Proposed Solution

Below is a proposed patch that adds a new _disableCalendarGestureRecognizer_ property to the _Calendar_component. When using a "infinite" vertically scrolled _CalendarList_ there is no need for the _Calendar_ items to handle or recognize any gestures.