### PR TITLE
fix for react-native-web > 12.0

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -14,9 +14,12 @@ import {AGENDA_CALENDAR_KNOB} from '../testIDs';
 
 const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
-// Fallback when RN version is < 0.44
+//Fallback for react-native-web or when RN version is < 0.44
 const {Text, View, Dimensions, Animated, ViewPropTypes} = ReactNative;
-const viewPropTypes = ViewPropTypes || View.propTypes;
+const viewPropTypes =
+  typeof document !== 'undefined'
+    ? PropTypes.shape({style: PropTypes.object})
+    : ViewPropTypes || View.propTypes;
 
 /**
  * @description: Agenda component

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -16,10 +16,12 @@ import shouldComponentUpdate from './updater';
 import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
 import {SELECT_DATE_SLOT} from '../testIDs';
 
-
-//Fallback when RN version is < 0.44
+//Fallback for react-native-web or when RN version is < 0.44
 const {View, ViewPropTypes} = ReactNative;
-const viewPropTypes = ViewPropTypes || View.propTypes;
+const viewPropTypes =
+  typeof document !== 'undefined'
+    ? PropTypes.shape({style: PropTypes.object})
+    : ViewPropTypes || View.propTypes;
 const EmptyArray = [];
 
 /**


### PR DESCRIPTION
Hey, this is the first time making a pull request on an open-source project so please tell me if I did something wrong.

With my team, we're developing our component library using storybook and react-native, and we're using this calendar. unfortunately, I kept getting `Cannot read "style" of undefined`. After some digging, I found out that `ViewPropTypes` doesn't exist anymore in `react-native-web` since version `0.12.0` (current version: `0.13.3`), so I made this pull request in order to fix that.

I tested that it works on both mobile and web.

