### PR TITLE
fixed #915

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -63,7 +63,7 @@ class CalendarList extends Component {
     showScrollIndicator: false,
     scrollEnabled: true,
     scrollsToTop: false,
-    removeClippedSubviews: Platform.OS === 'android' ? false : true,
+    removeClippedSubviews: Platform.OS === 'android' ? true : false,
     keyExtractor: (item, index) => String(index)
   }
 


### PR DESCRIPTION
This PR fixes error on #915.
I think the default value of removeClippedSubviews are reversed.

`src/calendar-list/index.js`

```diff
-   removeClippedSubviews: Platform.OS === 'android' ? false : true,
+   removeClippedSubviews: Platform.OS === 'android' ? true : false,
```

Because default value of removeClippedSubviews are true for Android and false for iOS on react-native.

[react-native/Libraries/Lists/FlatList.js](https://github.com/facebook/react-native/blob/3c9e5f1470c91ff8a161d8e248cf0a73318b1f40/Libraries/Lists/FlatList.js#L160-L170)

```
const defaultProps = {
  ...VirtualizedList.defaultProps,
  numColumns: 1,
  /**
   * Enabling this prop on Android greatly improves scrolling performance with no known issues.
   * The alternative is that scrolling on Android is unusably bad. Enabling it on iOS has a few
   * known issues.
   */
  removeClippedSubviews: Platform.OS === 'android',
};
export type DefaultProps = typeof defaultProps;
```

- [x] it works on iOS
- [x] it works on Android