### PR TITLE
removed old fallbacks and hacks for Calendar style PropTypes

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -11,6 +11,7 @@ import styleConstructor from './style';
 import {VelocityTracker} from '../input';
 import {AGENDA_CALENDAR_KNOB} from '../testIDs';
 
+
 const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
 
@@ -68,8 +69,8 @@ export default class AgendaView extends Component {
     /** Collection of dates that have to be marked. Default = items */
     markedDates: PropTypes.object,
     /** Optional marking type if custom markedDates are provided */
-    markingType: PropTypes.string /*
-    /** Hide knob button. Default = false */,
+    markingType: PropTypes.string,/*
+    /** Hide knob button. Default = false */
     hideKnob: PropTypes.bool,
     /** Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting */
     monthFormat: PropTypes.string,
@@ -88,7 +89,7 @@ export default class AgendaView extends Component {
     /** Called when the momentum scroll starts for the agenda list. **/
     onMomentumScrollBegin: PropTypes.func,
     /** Called when the momentum scroll stops for the agenda list. **/
-    onMomentumScrollEnd: PropTypes.func,
+    onMomentumScrollEnd: PropTypes.func
   };
 
   constructor(props) {
@@ -108,7 +109,7 @@ export default class AgendaView extends Component {
       calendarScrollable: false,
       firstResevationLoad: false,
       selectedDay: parseDate(this.props.selected) || XDate(true),
-      topDay: parseDate(this.props.selected) || XDate(true),
+      topDay: parseDate(this.props.selected) || XDate(true)
     };
 
     this.currentMonth = this.state.selectedDay.clone();
@@ -135,7 +136,7 @@ export default class AgendaView extends Component {
   UNSAFE_componentWillReceiveProps(props) {
     if (props.items) {
       this.setState({
-        firstResevationLoad: false,
+        firstResevationLoad: false
       });
     } else {
       this.loadReservations(props);
@@ -143,12 +144,12 @@ export default class AgendaView extends Component {
   }
 
   calendarOffset() {
-    return 96 - this.viewHeight / 2;
+    return 96 - (this.viewHeight / 2);
   }
 
   initialScrollPadPosition = () => {
     return Math.max(0, this.viewHeight - HEADER_HEIGHT);
-  };
+  }
 
   setScrollPadPosition = (y, animated) => {
     if (this.scrollPad.scrollTo) {
@@ -157,7 +158,7 @@ export default class AgendaView extends Component {
       // Support for RN O.61 (Expo 37)
       this.scrollPad.getNode().scrollTo({x: 0, y, animated});
     }
-  };
+  }
 
   onScrollPadLayout = () => {
     // When user touches knob, the actual component that receives touch events is a ScrollView.
@@ -166,7 +167,7 @@ export default class AgendaView extends Component {
     this.setScrollPadPosition(this.initialScrollPadPosition(), false);
     // delay rendering calendar in full height because otherwise it still flickers sometimes
     setTimeout(() => this.setState({calendarIsReady: true}), 0);
-  };
+  }
 
   onLayout(event) {
     this.viewHeight = event.nativeEvent.layout.height;
@@ -204,9 +205,9 @@ export default class AgendaView extends Component {
     this.onTouchEnd();
     const currentY = e.nativeEvent.contentOffset.y;
     this.knobTracker.add(currentY);
-    const projectedY = currentY + this.knobTracker.estimateSpeed() * 250; /*ms*/
+    const projectedY = currentY + this.knobTracker.estimateSpeed() * 250/*ms*/;
     const maxY = this.initialScrollPadPosition();
-    const snapY = projectedY > maxY / 2 ? maxY : 0;
+    const snapY = (projectedY > maxY / 2) ? maxY : 0;
     this.setScrollPadPosition(snapY, true);
 
     if (snapY === 0) {
@@ -230,22 +231,19 @@ export default class AgendaView extends Component {
 
   loadReservations(props) {
     if ((!props.items || !Object.keys(props.items).length) && !this.state.firstResevationLoad) {
-      this.setState(
-        {
-          firstResevationLoad: true,
-        },
-        () => {
-          if (this.props.loadItemsForMonth) {
-            this.props.loadItemsForMonth(xdateToData(this.state.selectedDay));
-          }
-        },
-      );
+      this.setState({
+        firstResevationLoad: true
+      }, () => {
+        if (this.props.loadItemsForMonth) {
+          this.props.loadItemsForMonth(xdateToData(this.state.selectedDay));
+        }
+      });
     }
   }
 
   enableCalendarScrolling() {
     this.setState({
-      calendarScrollable: true,
+      calendarScrollable: true
     });
 
     if (this.props.onCalendarToggled) {
@@ -271,7 +269,7 @@ export default class AgendaView extends Component {
 
     this.setState({
       calendarScrollable: false,
-      selectedDay: day.clone(),
+      selectedDay: day.clone()
     });
 
     if (this.props.onCalendarToggled) {
@@ -280,7 +278,7 @@ export default class AgendaView extends Component {
 
     if (!optimisticScroll) {
       this.setState({
-        topDay: day.clone(),
+        topDay: day.clone()
       });
     }
 
@@ -315,8 +313,8 @@ export default class AgendaView extends Component {
         renderEmptyData={this.props.renderEmptyData}
         topDay={this.state.topDay}
         onDayChange={this.onDayChange.bind(this)}
-        onScroll={() => {}}
-        ref={(c) => (this.list = c)}
+        onScroll={() => { }}
+        ref={(c) => this.list = c}
         theme={this.props.theme}
       />
     );
@@ -328,7 +326,7 @@ export default class AgendaView extends Component {
 
     this.calendar.scrollToDay(day, this.calendarOffset(), withAnimation);
     this.setState({
-      selectedDay: parseDate(day),
+      selectedDay: parseDate(day)
     });
 
     if (this.props.onDayChange) {
@@ -341,7 +339,7 @@ export default class AgendaView extends Component {
 
     if (!markings) {
       markings = {};
-      Object.keys(this.props.items || {}).forEach((key) => {
+      Object.keys(this.props.items || {}).forEach(key => {
         if (this.props.items[key] && this.props.items[key].length) {
           markings[key] = {marked: true};
         }
@@ -356,39 +354,37 @@ export default class AgendaView extends Component {
     const agendaHeight = this.initialScrollPadPosition();
     const weekDaysNames = dateutils.weekDayNames(this.props.firstDay);
 
-    const weekdaysStyle = [
-      this.styles.weekdays,
-      {
-        opacity: this.state.scrollY.interpolate({
-          inputRange: [agendaHeight - HEADER_HEIGHT, agendaHeight],
-          outputRange: [0, 1],
-          extrapolate: 'clamp',
-        }),
-        transform: [
-          {
-            translateY: this.state.scrollY.interpolate({
-              inputRange: [Math.max(0, agendaHeight - HEADER_HEIGHT), agendaHeight],
-              outputRange: [-HEADER_HEIGHT, 0],
-              extrapolate: 'clamp',
-            }),
-          },
-        ],
-      },
-    ];
+    const weekdaysStyle = [this.styles.weekdays, {
+      opacity: this.state.scrollY.interpolate({
+        inputRange: [agendaHeight - HEADER_HEIGHT, agendaHeight],
+        outputRange: [0, 1],
+        extrapolate: 'clamp'
+      }),
+      transform: [{
+        translateY: this.state.scrollY.interpolate({
+          inputRange: [Math.max(0, agendaHeight - HEADER_HEIGHT), agendaHeight],
+          outputRange: [-HEADER_HEIGHT, 0],
+          extrapolate: 'clamp'
+        })
+      }]
+    }];
 
     const headerTranslate = this.state.scrollY.interpolate({
       inputRange: [0, agendaHeight],
       outputRange: [agendaHeight, 0],
-      extrapolate: 'clamp',
+      extrapolate: 'clamp'
     });
 
     const contentTranslate = this.state.scrollY.interpolate({
       inputRange: [0, agendaHeight],
       outputRange: [0, agendaHeight / 2],
-      extrapolate: 'clamp',
+      extrapolate: 'clamp'
     });
 
-    const headerStyle = [this.styles.header, {bottom: agendaHeight, transform: [{translateY: headerTranslate}]}];
+    const headerStyle = [
+      this.styles.header,
+      {bottom: agendaHeight, transform: [{translateY: headerTranslate}]}
+    ];
 
     if (!this.state.calendarIsReady) {
       // limit header height until everything is setup for calendar dragging
@@ -405,28 +401,26 @@ export default class AgendaView extends Component {
       width: 80,
       height: KNOB_HEIGHT,
       top: scrollPadPosition,
-      left: (this.viewWidth - 80) / 2,
+      left: (this.viewWidth - 80) / 2
     };
 
-    let knob = <View style={this.styles.knobContainer} />;
+    let knob = (<View style={this.styles.knobContainer}/>);
 
     if (!this.props.hideKnob) {
-      const knobView = this.props.renderKnob ? this.props.renderKnob() : <View style={this.styles.knob} />;
+      const knobView = this.props.renderKnob ? this.props.renderKnob() : (<View style={this.styles.knob}/>);
       knob = this.state.calendarScrollable ? null : (
         <View style={this.styles.knobContainer}>
-          <View ref={(c) => (this.knob = c)}>{knobView}</View>
+          <View ref={(c) => this.knob = c}>{knobView}</View>
         </View>
       );
     }
     const shouldHideExtraDays = this.state.calendarScrollable ? this.props.hideExtraDays : false;
 
     return (
-      <View
-        testID={this.props.testID}
-        onLayout={this.onLayout}
-        style={[this.props.style, {flex: 1, overflow: 'hidden'}]}
-      >
-        <View style={this.styles.reservations}>{this.renderReservations()}</View>
+      <View testID={this.props.testID} onLayout={this.onLayout} style={[this.props.style, {flex: 1, overflow: 'hidden'}]}>
+        <View style={this.styles.reservations}>
+          {this.renderReservations()}
+        </View>
         <Animated.View style={headerStyle}>
           <Animated.View style={{flex: 1, transform: [{translateY: contentTranslate}]}}>
             <CalendarList
@@ -436,7 +430,7 @@ export default class AgendaView extends Component {
               calendarWidth={this.viewWidth}
               theme={this.props.theme}
               onVisibleMonthsChange={this.onVisibleMonthsChange.bind(this)}
-              ref={(c) => (this.calendar = c)}
+              ref={(c) => this.calendar = c}
               minDate={this.props.minDate}
               maxDate={this.props.maxDate}
               current={this.currentMonth}
@@ -459,18 +453,14 @@ export default class AgendaView extends Component {
           {knob}
         </Animated.View>
         <Animated.View style={weekdaysStyle}>
-          {this.props.showWeekNumbers && (
-            <Text allowFontScaling={false} style={this.styles.weekday} numberOfLines={1}></Text>
-          )}
+          {this.props.showWeekNumbers && <Text allowFontScaling={false} style={this.styles.weekday} numberOfLines={1}></Text>}
           {weekDaysNames.map((day, index) => (
-            <Text allowFontScaling={false} key={day + index} style={this.styles.weekday} numberOfLines={1}>
-              {day}
-            </Text>
+            <Text allowFontScaling={false} key={day + index} style={this.styles.weekday} numberOfLines={1}>{day}</Text>
           ))}
         </Animated.View>
         <Animated.ScrollView
-          ref={(ref) => (this.scrollPad = ref)}
-          overScrollMode="never"
+          ref={ref => this.scrollPad = ref}
+          overScrollMode='never'
           showsHorizontalScrollIndicator={false}
           showsVerticalScrollIndicator={false}
           style={scrollPadStyle}
@@ -480,7 +470,10 @@ export default class AgendaView extends Component {
           onTouchEnd={this.onTouchEnd}
           onScrollBeginDrag={this.onStartDrag}
           onScrollEndDrag={this.onSnapAfterDrag}
-          onScroll={Animated.event([{nativeEvent: {contentOffset: {y: this.state.scrollY}}}], {useNativeDriver: true})}
+          onScroll={Animated.event(
+            [{nativeEvent: {contentOffset: {y: this.state.scrollY}}}],
+            {useNativeDriver: true}
+          )}
         >
           <View
             testID={AGENDA_CALENDAR_KNOB}

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import * as ReactNative from 'react-native';
+import {Text, View, Dimensions, Animated} from 'react-native';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
@@ -11,15 +11,8 @@ import styleConstructor from './style';
 import {VelocityTracker} from '../input';
 import {AGENDA_CALENDAR_KNOB} from '../testIDs';
 
-
 const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
-//Fallback for react-native-web or when RN version is < 0.44
-const {Text, View, Dimensions, Animated, ViewPropTypes} = ReactNative;
-const viewPropTypes =
-  typeof document !== 'undefined'
-    ? PropTypes.shape({style: PropTypes.object})
-    : ViewPropTypes || View.propTypes;
 
 /**
  * @description: Agenda component
@@ -35,7 +28,7 @@ export default class AgendaView extends Component {
     /** Specify theme properties to override specific styles for calendar parts. Default = {} */
     theme: PropTypes.object,
     /** agenda container style */
-    style: viewPropTypes.style,
+    style: PropTypes.object,
     /** the list of items that have to be displayed in agenda. If you want to render item as empty date
     the value of date key has to be an empty array []. If there exists no value for date key it is
     considered that the date in question is not yet loaded */
@@ -75,8 +68,8 @@ export default class AgendaView extends Component {
     /** Collection of dates that have to be marked. Default = items */
     markedDates: PropTypes.object,
     /** Optional marking type if custom markedDates are provided */
-    markingType: PropTypes.string,/*
-    /** Hide knob button. Default = false */
+    markingType: PropTypes.string /*
+    /** Hide knob button. Default = false */,
     hideKnob: PropTypes.bool,
     /** Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting */
     monthFormat: PropTypes.string,
@@ -95,7 +88,7 @@ export default class AgendaView extends Component {
     /** Called when the momentum scroll starts for the agenda list. **/
     onMomentumScrollBegin: PropTypes.func,
     /** Called when the momentum scroll stops for the agenda list. **/
-    onMomentumScrollEnd: PropTypes.func
+    onMomentumScrollEnd: PropTypes.func,
   };
 
   constructor(props) {
@@ -115,7 +108,7 @@ export default class AgendaView extends Component {
       calendarScrollable: false,
       firstResevationLoad: false,
       selectedDay: parseDate(this.props.selected) || XDate(true),
-      topDay: parseDate(this.props.selected) || XDate(true)
+      topDay: parseDate(this.props.selected) || XDate(true),
     };
 
     this.currentMonth = this.state.selectedDay.clone();
@@ -142,7 +135,7 @@ export default class AgendaView extends Component {
   UNSAFE_componentWillReceiveProps(props) {
     if (props.items) {
       this.setState({
-        firstResevationLoad: false
+        firstResevationLoad: false,
       });
     } else {
       this.loadReservations(props);
@@ -150,12 +143,12 @@ export default class AgendaView extends Component {
   }
 
   calendarOffset() {
-    return 96 - (this.viewHeight / 2);
+    return 96 - this.viewHeight / 2;
   }
 
   initialScrollPadPosition = () => {
     return Math.max(0, this.viewHeight - HEADER_HEIGHT);
-  }
+  };
 
   setScrollPadPosition = (y, animated) => {
     if (this.scrollPad.scrollTo) {
@@ -164,7 +157,7 @@ export default class AgendaView extends Component {
       // Support for RN O.61 (Expo 37)
       this.scrollPad.getNode().scrollTo({x: 0, y, animated});
     }
-  }
+  };
 
   onScrollPadLayout = () => {
     // When user touches knob, the actual component that receives touch events is a ScrollView.
@@ -173,7 +166,7 @@ export default class AgendaView extends Component {
     this.setScrollPadPosition(this.initialScrollPadPosition(), false);
     // delay rendering calendar in full height because otherwise it still flickers sometimes
     setTimeout(() => this.setState({calendarIsReady: true}), 0);
-  }
+  };
 
   onLayout(event) {
     this.viewHeight = event.nativeEvent.layout.height;
@@ -211,9 +204,9 @@ export default class AgendaView extends Component {
     this.onTouchEnd();
     const currentY = e.nativeEvent.contentOffset.y;
     this.knobTracker.add(currentY);
-    const projectedY = currentY + this.knobTracker.estimateSpeed() * 250/*ms*/;
+    const projectedY = currentY + this.knobTracker.estimateSpeed() * 250; /*ms*/
     const maxY = this.initialScrollPadPosition();
-    const snapY = (projectedY > maxY / 2) ? maxY : 0;
+    const snapY = projectedY > maxY / 2 ? maxY : 0;
     this.setScrollPadPosition(snapY, true);
 
     if (snapY === 0) {
@@ -237,19 +230,22 @@ export default class AgendaView extends Component {
 
   loadReservations(props) {
     if ((!props.items || !Object.keys(props.items).length) && !this.state.firstResevationLoad) {
-      this.setState({
-        firstResevationLoad: true
-      }, () => {
-        if (this.props.loadItemsForMonth) {
-          this.props.loadItemsForMonth(xdateToData(this.state.selectedDay));
-        }
-      });
+      this.setState(
+        {
+          firstResevationLoad: true,
+        },
+        () => {
+          if (this.props.loadItemsForMonth) {
+            this.props.loadItemsForMonth(xdateToData(this.state.selectedDay));
+          }
+        },
+      );
     }
   }
 
   enableCalendarScrolling() {
     this.setState({
-      calendarScrollable: true
+      calendarScrollable: true,
     });
 
     if (this.props.onCalendarToggled) {
@@ -275,7 +271,7 @@ export default class AgendaView extends Component {
 
     this.setState({
       calendarScrollable: false,
-      selectedDay: day.clone()
+      selectedDay: day.clone(),
     });
 
     if (this.props.onCalendarToggled) {
@@ -284,7 +280,7 @@ export default class AgendaView extends Component {
 
     if (!optimisticScroll) {
       this.setState({
-        topDay: day.clone()
+        topDay: day.clone(),
       });
     }
 
@@ -319,8 +315,8 @@ export default class AgendaView extends Component {
         renderEmptyData={this.props.renderEmptyData}
         topDay={this.state.topDay}
         onDayChange={this.onDayChange.bind(this)}
-        onScroll={() => { }}
-        ref={(c) => this.list = c}
+        onScroll={() => {}}
+        ref={(c) => (this.list = c)}
         theme={this.props.theme}
       />
     );
@@ -332,7 +328,7 @@ export default class AgendaView extends Component {
 
     this.calendar.scrollToDay(day, this.calendarOffset(), withAnimation);
     this.setState({
-      selectedDay: parseDate(day)
+      selectedDay: parseDate(day),
     });
 
     if (this.props.onDayChange) {
@@ -345,7 +341,7 @@ export default class AgendaView extends Component {
 
     if (!markings) {
       markings = {};
-      Object.keys(this.props.items || {}).forEach(key => {
+      Object.keys(this.props.items || {}).forEach((key) => {
         if (this.props.items[key] && this.props.items[key].length) {
           markings[key] = {marked: true};
         }
@@ -360,37 +356,39 @@ export default class AgendaView extends Component {
     const agendaHeight = this.initialScrollPadPosition();
     const weekDaysNames = dateutils.weekDayNames(this.props.firstDay);
 
-    const weekdaysStyle = [this.styles.weekdays, {
-      opacity: this.state.scrollY.interpolate({
-        inputRange: [agendaHeight - HEADER_HEIGHT, agendaHeight],
-        outputRange: [0, 1],
-        extrapolate: 'clamp'
-      }),
-      transform: [{
-        translateY: this.state.scrollY.interpolate({
-          inputRange: [Math.max(0, agendaHeight - HEADER_HEIGHT), agendaHeight],
-          outputRange: [-HEADER_HEIGHT, 0],
-          extrapolate: 'clamp'
-        })
-      }]
-    }];
+    const weekdaysStyle = [
+      this.styles.weekdays,
+      {
+        opacity: this.state.scrollY.interpolate({
+          inputRange: [agendaHeight - HEADER_HEIGHT, agendaHeight],
+          outputRange: [0, 1],
+          extrapolate: 'clamp',
+        }),
+        transform: [
+          {
+            translateY: this.state.scrollY.interpolate({
+              inputRange: [Math.max(0, agendaHeight - HEADER_HEIGHT), agendaHeight],
+              outputRange: [-HEADER_HEIGHT, 0],
+              extrapolate: 'clamp',
+            }),
+          },
+        ],
+      },
+    ];
 
     const headerTranslate = this.state.scrollY.interpolate({
       inputRange: [0, agendaHeight],
       outputRange: [agendaHeight, 0],
-      extrapolate: 'clamp'
+      extrapolate: 'clamp',
     });
 
     const contentTranslate = this.state.scrollY.interpolate({
       inputRange: [0, agendaHeight],
       outputRange: [0, agendaHeight / 2],
-      extrapolate: 'clamp'
+      extrapolate: 'clamp',
     });
 
-    const headerStyle = [
-      this.styles.header,
-      {bottom: agendaHeight, transform: [{translateY: headerTranslate}]}
-    ];
+    const headerStyle = [this.styles.header, {bottom: agendaHeight, transform: [{translateY: headerTranslate}]}];
 
     if (!this.state.calendarIsReady) {
       // limit header height until everything is setup for calendar dragging
@@ -407,26 +405,28 @@ export default class AgendaView extends Component {
       width: 80,
       height: KNOB_HEIGHT,
       top: scrollPadPosition,
-      left: (this.viewWidth - 80) / 2
+      left: (this.viewWidth - 80) / 2,
     };
 
-    let knob = (<View style={this.styles.knobContainer}/>);
+    let knob = <View style={this.styles.knobContainer} />;
 
     if (!this.props.hideKnob) {
-      const knobView = this.props.renderKnob ? this.props.renderKnob() : (<View style={this.styles.knob}/>);
+      const knobView = this.props.renderKnob ? this.props.renderKnob() : <View style={this.styles.knob} />;
       knob = this.state.calendarScrollable ? null : (
         <View style={this.styles.knobContainer}>
-          <View ref={(c) => this.knob = c}>{knobView}</View>
+          <View ref={(c) => (this.knob = c)}>{knobView}</View>
         </View>
       );
     }
     const shouldHideExtraDays = this.state.calendarScrollable ? this.props.hideExtraDays : false;
 
     return (
-      <View testID={this.props.testID} onLayout={this.onLayout} style={[this.props.style, {flex: 1, overflow: 'hidden'}]}>
-        <View style={this.styles.reservations}>
-          {this.renderReservations()}
-        </View>
+      <View
+        testID={this.props.testID}
+        onLayout={this.onLayout}
+        style={[this.props.style, {flex: 1, overflow: 'hidden'}]}
+      >
+        <View style={this.styles.reservations}>{this.renderReservations()}</View>
         <Animated.View style={headerStyle}>
           <Animated.View style={{flex: 1, transform: [{translateY: contentTranslate}]}}>
             <CalendarList
@@ -436,7 +436,7 @@ export default class AgendaView extends Component {
               calendarWidth={this.viewWidth}
               theme={this.props.theme}
               onVisibleMonthsChange={this.onVisibleMonthsChange.bind(this)}
-              ref={(c) => this.calendar = c}
+              ref={(c) => (this.calendar = c)}
               minDate={this.props.minDate}
               maxDate={this.props.maxDate}
               current={this.currentMonth}
@@ -459,14 +459,18 @@ export default class AgendaView extends Component {
           {knob}
         </Animated.View>
         <Animated.View style={weekdaysStyle}>
-          {this.props.showWeekNumbers && <Text allowFontScaling={false} style={this.styles.weekday} numberOfLines={1}></Text>}
+          {this.props.showWeekNumbers && (
+            <Text allowFontScaling={false} style={this.styles.weekday} numberOfLines={1}></Text>
+          )}
           {weekDaysNames.map((day, index) => (
-            <Text allowFontScaling={false} key={day + index} style={this.styles.weekday} numberOfLines={1}>{day}</Text>
+            <Text allowFontScaling={false} key={day + index} style={this.styles.weekday} numberOfLines={1}>
+              {day}
+            </Text>
           ))}
         </Animated.View>
         <Animated.ScrollView
-          ref={ref => this.scrollPad = ref}
-          overScrollMode='never'
+          ref={(ref) => (this.scrollPad = ref)}
+          overScrollMode="never"
           showsHorizontalScrollIndicator={false}
           showsVerticalScrollIndicator={false}
           style={scrollPadStyle}
@@ -476,10 +480,7 @@ export default class AgendaView extends Component {
           onTouchEnd={this.onTouchEnd}
           onScrollBeginDrag={this.onStartDrag}
           onScrollEndDrag={this.onSnapAfterDrag}
-          onScroll={Animated.event(
-            [{nativeEvent: {contentOffset: {y: this.state.scrollY}}}],
-            {useNativeDriver: true}
-          )}
+          onScroll={Animated.event([{nativeEvent: {contentOffset: {y: this.state.scrollY}}}], {useNativeDriver: true})}
         >
           <View
             testID={AGENDA_CALENDAR_KNOB}

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -29,7 +29,7 @@ export default class AgendaView extends Component {
     /** Specify theme properties to override specific styles for calendar parts. Default = {} */
     theme: PropTypes.object,
     /** agenda container style */
-    style: PropTypes.object,
+    style: View.propTypes.style,
     /** the list of items that have to be displayed in agenda. If you want to render item as empty date
     the value of date key has to be an empty array []. If there exists no value for date key it is
     considered that the date in question is not yet loaded */

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -92,11 +92,11 @@ class Calendar extends Component {
     /** Replace default month and year title with custom one. the function receive a date as parameter. */
     renderHeader: PropTypes.any,
     /** Enable the option to swipe between months. Default: false */
-    enableSwipeMonths: PropTypes.bool,
+    enableSwipeMonths: PropTypes.bool
   };
 
   static defaultProps = {
-    enableSwipeMonths: false,
+    enableSwipeMonths: false
   };
 
   constructor(props) {
@@ -104,7 +104,7 @@ class Calendar extends Component {
 
     this.style = styleConstructor(this.props.theme);
     this.state = {
-      currentMonth: props.current ? parseDate(props.current) : XDate(),
+      currentMonth: props.current ? parseDate(props.current) : XDate()
     };
 
     this.updateMonth = this.updateMonth.bind(this);
@@ -117,22 +117,19 @@ class Calendar extends Component {
     if (day.toString('yyyy MM') === this.state.currentMonth.toString('yyyy MM')) {
       return;
     }
-    this.setState(
-      {
-        currentMonth: day.clone(),
-      },
-      () => {
-        if (!doNotTriggerListeners) {
-          const currMont = this.state.currentMonth.clone();
-          if (this.props.onMonthChange) {
-            this.props.onMonthChange(xdateToData(currMont));
-          }
-          if (this.props.onVisibleMonthsChange) {
-            this.props.onVisibleMonthsChange([xdateToData(currMont)]);
-          }
+    this.setState({
+      currentMonth: day.clone()
+    }, () => {
+      if (!doNotTriggerListeners) {
+        const currMont = this.state.currentMonth.clone();
+        if (this.props.onMonthChange) {
+          this.props.onMonthChange(xdateToData(currMont));
         }
-      },
-    );
+        if (this.props.onVisibleMonthsChange) {
+          this.props.onVisibleMonthsChange([xdateToData(currMont)]);
+        }
+      }
+    });
   }
 
   _handleDayInteraction(date, interaction) {
@@ -160,11 +157,11 @@ class Calendar extends Component {
 
   addMonth = (count) => {
     this.updateMonth(this.state.currentMonth.clone().addMonths(count, true));
-  };
+  }
 
   isDateNotInTheRange = (minDate, maxDate, date) => {
     return (minDate && !dateutils.isGTE(date, minDate)) || (maxDate && !dateutils.isLTE(date, maxDate));
-  };
+  }
 
   getAccessibilityLabel = (state, day) => {
     const today = XDate.locales[XDate.defaultLocale].today;
@@ -177,7 +174,8 @@ class Calendar extends Component {
     }
 
     return `${isToday ? 'today' : ''} ${day.toString('dddd d MMMM yyyy')} ${markingLabel}`;
-  };
+  }
+
 
   renderDay(day, id) {
     const minDate = parseDate(this.props.minDate);
@@ -194,7 +192,7 @@ class Calendar extends Component {
     }
 
     if (!dateutils.sameMonth(day, this.state.currentMonth) && this.props.hideExtraDays) {
-      return <View key={id} style={{flex: 1}} />;
+      return (<View key={id} style={{flex: 1}}/>);
     }
 
     const DayComp = this.getDayComponent();
@@ -256,16 +254,16 @@ class Calendar extends Component {
     }
 
     switch (this.props.markingType) {
-      case 'period':
-        return UnitDay;
-      case 'multi-dot':
-        return MultiDotDay;
-      case 'multi-period':
-        return MultiPeriodDay;
-      case 'custom':
-        return SingleDay;
-      default:
-        return Day;
+    case 'period':
+      return UnitDay;
+    case 'multi-dot':
+      return MultiDotDay;
+    case 'multi-period':
+      return MultiPeriodDay;
+    case 'custom':
+      return SingleDay;
+    default:
+      return Day;
     }
   }
 
@@ -286,30 +284,35 @@ class Calendar extends Component {
     const {SWIPE_UP, SWIPE_DOWN, SWIPE_LEFT, SWIPE_RIGHT} = swipeDirections;
 
     switch (gestureName) {
-      case SWIPE_UP:
-      case SWIPE_DOWN:
-        break;
-      case SWIPE_LEFT:
-        this.onSwipeLeft();
-        break;
-      case SWIPE_RIGHT:
-        this.onSwipeRight();
-        break;
+    case SWIPE_UP:
+    case SWIPE_DOWN:
+      break;
+    case SWIPE_LEFT:
+      this.onSwipeLeft();
+      break;
+    case SWIPE_RIGHT:
+      this.onSwipeRight();
+      break;
     }
-  };
+  }
 
   onSwipeLeft = () => {
     this.header.onPressRight();
-  };
+  }
 
   onSwipeRight = () => {
     this.header.onPressLeft();
-  };
+  }
 
   renderWeekNumber(weekNumber) {
     return (
       <View style={{flex: 1, alignItems: 'center'}} key={`week-container-${weekNumber}`}>
-        <Day key={`week-${weekNumber}`} theme={this.props.theme} marking={{disableTouchEvent: true}} state="disabled">
+        <Day
+          key={`week-${weekNumber}`}
+          theme={this.props.theme}
+          marking={{disableTouchEvent: true}}
+          state='disabled'
+        >
           {weekNumber}
         </Day>
       </View>
@@ -326,11 +329,7 @@ class Calendar extends Component {
       week.unshift(this.renderWeekNumber(days[days.length - 1].getWeek()));
     }
 
-    return (
-      <View style={this.style.week} key={id}>
-        {week}
-      </View>
-    );
+    return (<View style={this.style.week} key={id}>{week}</View>);
   }
 
   render() {
@@ -348,7 +347,8 @@ class Calendar extends Component {
     const current = parseDate(this.props.current);
     if (current) {
       const lastMonthOfDay = current.clone().addMonths(1, true).setDate(1).addDays(-1).toString('yyyy-MM-dd');
-      if (this.props.displayLoadingIndicator && !(this.props.markedDates && this.props.markedDates[lastMonthOfDay])) {
+      if (this.props.displayLoadingIndicator &&
+        !(this.props.markedDates && this.props.markedDates[lastMonthOfDay])) {
         indicator = true;
       }
     }
@@ -365,7 +365,7 @@ class Calendar extends Component {
         >
           <CalendarHeader
             testID={this.props.testID}
-            ref={(c) => (this.header = c)}
+            ref={c => this.header = c}
             style={this.props.headerStyle}
             theme={this.props.theme}
             hideArrows={this.props.hideArrows}

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -32,7 +32,7 @@ class Calendar extends Component {
     /** Collection of dates that have to be marked. Default = {} */
     markedDates: PropTypes.object,
     /** Specify style for calendar container element. Default = {} */
-    style: PropTypes.object,
+    style: View.propTypes.style,
     /** Initially visible month. Default = Date() */
     current: PropTypes.any,
     /** Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined */

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import * as ReactNative from 'react-native';
+import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
@@ -16,12 +16,6 @@ import shouldComponentUpdate from './updater';
 import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
 import {SELECT_DATE_SLOT} from '../testIDs';
 
-//Fallback for react-native-web or when RN version is < 0.44
-const {View, ViewPropTypes} = ReactNative;
-const viewPropTypes =
-  typeof document !== 'undefined'
-    ? PropTypes.shape({style: PropTypes.object})
-    : ViewPropTypes || View.propTypes;
 const EmptyArray = [];
 
 /**
@@ -38,7 +32,7 @@ class Calendar extends Component {
     /** Collection of dates that have to be marked. Default = {} */
     markedDates: PropTypes.object,
     /** Specify style for calendar container element. Default = {} */
-    style: viewPropTypes.style,
+    style: PropTypes.object,
     /** Initially visible month. Default = Date() */
     current: PropTypes.any,
     /** Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined */
@@ -98,11 +92,11 @@ class Calendar extends Component {
     /** Replace default month and year title with custom one. the function receive a date as parameter. */
     renderHeader: PropTypes.any,
     /** Enable the option to swipe between months. Default: false */
-    enableSwipeMonths: PropTypes.bool
+    enableSwipeMonths: PropTypes.bool,
   };
 
   static defaultProps = {
-    enableSwipeMonths: false
+    enableSwipeMonths: false,
   };
 
   constructor(props) {
@@ -110,7 +104,7 @@ class Calendar extends Component {
 
     this.style = styleConstructor(this.props.theme);
     this.state = {
-      currentMonth: props.current ? parseDate(props.current) : XDate()
+      currentMonth: props.current ? parseDate(props.current) : XDate(),
     };
 
     this.updateMonth = this.updateMonth.bind(this);
@@ -123,19 +117,22 @@ class Calendar extends Component {
     if (day.toString('yyyy MM') === this.state.currentMonth.toString('yyyy MM')) {
       return;
     }
-    this.setState({
-      currentMonth: day.clone()
-    }, () => {
-      if (!doNotTriggerListeners) {
-        const currMont = this.state.currentMonth.clone();
-        if (this.props.onMonthChange) {
-          this.props.onMonthChange(xdateToData(currMont));
+    this.setState(
+      {
+        currentMonth: day.clone(),
+      },
+      () => {
+        if (!doNotTriggerListeners) {
+          const currMont = this.state.currentMonth.clone();
+          if (this.props.onMonthChange) {
+            this.props.onMonthChange(xdateToData(currMont));
+          }
+          if (this.props.onVisibleMonthsChange) {
+            this.props.onVisibleMonthsChange([xdateToData(currMont)]);
+          }
         }
-        if (this.props.onVisibleMonthsChange) {
-          this.props.onVisibleMonthsChange([xdateToData(currMont)]);
-        }
-      }
-    });
+      },
+    );
   }
 
   _handleDayInteraction(date, interaction) {
@@ -163,11 +160,11 @@ class Calendar extends Component {
 
   addMonth = (count) => {
     this.updateMonth(this.state.currentMonth.clone().addMonths(count, true));
-  }
+  };
 
   isDateNotInTheRange = (minDate, maxDate, date) => {
     return (minDate && !dateutils.isGTE(date, minDate)) || (maxDate && !dateutils.isLTE(date, maxDate));
-  }
+  };
 
   getAccessibilityLabel = (state, day) => {
     const today = XDate.locales[XDate.defaultLocale].today;
@@ -180,8 +177,7 @@ class Calendar extends Component {
     }
 
     return `${isToday ? 'today' : ''} ${day.toString('dddd d MMMM yyyy')} ${markingLabel}`;
-  }
-
+  };
 
   renderDay(day, id) {
     const minDate = parseDate(this.props.minDate);
@@ -198,7 +194,7 @@ class Calendar extends Component {
     }
 
     if (!dateutils.sameMonth(day, this.state.currentMonth) && this.props.hideExtraDays) {
-      return (<View key={id} style={{flex: 1}}/>);
+      return <View key={id} style={{flex: 1}} />;
     }
 
     const DayComp = this.getDayComponent();
@@ -260,16 +256,16 @@ class Calendar extends Component {
     }
 
     switch (this.props.markingType) {
-    case 'period':
-      return UnitDay;
-    case 'multi-dot':
-      return MultiDotDay;
-    case 'multi-period':
-      return MultiPeriodDay;
-    case 'custom':
-      return SingleDay;
-    default:
-      return Day;
+      case 'period':
+        return UnitDay;
+      case 'multi-dot':
+        return MultiDotDay;
+      case 'multi-period':
+        return MultiPeriodDay;
+      case 'custom':
+        return SingleDay;
+      default:
+        return Day;
     }
   }
 
@@ -290,35 +286,30 @@ class Calendar extends Component {
     const {SWIPE_UP, SWIPE_DOWN, SWIPE_LEFT, SWIPE_RIGHT} = swipeDirections;
 
     switch (gestureName) {
-    case SWIPE_UP:
-    case SWIPE_DOWN:
-      break;
-    case SWIPE_LEFT:
-      this.onSwipeLeft();
-      break;
-    case SWIPE_RIGHT:
-      this.onSwipeRight();
-      break;
+      case SWIPE_UP:
+      case SWIPE_DOWN:
+        break;
+      case SWIPE_LEFT:
+        this.onSwipeLeft();
+        break;
+      case SWIPE_RIGHT:
+        this.onSwipeRight();
+        break;
     }
-  }
+  };
 
   onSwipeLeft = () => {
     this.header.onPressRight();
-  }
+  };
 
   onSwipeRight = () => {
     this.header.onPressLeft();
-  }
+  };
 
   renderWeekNumber(weekNumber) {
     return (
       <View style={{flex: 1, alignItems: 'center'}} key={`week-container-${weekNumber}`}>
-        <Day
-          key={`week-${weekNumber}`}
-          theme={this.props.theme}
-          marking={{disableTouchEvent: true}}
-          state='disabled'
-        >
+        <Day key={`week-${weekNumber}`} theme={this.props.theme} marking={{disableTouchEvent: true}} state="disabled">
           {weekNumber}
         </Day>
       </View>
@@ -335,7 +326,11 @@ class Calendar extends Component {
       week.unshift(this.renderWeekNumber(days[days.length - 1].getWeek()));
     }
 
-    return (<View style={this.style.week} key={id}>{week}</View>);
+    return (
+      <View style={this.style.week} key={id}>
+        {week}
+      </View>
+    );
   }
 
   render() {
@@ -353,8 +348,7 @@ class Calendar extends Component {
     const current = parseDate(this.props.current);
     if (current) {
       const lastMonthOfDay = current.clone().addMonths(1, true).setDate(1).addDays(-1).toString('yyyy-MM-dd');
-      if (this.props.displayLoadingIndicator &&
-        !(this.props.markedDates && this.props.markedDates[lastMonthOfDay])) {
+      if (this.props.displayLoadingIndicator && !(this.props.markedDates && this.props.markedDates[lastMonthOfDay])) {
         indicator = true;
       }
     }
@@ -371,7 +365,7 @@ class Calendar extends Component {
         >
           <CalendarHeader
             testID={this.props.testID}
-            ref={c => this.header = c}
+            ref={(c) => (this.header = c)}
             style={this.props.headerStyle}
             theme={this.props.theme}
             hideArrows={this.props.hideArrows}


### PR DESCRIPTION
There was a wrong PropType fallback for react-native-web, because of bad PropType **PropTypes.shape({style: PropTypes.object})**
And there is no sense in other fallbacks, because of react-native version 0.62.2 at deps (it has typescript type checks now, not PropTypes).

P.S. fixing warnings
_index.js:1 Warning: Failed prop type: Calendar: prop type `style` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`._
and
_Attempted import error: 'ViewPropTypes' is not exported from 'react-native-web/dist/index' (imported as 'ReactNative')._