### PR TITLE
Unblock rerendering when no items for agenda

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -91,7 +91,9 @@ export default class AgendaView extends Component {
     /** Called when the momentum scroll starts for the agenda list. **/
     onMomentumScrollBegin: PropTypes.func,
     /** Called when the momentum scroll stops for the agenda list. **/
-    onMomentumScrollEnd: PropTypes.func
+    onMomentumScrollEnd: PropTypes.func,
+    /** Allows rerendering of day even if no reservations for day. Useful for a day that includes buttons, overlays, modals **/
+    isInteractive: PropTypes.bool
   };
 
   constructor(props) {
@@ -313,6 +315,7 @@ export default class AgendaView extends Component {
         onScroll={() => {}}
         ref={(c) => this.list = c}
         theme={this.props.theme}
+        isInteractive={this.props.isInteractive}
       />
     );
   }

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -36,7 +36,8 @@ class ReservationList extends Component {
     onScrollBeginDrag: PropTypes.func,
     onScrollEndDrag: PropTypes.func,
     onMomentumScrollBegin: PropTypes.func,
-    onMomentumScrollEnd: PropTypes.func
+    onMomentumScrollEnd: PropTypes.func,
+    isInteractive: PropTypes.bool
   };
 
   constructor(props) {
@@ -124,6 +125,7 @@ class ReservationList extends Component {
           renderEmptyDate={this.props.renderEmptyDate}
           theme={this.props.theme}
           rowHasChanged={this.props.rowHasChanged}
+          isInteractive={this.props.isInteractive}
         />
       </View>
     );

--- a/src/agenda/reservation-list/reservation.js
+++ b/src/agenda/reservation-list/reservation.js
@@ -27,6 +27,8 @@ class Reservation extends Component {
     } else if (r1 && r2) {
       if (r1.day.getTime() !== r2.day.getTime()) {
         changed = true;
+      } else if (!this.props.isInteractive && !r1.reservation && !r2.reservation) {
+        changed = false;
       } else if (r1.reservation && r2.reservation) {
         if ((!r1.date && !r2.date) || (r1.date && r2.date)) {
           if (_.isFunction(this.props.rowHasChanged)) {

--- a/src/agenda/reservation-list/reservation.js
+++ b/src/agenda/reservation-list/reservation.js
@@ -27,8 +27,6 @@ class Reservation extends Component {
     } else if (r1 && r2) {
       if (r1.day.getTime() !== r2.day.getTime()) {
         changed = true;
-      } else if (!r1.reservation && !r2.reservation) {
-        changed = false;
       } else if (r1.reservation && r2.reservation) {
         if ((!r1.date && !r2.date) || (r1.date && r2.date)) {
           if (_.isFunction(this.props.rowHasChanged)) {


### PR DESCRIPTION
I use this library in a project of mine and I have buttons that trigger overlays that render in the day view. These buttons are present even when there are no items in the agenda for that day. Because of a function that attempts to optimize the rerenders, these overlays could not be displayed. In this pull request, there are two commits. The first removes the condition, but then I thought it might be good to make this toggleable and the second commit does that. If this change is taken, we would need to update the @types library with it.