### PR TITLE
Fixed startingDate and endingDate style

### DIFF
--- a/src/calendar/day/period/index.js
+++ b/src/calendar/day/period/index.js
@@ -127,7 +127,8 @@ class Day extends Component {
 
     if (this.props.marking) {
       containerStyle.push({
-        borderRadius: 17
+        borderRadius: 17,
+        overflow: 'hidden'
       });
 
       const flags = this.markingStyle;


### PR DESCRIPTION
This would fix a common problem with starting and ending date in period selection not being rounded.