### PR TITLE
Fix: disableArrowLeft, disableArrowRight update

### DIFF
--- a/src/calendar/updater.js
+++ b/src/calendar/updater.js
@@ -12,7 +12,7 @@ export default function shouldComponentUpdate(nextProps, nextState) {
     return prev;
   }, {update: false});
 
-  shouldUpdate = ['markedDates', 'hideExtraDays', 'displayLoadingIndicator'].reduce((prev, next) => {
+  shouldUpdate = ['markedDates', 'hideExtraDays', 'displayLoadingIndicator', 'disableArrowLeft', 'disableArrowRight'].reduce((prev, next) => {
     if (!prev.update && nextProps[next] !== this.props[next]) {
       return {
         update: true,


### PR DESCRIPTION
Fix changing `disableArrowLeft`, `disableArrowRight` doesn't update calendar header
adresses #1284