### PR TITLE
Fix CalendarList rendering on react-native-web

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -16,10 +16,6 @@ const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
 //Fallback for react-native-web or when RN version is < 0.44
 const {Text, View, Dimensions, Animated, Platform} = ReactNative;
-const viewPropTypes =
-  typeof document !== 'undefined' || Platform.OS === 'web'
-    ? PropTypes.shape({style: PropTypes.object})
-    : require('react-native').ViewPropTypes || View.propTypes;
 
 /**
  * @description: Agenda component
@@ -151,12 +147,12 @@ export default class AgendaView extends Component {
   }
 
   onHover() {
-    this.knob.setNativeProps({ style: { opacity: 0.7 } });
+    this.knob.setNativeProps({style: {opacity: 0.7}});
   }
 
   onStopHover() {
     if (this.knob) {
-      this.knob.setNativeProps({ style: { opacity: 1 } });
+      this.knob.setNativeProps({style: {opacity: 1}});
     }
   }
 

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -31,7 +31,7 @@ export default class AgendaView extends Component {
     /** Specify theme properties to override specific styles for calendar parts. Default = {} */
     theme: PropTypes.object,
     /** agenda container style */
-    style: PropTypes.object,
+    style: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     /** the list of items that have to be displayed in agenda. If you want to render item as empty date
     the value of date key has to be an empty array []. If there exists no value for date key it is
     considered that the date in question is not yet loaded */

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -137,11 +137,8 @@ class CalendarList extends Component {
   scrollToMonth(m) {
     const month = parseDate(m);
     const scrollTo = month || this.state.openDate;
-    let diffMonths = Math.round(this.state.openDate.clone().setDate(1).diffMonths(scrollTo.clone().setDate(1)));
-    const size = this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight;
-    const scrollAmount = (size * this.props.pastScrollRange) + (diffMonths * size);
 
-    this.listView.scrollToOffset({offset: scrollAmount, animated: false});
+    this.listView.scrollToIndex({index: this.getMonthIndex(scrollTo)})
   }
 
   UNSAFE_componentWillReceiveProps(props) {
@@ -294,7 +291,7 @@ class CalendarList extends Component {
 
   render() {
     return (
-      <View>
+      <View style={{ flex: 1 }}>
         <FlatList
           testID={this.props.testID}
           onLayout={this.onLayout}
@@ -316,7 +313,9 @@ class CalendarList extends Component {
           showsHorizontalScrollIndicator={this.props.showScrollIndicator}
           scrollEnabled={this.props.scrollEnabled}
           keyExtractor={this.props.keyExtractor}
-          initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
+          initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : 0}
+          //initialScrollIndex={1}
+          onScrollToIndexFailed={() => {}}
           getItemLayout={this.getItemLayout}
           scrollsToTop={this.props.scrollsToTop}
           onEndReachedThreshold={this.props.onEndReachedThreshold}

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -138,7 +138,7 @@ class CalendarList extends Component {
     const month = parseDate(m);
     const scrollTo = month || this.state.openDate;
 
-    this.listView.scrollToIndex({index: this.getMonthIndex(scrollTo)})
+    this.listView.scrollToIndex({index: this.getMonthIndex(scrollTo)});
   }
 
   UNSAFE_componentWillReceiveProps(props) {
@@ -291,7 +291,7 @@ class CalendarList extends Component {
 
   render() {
     return (
-      <View style={{ flex: 1 }}>
+      <View style={{flex: 1}}>
         <FlatList
           testID={this.props.testID}
           onLayout={this.onLayout}

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -17,11 +17,11 @@ import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
 import {SELECT_DATE_SLOT} from '../testIDs';
 
 //Fallback for react-native-web or when RN version is < 0.44
-const {View, ViewPropTypes} = ReactNative;
+const {View} = ReactNative;
 const viewPropTypes =
-  typeof document !== 'undefined'
+  typeof document !== 'undefined' || Platform.OS === 'web'
     ? PropTypes.shape({style: PropTypes.object})
-    : ViewPropTypes || View.propTypes;
+    : require('react-native').ViewPropTypes || View.propTypes;
 const EmptyArray = [];
 
 /**
@@ -38,7 +38,7 @@ class Calendar extends Component {
     /** Collection of dates that have to be marked. Default = {} */
     markedDates: PropTypes.object,
     /** Specify style for calendar container element. Default = {} */
-    style: viewPropTypes.style,
+    style: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     /** Initially visible month. Default = Date() */
     current: PropTypes.any,
     /** Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined */

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -18,10 +18,6 @@ import {SELECT_DATE_SLOT} from '../testIDs';
 
 //Fallback for react-native-web or when RN version is < 0.44
 const {View} = ReactNative;
-const viewPropTypes =
-  typeof document !== 'undefined' || Platform.OS === 'web'
-    ? PropTypes.shape({style: PropTypes.object})
-    : require('react-native').ViewPropTypes || View.propTypes;
 const EmptyArray = [];
 
 /**


### PR DESCRIPTION
This fixes CalendarList / Agenda rendering when running on web via Expo.

Thanks to @bkniffler with his fix for touch support on web here: https://github.com/bkniffler/react-native-calendars/commit/7a0f986bbef1f84b0fd6901af6974c8bcd7436c2

The main issue was that `FlatList` scrolling only works on web if the parent component has a `flex` style. Source: https://github.com/necolas/react-native-web/issues/1436#issuecomment-612845122

Also incorporated fixes for some `PropTypes` errors on web, thanks @nandorojo: https://github.com/wix/react-native-calendars/issues/1033#issuecomment-712977254

Fixes #924 