### PR TITLE
Current time indicator and scrolling to current time

### DIFF
--- a/example/src/screens/timelineCalendar.js
+++ b/example/src/screens/timelineCalendar.js
@@ -198,6 +198,7 @@ export default class TimelineCalendarScreen extends Component {
           // scrollToFirst={true}
           // scrollToNow={true}
           // currentDateString={this.state.currentDate}
+          // updateCurrentTimeIndicatorEveryMinute={true}
           // start={0}
           // end={24}
         />

--- a/example/src/screens/timelineCalendar.js
+++ b/example/src/screens/timelineCalendar.js
@@ -196,6 +196,8 @@ export default class TimelineCalendarScreen extends Component {
           eventTapped={e => e}
           events={EVENTS.filter(event => moment(event.start).isSame(this.state.currentDate, 'day'))}
           // scrollToFirst={true}
+          // scrollToNow={true}
+          // currentDateString={this.state.currentDate}
           // start={0}
           // end={24}
         />

--- a/src/timeline/Timeline.js
+++ b/src/timeline/Timeline.js
@@ -126,7 +126,7 @@ export default class Timeline extends React.PureComponent {
         <View
           key={'timeNow'}
           style={[
-            this.styles.lineNow,
+            this.style.lineNow,
             {
               top: this.currentTimeOffset(),
               width: dimensionWidth - 20,


### PR DESCRIPTION
Adds current time indicator on current date.
![image](https://user-images.githubusercontent.com/25594581/98358485-10a51600-2027-11eb-8ff3-a308be83cc74.png)

Scrolls to current time when calendar is opened.
![demo](https://user-images.githubusercontent.com/25594581/98358992-d1c39000-2027-11eb-986e-88a1e5256e3e.gif)

Also `npm run test` doesn't work because of `Agenda should move to previous month` so I couldn't get through that.