### PR TITLE
[Infrastructure] Reduce npm package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+.github
 src/**/*.spec.js
 example/
 demo/
@@ -8,9 +9,18 @@ android/
 index.android.js
 index.ios.js
 
-
-.npmignore
+.nvmrc
+.*ignore
 .watchmanconfig
+
+.eslintrc
+.eslintrc.js
+.prettierrc.json
+
+e2e
+spec
+
+ISSUE_TEMPLATE.md
 
 
 #################
@@ -241,3 +251,4 @@ demo/
 .babelrc
 # eslint-rules/
 scripts/
+


### PR DESCRIPTION
**To test:**
```sh
npm pack --dry-run
```


**Diff:**
|   | package size | unpacked size |
|---|---|---|
|Before| 58.4 kB | 218.1 kB |
|After| 55.4 kB | 207.8 kB |

- [See package content on the web](https://unpkg.com/browse/react-native-calendars/)