### PR TITLE
fixed #1304

### DIFF
--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -45,6 +45,7 @@ class WeekCalendar extends Component {
 
     this.list = React.createRef();
     this.page = NUMBER_OF_PAGES;
+    this.gettingDatesMedianIndex = 0;
 
     this.state = {
       items: this.getDatesArray()
@@ -67,7 +68,7 @@ class WeekCalendar extends Component {
   getDatesArray() {
     const array = [];
     for (let index = -NUMBER_OF_PAGES; index <= NUMBER_OF_PAGES; index++) {
-      const d = this.getDate(index);
+      const d = this.getDate(index + this.gettingDatesMedianIndex);
       array.push(d);
     }
     return array;
@@ -139,16 +140,14 @@ class WeekCalendar extends Component {
     if (isFirstPage || isLastPage) {
       this.list.current.scrollToIndex({animated: false, index: NUMBER_OF_PAGES});
       this.page = NUMBER_OF_PAGES;
-      const newWeekArray = this.getDatesArray();
 
-      if (isLastPage) {
-        for (let i = NUMBER_OF_PAGES + 1; i < items.length; i++) {
-          items[i] = newWeekArray[i];
-        }
-      } else {
-        for (let i = 0; i < NUMBER_OF_PAGES; i++) {
-          items[i] = newWeekArray[i];
-        }
+      const startIndex = isLastPage ? NUMBER_OF_PAGES : 0;
+      const endIndex = isLastPage ? items.length : NUMBER_OF_PAGES;
+      isLastPage ? this.gettingDatesMedianIndex += NUMBER_OF_PAGES : this.gettingDatesMedianIndex -= NUMBER_OF_PAGES;
+
+      const newDatesArray = this.getDatesArray();
+      for (let i = startIndex; i < endIndex; i++) {
+        items[i] = newDatesArray[i];
       }
 
       setTimeout(() => {


### PR DESCRIPTION
This PR fixes issue on #1304. 

When we scroll `WeekCalendar` to the end, it calls `onMomentumScrollEnd`.
And `getDatesArray` is also called in the `onMomentumScrollEnd`.

Maybe it have to change newDateArray on scroll to the end.
But it loads same dateArray.
So I changed code to resolve issue.


|Before|After|
|:--:|:--:|
|<img src="https://user-images.githubusercontent.com/24249859/100538840-775bcf00-3275-11eb-9386-bd51792c4bdc.png" width=400px>|<img src="https://user-images.githubusercontent.com/24249859/100538964-44fea180-3276-11eb-9adc-6e9fd3d21c2a.png" width=400px>|

![Nov-29-2020 19-32-06](https://user-images.githubusercontent.com/24249859/100539425-b724b580-3279-11eb-8890-bb20a4d8a214.gif)
