### PR TITLE
Infra/sorting prop mess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,3 +404,10 @@
 ## [1.492.0] - 2020-11-29
 ### Fix
 - example - fix formatting.
+
+## [1.493.0] - 2020-11-29
+### Fix
+- CalendarList - Forwarding missing 'disabledDaysIndexes' prop from CalendarListItem to Calendar (PR #1323).
+
+## [1.493.0] - 2020-11-29
+- Code cleanup.

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -55,8 +55,6 @@ export default class AgendaView extends Component {
     renderKnob: PropTypes.func,
     /** specify how empty date content with no items should be rendered */
     renderEmptyDay: PropTypes.func,
-    /** specify what should be rendered instead of ActivityIndicator */
-    renderEmptyData: PropTypes.func,
     /** specify your item comparison function for increased performance */
     rowHasChanged: PropTypes.func,
     /** initially selected day */

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -47,16 +47,14 @@ export default class AgendaView extends Component {
     onDayPress: PropTypes.func,
     /** callback that gets called when day changes while scrolling agenda list */
     onDaychange: PropTypes.func,
-    /** specify how each item should be rendered in agenda */
-    renderItem: PropTypes.func,
-    /** specify how each date should be rendered. day can be undefined if the item is not first in that day. */
-    renderDay: PropTypes.func,
+    
     /** specify how agenda knob should look like */
     renderKnob: PropTypes.func,
     /** specify how empty date content with no items should be rendered */
-    renderEmptyDay: PropTypes.func,
-    /** specify your item comparison function for increased performance */
-    rowHasChanged: PropTypes.func,
+    renderEmptyDate: PropTypes.func,
+    /** specify what should be rendered instead of ActivityIndicator */
+    renderEmptyData: PropTypes.func,
+    
     /** initially selected day */
     selected: PropTypes.any,
     /** Hide knob button. Default = false */

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -92,13 +92,13 @@ export default class AgendaView extends Component {
     this.state.scrollY.removeAllListeners();
   }
 
-  UNSAFE_componentWillReceiveProps(props) {
-    if (props.items) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (nextProps.items) {
       this.setState({
         firstReservationLoad: false
       });
     } else {
-      this.loadReservations(props);
+      this.loadReservations(nextProps);
     }
   }
 

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -46,15 +46,9 @@ export default class AgendaView extends Component {
     /** callback that gets called on day press */
     onDayPress: PropTypes.func,
     /** callback that gets called when day changes while scrolling agenda list */
-    onDaychange: PropTypes.func,
-    
+    onDaychange: PropTypes.func, 
     /** specify how agenda knob should look like */
     renderKnob: PropTypes.func,
-    /** specify how empty date content with no items should be rendered */
-    renderEmptyDate: PropTypes.func,
-    /** specify what should be rendered instead of ActivityIndicator */
-    renderEmptyData: PropTypes.func,
-    
     /** initially selected day */
     selected: PropTypes.any,
     /** Hide knob button. Default = false */

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -1,25 +1,24 @@
-import React, {Component} from 'react';
-import * as ReactNative from 'react-native';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
-
+import React, {Component} from 'react';
+import * as ReactNative from 'react-native';
+import {extractComponentProps} from '../component-updater';
 import {parseDate, xdateToData} from '../interface';
 import dateutils from '../dateutils';
-import CalendarList from '../calendar-list';
-import ReservationsList from './reservation-list';
-import styleConstructor from './style';
-import {VelocityTracker} from '../input';
 import {AGENDA_CALENDAR_KNOB} from '../testIDs';
-
+import {VelocityTracker} from '../input';
+import styleConstructor from './style';
+import CalendarList from '../calendar-list';
+import ReservationList from './reservation-list';
 
 const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
+
 //Fallback for react-native-web or when RN version is < 0.44
 const {Text, View, Dimensions, Animated, ViewPropTypes} = ReactNative;
 const viewPropTypes =
-  typeof document !== 'undefined'
-    ? PropTypes.shape({style: PropTypes.object})
-    : ViewPropTypes || View.propTypes;
+  typeof document !== 'undefined' ? PropTypes.shape({style: PropTypes.object}) : ViewPropTypes || View.propTypes;
 
 /**
  * @description: Agenda component
@@ -32,13 +31,13 @@ export default class AgendaView extends Component {
   static displayName = 'Agenda';
 
   static propTypes = {
-    /** Specify theme properties to override specific styles for calendar parts. Default = {} */
-    theme: PropTypes.object,
+    ...CalendarList.propTypes,
+    ...ReservationList.propTypes,
     /** agenda container style */
     style: viewPropTypes.style,
     /** the list of items that have to be displayed in agenda. If you want to render item as empty date
-    the value of date key has to be an empty array []. If there exists no value for date key it is
-    considered that the date in question is not yet loaded */
+     the value of date key has to be an empty array []. If there exists no value for date key it is
+     considered that the date in question is not yet loaded */
     items: PropTypes.object,
     /** callback that gets called when items for a certain month should be loaded (month became visible) */
     loadItemsForMonth: PropTypes.func,
@@ -60,44 +59,10 @@ export default class AgendaView extends Component {
     renderEmptyData: PropTypes.func,
     /** specify your item comparison function for increased performance */
     rowHasChanged: PropTypes.func,
-    /** Max amount of months allowed to scroll to the past. Default = 50 */
-    pastScrollRange: PropTypes.number,
-    /** Max amount of months allowed to scroll to the future. Default = 50 */
-    futureScrollRange: PropTypes.number,
     /** initially selected day */
     selected: PropTypes.any,
-    /** Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined */
-    minDate: PropTypes.any,
-    /** Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined */
-    maxDate: PropTypes.any,
-    /** If firstDay=1 week starts from Monday. Note that dayNames and dayNamesShort should still start from Sunday. */
-    firstDay: PropTypes.number,
-    /** Collection of dates that have to be marked. Default = items */
-    markedDates: PropTypes.object,
-    /** Optional marking type if custom markedDates are provided */
-    markingType: PropTypes.string,/*
     /** Hide knob button. Default = false */
-    hideKnob: PropTypes.bool,
-    /** Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting */
-    monthFormat: PropTypes.string,
-    /** A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. */
-    refreshControl: PropTypes.element,
-    /** If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the refreshing prop correctly. */
-    onRefresh: PropTypes.func,
-    /** Set this true while waiting for new data from a refresh. */
-    refreshing: PropTypes.bool,
-    /** Display loading indicator. Default = false */
-    displayLoadingIndicator: PropTypes.bool,
-    /** Called when the user begins dragging the agenda list. **/
-    onScrollBeginDrag: PropTypes.func,
-    /** Called when the user stops dragging the agenda list. **/
-    onScrollEndDrag: PropTypes.func,
-    /** Called when the momentum scroll starts for the agenda list. **/
-    onMomentumScrollBegin: PropTypes.func,
-    /** Called when the momentum scroll stops for the agenda list. **/
-    onMomentumScrollEnd: PropTypes.func,
-    /** Show items only for the selected day. Default = false */
-    showOnlySelectedDayItems: PropTypes.bool
+    hideKnob: PropTypes.bool
   };
 
   constructor(props) {
@@ -108,6 +73,7 @@ export default class AgendaView extends Component {
     const windowSize = Dimensions.get('window');
     this.viewHeight = windowSize.height;
     this.viewWidth = windowSize.width;
+
     this.scrollTimeout = undefined;
     this.headerState = 'idle';
 
@@ -115,18 +81,13 @@ export default class AgendaView extends Component {
       scrollY: new Animated.Value(0),
       calendarIsReady: false,
       calendarScrollable: false,
-      firstResevationLoad: false,
-      selectedDay: parseDate(this.props.selected) || XDate(true),
-      topDay: parseDate(this.props.selected) || XDate(true)
+      firstReservationLoad: false,
+      selectedDay: parseDate(props.selected) || XDate(true),
+      topDay: parseDate(props.selected) || XDate(true)
     };
 
     this.currentMonth = this.state.selectedDay.clone();
-    this.onLayout = this.onLayout.bind(this);
-    this.onTouchStart = this.onTouchStart.bind(this);
-    this.onTouchEnd = this.onTouchEnd.bind(this);
-    this.onStartDrag = this.onStartDrag.bind(this);
-    this.onSnapAfterDrag = this.onSnapAfterDrag.bind(this);
-    this.generateMarkings = this.generateMarkings.bind(this);
+
     this.knobTracker = new VelocityTracker();
     this.state.scrollY.addListener(({value}) => this.knobTracker.add(value));
   }
@@ -144,7 +105,7 @@ export default class AgendaView extends Component {
   UNSAFE_componentWillReceiveProps(props) {
     if (props.items) {
       this.setState({
-        firstResevationLoad: false
+        firstReservationLoad: false
       });
     } else {
       this.loadReservations(props);
@@ -152,12 +113,12 @@ export default class AgendaView extends Component {
   }
 
   calendarOffset() {
-    return 96 - (this.viewHeight / 2);
+    return 96 - this.viewHeight / 2;
   }
 
   initialScrollPadPosition = () => {
     return Math.max(0, this.viewHeight - HEADER_HEIGHT);
-  }
+  };
 
   setScrollPadPosition = (y, animated) => {
     if (this.scrollPad.scrollTo) {
@@ -166,97 +127,15 @@ export default class AgendaView extends Component {
       // Support for RN O.61 (Expo 37)
       this.scrollPad.getNode().scrollTo({x: 0, y, animated});
     }
-  }
-
-  onScrollPadLayout = () => {
-    // When user touches knob, the actual component that receives touch events is a ScrollView.
-    // It needs to be scrolled to the bottom, so that when user moves finger downwards,
-    // scroll position actually changes (it would stay at 0, when scrolled to the top).
-    this.setScrollPadPosition(this.initialScrollPadPosition(), false);
-    // delay rendering calendar in full height because otherwise it still flickers sometimes
-    setTimeout(() => this.setState({calendarIsReady: true}), 0);
-  }
-
-  onLayout(event) {
-    this.viewHeight = event.nativeEvent.layout.height;
-    this.viewWidth = event.nativeEvent.layout.width;
-    this.forceUpdate();
-  }
-
-  onTouchStart() {
-    this.headerState = 'touched';
-    if (this.knob) {
-      this.knob.setNativeProps({style: {opacity: 0.5}});
-    }
-  }
-
-  onTouchEnd() {
-    if (this.knob) {
-      this.knob.setNativeProps({style: {opacity: 1}});
-    }
-
-    if (this.headerState === 'touched') {
-      this.setScrollPadPosition(0, true);
-      this.enableCalendarScrolling();
-    }
-
-    this.headerState = 'idle';
-  }
-
-  onStartDrag() {
-    this.headerState = 'dragged';
-    this.knobTracker.reset();
-  }
-
-  onSnapAfterDrag(e) {
-    // on Android onTouchEnd is not called if dragging was started
-    this.onTouchEnd();
-    const currentY = e.nativeEvent.contentOffset.y;
-    this.knobTracker.add(currentY);
-    const projectedY = currentY + this.knobTracker.estimateSpeed() * 250/*ms*/;
-    const maxY = this.initialScrollPadPosition();
-    const snapY = (projectedY > maxY / 2) ? maxY : 0;
-    this.setScrollPadPosition(snapY, true);
-
-    if (snapY === 0) {
-      this.enableCalendarScrolling();
-    }
-  }
-
-  onVisibleMonthsChange(months) {
-    if (this.props.onVisibleMonthsChange) {
-      this.props.onVisibleMonthsChange(months);
-    }
-    if (this.props.items && !this.state.firstResevationLoad) {
-      clearTimeout(this.scrollTimeout);
-      this.scrollTimeout = setTimeout(() => {
-        if (this.props.loadItemsForMonth && this._isMounted) {
-          this.props.loadItemsForMonth(months[0]);
-        }
-      }, 200);
-    }
-  }
-
-  loadReservations(props) {
-    if ((!props.items || !Object.keys(props.items).length) && !this.state.firstResevationLoad) {
-      this.setState({
-        firstResevationLoad: true
-      }, () => {
-        if (this.props.loadItemsForMonth) {
-          this.props.loadItemsForMonth(xdateToData(this.state.selectedDay));
-        }
-      });
-    }
-  }
+  };
 
   enableCalendarScrolling() {
     this.setState({
       calendarScrollable: true
     });
 
-    if (this.props.onCalendarToggled) {
-      this.props.onCalendarToggled(true);
-    }
+    _.invoke(this.props, 'onCalendarToggled', true);
+
     // Enlarge calendarOffset here as a workaround on iOS to force repaint.
     // Otherwise the month after current one or before current one remains invisible.
     // The problem is caused by overflow: 'hidden' style, which we need for dragging
@@ -268,9 +147,22 @@ export default class AgendaView extends Component {
     this.calendar.scrollToDay(this.state.selectedDay, this.calendarOffset() + 1, true);
   }
 
-  _chooseDayFromCalendar(d) {
-    this.chooseDay(d, !this.state.calendarScrollable);
+  loadReservations(props) {
+    if ((!props.items || !Object.keys(props.items).length) && !this.state.firstReservationLoad) {
+      this.setState(
+        {
+          firstReservationLoad: true
+        },
+        () => {
+          _.invoke(this.props, 'loadItemsForMonth', xdateToData(this.state.selectedDay));
+        }
+      );
+    }
   }
+
+  chooseDayFromCalendar = d => {
+    this.chooseDay(d, !this.state.calendarScrollable);
+  };
 
   chooseDay(d, optimisticScroll) {
     const day = parseDate(d);
@@ -280,9 +172,7 @@ export default class AgendaView extends Component {
       selectedDay: day.clone()
     });
 
-    if (this.props.onCalendarToggled) {
-      this.props.onCalendarToggled(false);
-    }
+    _.invoke(this.props, 'onCalendarToggled', false);
 
     if (!optimisticScroll) {
       this.setState({
@@ -293,43 +183,101 @@ export default class AgendaView extends Component {
     this.setScrollPadPosition(this.initialScrollPadPosition(), true);
     this.calendar.scrollToDay(day, this.calendarOffset(), true);
 
-    if (this.props.loadItemsForMonth) {
-      this.props.loadItemsForMonth(xdateToData(day));
-    }
-
-    if (this.props.onDayPress) {
-      this.props.onDayPress(xdateToData(day));
-    }
+    _.invoke(this.props, 'loadItemsForMonth', xdateToData(day));
+    _.invoke(this.props, 'onDayPress', xdateToData(day));
   }
 
-  renderReservations() {
-    return (
-      <ReservationsList
-        onScrollBeginDrag={this.props.onScrollBeginDrag}
-        onScrollEndDrag={this.props.onScrollEndDrag}
-        onMomentumScrollBegin={this.props.onMomentumScrollBegin}
-        onMomentumScrollEnd={this.props.onMomentumScrollEnd}
-        refreshControl={this.props.refreshControl}
-        refreshing={this.props.refreshing}
-        onRefresh={this.props.onRefresh}
-        rowHasChanged={this.props.rowHasChanged}
-        renderItem={this.props.renderItem}
-        renderDay={this.props.renderDay}
-        renderEmptyDate={this.props.renderEmptyDate}
-        reservations={this.props.items}
-        selectedDay={this.state.selectedDay}
-        renderEmptyData={this.props.renderEmptyData}
-        topDay={this.state.topDay}
-        onDayChange={this.onDayChange.bind(this)}
-        onScroll={() => { }}
-        ref={(c) => this.list = c}
-        theme={this.props.theme}
-        showOnlySelectedDayItems={this.props.showOnlySelectedDayItems}
-      />
-    );
+  generateMarkings = () => {
+    const {markedDates, items} = this.props;
+    let markings = markedDates;
+
+    if (!markings) {
+      markings = {};
+      Object.keys(items || {}).forEach(key => {
+        if (items[key] && items[key].length) {
+          markings[key] = {marked: true};
+        }
+      });
+    }
+
+    const key = this.state.selectedDay.toString('yyyy-MM-dd');
+    return {...markings, [key]: {...(markings[key] || {}), ...{selected: true}}};
+  };
+
+  onScrollPadLayout = () => {
+    // When user touches knob, the actual component that receives touch events is a ScrollView.
+    // It needs to be scrolled to the bottom, so that when user moves finger downwards,
+    // scroll position actually changes (it would stay at 0, when scrolled to the top).
+    this.setScrollPadPosition(this.initialScrollPadPosition(), false);
+    // delay rendering calendar in full height because otherwise it still flickers sometimes
+    setTimeout(() => this.setState({calendarIsReady: true}), 0);
+  };
+
+  onCalendarListLayout = () => {
+    this.calendar.scrollToDay(this.state.selectedDay.clone(), this.calendarOffset(), false);
   }
 
-  onDayChange(day) {
+  onLayout = event => {
+    this.viewHeight = event.nativeEvent.layout.height;
+    this.viewWidth = event.nativeEvent.layout.width;
+    this.forceUpdate();
+  };
+
+  onTouchStart = () => {
+    this.headerState = 'touched';
+    if (this.knob) {
+      this.knob.setNativeProps({style: {opacity: 0.5}});
+    }
+  };
+
+  onTouchEnd = () => {
+    if (this.knob) {
+      this.knob.setNativeProps({style: {opacity: 1}});
+    }
+
+    if (this.headerState === 'touched') {
+      this.setScrollPadPosition(0, true);
+      this.enableCalendarScrolling();
+    }
+
+    this.headerState = 'idle';
+  };
+
+  onStartDrag = () => {
+    this.headerState = 'dragged';
+    this.knobTracker.reset();
+  };
+
+  onSnapAfterDrag = e => {
+    // on Android onTouchEnd is not called if dragging was started
+    this.onTouchEnd();
+    const currentY = e.nativeEvent.contentOffset.y;
+    this.knobTracker.add(currentY);
+    const projectedY = currentY + this.knobTracker.estimateSpeed() * 250; /*ms*/
+    const maxY = this.initialScrollPadPosition();
+    const snapY = projectedY > maxY / 2 ? maxY : 0;
+    this.setScrollPadPosition(snapY, true);
+
+    if (snapY === 0) {
+      this.enableCalendarScrolling();
+    }
+  };
+
+  onVisibleMonthsChange = months => {
+    _.invoke(this.props, 'onVisibleMonthsChange', months);
+
+    if (this.props.items && !this.state.firstReservationLoad) {
+      clearTimeout(this.scrollTimeout);
+
+      this.scrollTimeout = setTimeout(() => {
+        if (this._isMounted) {
+          _.invoke(this.props, 'loadItemsForMonth', months[0]);
+        }
+      }, 200);
+    }
+  };
+
+  onDayChange = day => {
     const newDate = parseDate(day);
     const withAnimation = dateutils.sameMonth(newDate, this.state.selectedDay);
 
@@ -338,61 +286,100 @@ export default class AgendaView extends Component {
       selectedDay: parseDate(day)
     });
 
-    if (this.props.onDayChange) {
-      this.props.onDayChange(xdateToData(newDate));
-    }
+    _.invoke(this.props, 'onDayChange', xdateToData(newDate));
+  };
+
+
+  renderReservations() {
+    const reservationListUserProps = extractComponentProps(ReservationList, this.props);
+
+    return (
+      <ReservationList
+        {...reservationListUserProps}
+        ref={c => (this.list = c)}
+        reservations={this.props.items}
+        selectedDay={this.state.selectedDay}
+        topDay={this.state.topDay}
+        onDayChange={this.onDayChange}
+        onScroll={() => {}}
+      />
+    );
   }
 
-  generateMarkings() {
-    let markings = this.props.markedDates;
+  renderCalendarList() {
+    const shouldHideExtraDays = this.state.calendarScrollable ? this.props.hideExtraDays : false;
+    const calendarListUserProps = extractComponentProps(CalendarList, this.props);
 
-    if (!markings) {
-      markings = {};
-      Object.keys(this.props.items || {}).forEach(key => {
-        if (this.props.items[key] && this.props.items[key].length) {
-          markings[key] = {marked: true};
-        }
-      });
+    return (
+      <CalendarList
+        {...calendarListUserProps}
+        ref={c => (this.calendar = c)}
+        current={this.currentMonth}
+        markedDates={this.generateMarkings()}
+        calendarWidth={this.viewWidth}
+        scrollEnabled={this.state.calendarScrollable}
+        hideExtraDays={shouldHideExtraDays}
+        onLayout={this.onCalendarListLayout}
+        onDayPress={this.chooseDayFromCalendar}
+        onVisibleMonthsChange={this.onVisibleMonthsChange}
+      />
+    );
+  }
+
+  renderKnob() {
+    const {hideKnob, renderKnob} = this.props;
+    let knob = <View style={this.style.knobContainer}/>;
+    
+    if (!hideKnob) {
+      const knobView = renderKnob ? renderKnob() : <View style={this.style.knob}/>;
+      knob = this.state.calendarScrollable ? null : (
+        <View style={this.style.knobContainer}>
+          <View ref={c => (this.knob = c)}>{knobView}</View>
+        </View>
+      );
     }
-
-    const key = this.state.selectedDay.toString('yyyy-MM-dd');
-    return {...markings, [key]: {...(markings[key] || {}), ...{selected: true}}};
+    return knob;
   }
 
   render() {
+    const {firstDay, hideKnob, showWeekNumbers, style, testID} = this.props;
     const agendaHeight = this.initialScrollPadPosition();
-    const weekDaysNames = dateutils.weekDayNames(this.props.firstDay);
-
-    const weekdaysStyle = [this.style.weekdays, {
-      opacity: this.state.scrollY.interpolate({
-        inputRange: [agendaHeight - HEADER_HEIGHT, agendaHeight],
-        outputRange: [0, 1],
-        extrapolate: 'clamp'
-      }),
-      transform: [{
-        translateY: this.state.scrollY.interpolate({
-          inputRange: [Math.max(0, agendaHeight - HEADER_HEIGHT), agendaHeight],
-          outputRange: [-HEADER_HEIGHT, 0],
+    const weekDaysNames = dateutils.weekDayNames(firstDay);
+    const weekdaysStyle = [
+      this.style.weekdays,
+      {
+        opacity: this.state.scrollY.interpolate({
+          inputRange: [agendaHeight - HEADER_HEIGHT, agendaHeight],
+          outputRange: [0, 1],
           extrapolate: 'clamp'
-        })
-      }]
-    }];
-
+        }),
+        transform: [
+          {
+            translateY: this.state.scrollY.interpolate({
+              inputRange: [Math.max(0, agendaHeight - HEADER_HEIGHT), agendaHeight],
+              outputRange: [-HEADER_HEIGHT, 0],
+              extrapolate: 'clamp'
+            })
+          }
+        ]
+      }
+    ];
     const headerTranslate = this.state.scrollY.interpolate({
       inputRange: [0, agendaHeight],
       outputRange: [agendaHeight, 0],
       extrapolate: 'clamp'
     });
-
     const contentTranslate = this.state.scrollY.interpolate({
       inputRange: [0, agendaHeight],
       outputRange: [0, agendaHeight / 2],
       extrapolate: 'clamp'
     });
-
     const headerStyle = [
-      this.style.header,
-      {bottom: agendaHeight, transform: [{translateY: headerTranslate}]}
+      this.style.header, 
+      {
+        bottom: agendaHeight, 
+        transform: [{translateY: headerTranslate}]
+      }
     ];
 
     if (!this.state.calendarIsReady) {
@@ -402,9 +389,8 @@ export default class AgendaView extends Component {
       weekdaysStyle.push({height: HEADER_HEIGHT});
     }
 
-    const shouldAllowDragging = !this.props.hideKnob && !this.state.calendarScrollable;
+    const shouldAllowDragging = !hideKnob && !this.state.calendarScrollable;
     const scrollPadPosition = (shouldAllowDragging ? HEADER_HEIGHT : 0) - KNOB_HEIGHT;
-
     const scrollPadStyle = {
       position: 'absolute',
       width: 80,
@@ -413,76 +399,42 @@ export default class AgendaView extends Component {
       left: (this.viewWidth - 80) / 2
     };
 
-    let knob = (<View style={this.style.knobContainer}/>);
-
-    if (!this.props.hideKnob) {
-      const knobView = this.props.renderKnob ? this.props.renderKnob() : (<View style={this.style.knob}/>);
-      knob = this.state.calendarScrollable ? null : (
-        <View style={this.style.knobContainer}>
-          <View ref={(c) => this.knob = c}>{knobView}</View>
-        </View>
-      );
-    }
-    const shouldHideExtraDays = this.state.calendarScrollable ? this.props.hideExtraDays : false;
-
     return (
-      <View testID={this.props.testID} onLayout={this.onLayout} style={[this.props.style, {flex: 1, overflow: 'hidden'}]}>
-        <View style={this.style.reservations}>
-          {this.renderReservations()}
-        </View>
+      <View
+        testID={testID}
+        onLayout={this.onLayout}
+        style={[style, {flex: 1, overflow: 'hidden'}]}
+      >
+        <View style={this.style.reservations}>{this.renderReservations()}</View>
         <Animated.View style={headerStyle}>
           <Animated.View style={{flex: 1, transform: [{translateY: contentTranslate}]}}>
-            <CalendarList
-              onLayout={() => {
-                this.calendar.scrollToDay(this.state.selectedDay.clone(), this.calendarOffset(), false);
-              }}
-              calendarWidth={this.viewWidth}
-              theme={this.props.theme}
-              onVisibleMonthsChange={this.onVisibleMonthsChange.bind(this)}
-              ref={(c) => this.calendar = c}
-              minDate={this.props.minDate}
-              maxDate={this.props.maxDate}
-              current={this.currentMonth}
-              markedDates={this.generateMarkings()}
-              markingType={this.props.markingType}
-              removeClippedSubviews={this.props.removeClippedSubviews}
-              onDayPress={this._chooseDayFromCalendar.bind(this)}
-              scrollEnabled={this.state.calendarScrollable}
-              hideExtraDays={shouldHideExtraDays}
-              firstDay={this.props.firstDay}
-              monthFormat={this.props.monthFormat}
-              pastScrollRange={this.props.pastScrollRange}
-              futureScrollRange={this.props.futureScrollRange}
-              dayComponent={this.props.dayComponent}
-              disabledByDefault={this.props.disabledByDefault}
-              displayLoadingIndicator={this.props.displayLoadingIndicator}
-              showWeekNumbers={this.props.showWeekNumbers}
-            />
+            {this.renderCalendarList()}
           </Animated.View>
-          {knob}
+          {this.renderKnob()}
         </Animated.View>
         <Animated.View style={weekdaysStyle}>
-          {this.props.showWeekNumbers && <Text allowFontScaling={false} style={this.style.weekday} numberOfLines={1}></Text>}
+          {showWeekNumbers && (
+            <Text allowFontScaling={false} style={this.style.weekday} numberOfLines={1}></Text>
+          )}
           {weekDaysNames.map((day, index) => (
-            <Text allowFontScaling={false} key={day + index} style={this.style.weekday} numberOfLines={1}>{day}</Text>
+            <Text allowFontScaling={false} key={day + index} style={this.style.weekday} numberOfLines={1}>
+              {day}
+            </Text>
           ))}
         </Animated.View>
         <Animated.ScrollView
-          ref={ref => this.scrollPad = ref}
-          overScrollMode='never'
+          ref={ref => (this.scrollPad = ref)}
+          style={scrollPadStyle}
+          overScrollMode="never"
           showsHorizontalScrollIndicator={false}
           showsVerticalScrollIndicator={false}
-          style={scrollPadStyle}
           scrollEventThrottle={8}
           scrollsToTop={false}
           onTouchStart={this.onTouchStart}
           onTouchEnd={this.onTouchEnd}
           onScrollBeginDrag={this.onStartDrag}
           onScrollEndDrag={this.onSnapAfterDrag}
-          onScroll={Animated.event(
-            [{nativeEvent: {contentOffset: {y: this.state.scrollY}}}],
-            {useNativeDriver: true}
-          )}
+          onScroll={Animated.event([{nativeEvent: {contentOffset: {y: this.state.scrollY}}}], {useNativeDriver: true})}
         >
           <View
             testID={AGENDA_CALENDAR_KNOB}

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -273,7 +273,7 @@ export default class AgendaView extends Component {
 
     this.calendar.scrollToDay(day, this.calendarOffset(), withAnimation);
     this.setState({
-      selectedDay: parseDate(day)
+      selectedDay: newDate
     });
 
     _.invoke(this.props, 'onDayChange', xdateToData(newDate));

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -23,7 +23,8 @@ class ReservationList extends Component {
     showOnlySelectedDayItems: PropTypes.bool,
     // callback that gets called when day changes while scrolling agenda list
     onDayChange: PropTypes.func,
-
+    /** specify what should be rendered instead of ActivityIndicator */
+    renderEmptyData: PropTypes.func,
 
     /** A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. */
     refreshControl: PropTypes.element,

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -1,44 +1,50 @@
-import React, {Component} from 'react';
-import {FlatList, ActivityIndicator, View} from 'react-native';
-import Reservation from './reservation';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
-
+import React, {Component} from 'react';
+import {FlatList, ActivityIndicator, View} from 'react-native';
+import {extractComponentProps} from '../../component-updater';
 import dateutils from '../../dateutils';
 import styleConstructor from './style';
-
+import Reservation from './reservation';
 
 class ReservationList extends Component {
   static displayName = 'IGNORE';
 
   static propTypes = {
-    // specify your item comparison function for increased performance
-    rowHasChanged: PropTypes.func,
-    // specify how each item should be rendered in agenda
-    renderItem: PropTypes.func,
-    // specify how each date should be rendered. day can be undefined if the item is not first in that day.
-    renderDay: PropTypes.func,
-    // specify how empty date content with no items should be rendered
-    renderEmptyDate: PropTypes.func,
-    // callback that gets called when day changes while scrolling agenda list
-    onDayChange: PropTypes.func,
-    // onScroll ListView event
-    onScroll: PropTypes.func,
+    ...Reservation.propTypes,
     // the list of items that have to be displayed in agenda. If you want to render item as empty date
     // the value of date key kas to be an empty array []. If there exists no value for date key it is
     // considered that the date in question is not yet loaded
     reservations: PropTypes.object,
     selectedDay: PropTypes.instanceOf(XDate),
     topDay: PropTypes.instanceOf(XDate),
-    refreshControl: PropTypes.element,
-    refreshing: PropTypes.bool,
-    onRefresh: PropTypes.func,
-    onScrollBeginDrag: PropTypes.func,
-    onScrollEndDrag: PropTypes.func,
-    onMomentumScrollBegin: PropTypes.func,
-    onMomentumScrollEnd: PropTypes.func,
     /** Show items only for the selected day. Default = false */
-    showOnlySelectedDayItems: PropTypes.bool
+    showOnlySelectedDayItems: PropTypes.bool,
+    // callback that gets called when day changes while scrolling agenda list
+    onDayChange: PropTypes.func,
+
+
+    /** A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. */
+    refreshControl: PropTypes.element,
+    /** Set this true while waiting for new data from a refresh. */
+    refreshing: PropTypes.bool,
+    /** If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the refreshing prop correctly. */
+    onRefresh: PropTypes.func,
+    /** onScroll ListView event */
+    onScroll: PropTypes.func,
+    /** Called when the user begins dragging the agenda list. **/
+    onScrollBeginDrag: PropTypes.func,
+    /** Called when the user stops dragging the agenda list. **/
+    onScrollEndDrag: PropTypes.func,
+    /** Called when the momentum scroll starts for the agenda list. **/
+    onMomentumScrollBegin: PropTypes.func,
+    /** Called when the momentum scroll stops for the agenda list. **/
+    onMomentumScrollEnd: PropTypes.func
+  };
+
+  static defaultProps = {
+    refreshing: false
   };
 
   constructor(props) {
@@ -50,13 +56,28 @@ class ReservationList extends Component {
       reservations: []
     };
 
-    this.heights=[];
-    this.selectedDay = this.props.selectedDay;
+    this.heights = [];
+    this.selectedDay = props.selectedDay;
     this.scrollOver = true;
   }
 
   UNSAFE_componentWillMount() {
     this.updateDataSource(this.getReservations(this.props).reservations);
+  }
+
+  UNSAFE_componentWillReceiveProps(props) {
+    if (!dateutils.sameDate(props.topDay, this.props.topDay)) {
+      this.setState(
+        {
+          reservations: []
+        },
+        () => {
+          this.updateReservations(props);
+        }
+      );
+    } else {
+      this.updateReservations(props);
+    }
   }
 
   updateDataSource(reservations) {
@@ -79,58 +100,6 @@ class ReservationList extends Component {
     this.updateDataSource(reservations.reservations);
   }
 
-  UNSAFE_componentWillReceiveProps(props) {
-    if (!dateutils.sameDate(props.topDay, this.props.topDay)) {
-      this.setState({
-        reservations: []
-      }, () => {
-        this.updateReservations(props);
-      });
-    } else {
-      this.updateReservations(props);
-    }
-  }
-
-  onScroll(event) {
-    const yOffset = event.nativeEvent.contentOffset.y;
-    this.props.onScroll(yOffset);
-    let topRowOffset = 0;
-    let topRow;
-    for (topRow = 0; topRow < this.heights.length; topRow++) {
-      if (topRowOffset + this.heights[topRow] / 2 >= yOffset) {
-        break;
-      }
-      topRowOffset += this.heights[topRow];
-    }
-    const row = this.state.reservations[topRow];
-    if (!row) return;
-    const day = row.day;
-    const sameDate = dateutils.sameDate(day, this.selectedDay);
-    if (!sameDate && this.scrollOver) {
-      this.selectedDay = day.clone();
-      this.props.onDayChange(day.clone());
-    }
-  }
-
-  onRowLayoutChange(ind, event) {
-    this.heights[ind] = event.nativeEvent.layout.height;
-  }
-
-  renderRow({item, index}) {
-    return (
-      <View onLayout={this.onRowLayoutChange.bind(this, index)}>
-        <Reservation
-          item={item}
-          renderItem={this.props.renderItem}
-          renderDay={this.props.renderDay}
-          renderEmptyDate={this.props.renderEmptyDate}
-          theme={this.props.theme}
-          rowHasChanged={this.props.rowHasChanged}
-        />
-      </View>
-    );
-  }
-
   getReservationsForDay(iterator, props) {
     const day = iterator.clone();
     const res = props.reservations[day.toString('yyyy-MM-dd')];
@@ -143,26 +112,26 @@ class ReservationList extends Component {
         };
       });
     } else if (res) {
-      return [{
-        date: iterator.clone(),
-        day
-      }];
+      return [
+        {
+          date: iterator.clone(),
+          day
+        }
+      ];
     } else {
       return false;
     }
-  }
-
-  onListTouch() {
-    this.scrollOver = true;
   }
 
   getReservations(props) {
     if (!props.reservations || !props.selectedDay) {
       return {reservations: [], scrollPosition: 0};
     }
+
     let reservations = [];
     if (this.state.reservations && this.state.reservations.length) {
       const iterator = this.state.reservations[0].day.clone();
+
       while (iterator.getTime() < props.selectedDay.getTime()) {
         const res = this.getReservationsForDay(iterator, props);
         if (!res) {
@@ -174,10 +143,12 @@ class ReservationList extends Component {
         iterator.addDays(1);
       }
     }
+
     const scrollPosition = reservations.length;
     const iterator = props.selectedDay.clone();
-    if(this.props.showOnlySelectedDayItems){
+    if (this.props.showOnlySelectedDayItems) {
       const res = this.getReservationsForDay(iterator, props);
+
       if (res) {
         reservations = res;
       }
@@ -185,6 +156,7 @@ class ReservationList extends Component {
     } else {
       for (let i = 0; i < 31; i++) {
         const res = this.getReservationsForDay(iterator, props);
+
         if (res) {
           reservations = reservations.concat(res);
         }
@@ -195,30 +167,75 @@ class ReservationList extends Component {
     return {reservations, scrollPosition};
   }
 
-  render() {
-    const {reservations} = this.props;
-    if (!reservations || !reservations[this.props.selectedDay.toString('yyyy-MM-dd')]) {
-      if (this.props.renderEmptyData) {
-        return this.props.renderEmptyData();
+  onScroll = event => {
+    const yOffset = event.nativeEvent.contentOffset.y;
+    _.invoke(this.props, 'onScroll', yOffset);
+
+    let topRowOffset = 0;
+    let topRow;
+    for (topRow = 0; topRow < this.heights.length; topRow++) {
+      if (topRowOffset + this.heights[topRow] / 2 >= yOffset) {
+        break;
       }
-      return (
-        <ActivityIndicator style={this.style.indicator} color={this.props.theme && this.props.theme.indicatorColor}/>
-      );
+      topRowOffset += this.heights[topRow];
     }
+
+    const row = this.state.reservations[topRow];
+    if (!row) return;
+
+    const day = row.day;
+    const sameDate = dateutils.sameDate(day, this.selectedDay);
+    if (!sameDate && this.scrollOver) {
+      this.selectedDay = day.clone();
+      _.invoke(this.props, 'onDayChange', day.clone());
+    }
+  };
+
+  onListTouch() {
+    this.scrollOver = true;
+  }
+
+  onRowLayoutChange(ind, event) {
+    this.heights[ind] = event.nativeEvent.layout.height;
+  }
+
+  renderRow = ({item, index}) => {
+    const reservationUserProps = extractComponentProps(Reservation, this.props);
+
+    return (
+      <View onLayout={this.onRowLayoutChange.bind(this, index)}>
+        <Reservation {...reservationUserProps} item={item} />
+      </View>
+    );
+  };
+
+  render() {
+    const {reservations, selectedDay, theme} = this.props;
+
+    if (!reservations || !reservations[selectedDay.toString('yyyy-MM-dd')]) {
+      _.invoke(this.props, 'renderEmptyData');
+
+      return <ActivityIndicator style={this.style.indicator} color={theme && theme.indicatorColor} />;
+    }
+
     return (
       <FlatList
-        ref={(c) => this.list = c}
+        ref={c => (this.list = c)}
         style={this.props.style}
         contentContainerStyle={this.style.content}
-        renderItem={this.renderRow.bind(this)}
         data={this.state.reservations}
-        onScroll={this.onScroll.bind(this)}
+        renderItem={this.renderRow}
+        keyExtractor={(item, index) => String(index)}
         showsVerticalScrollIndicator={false}
         scrollEventThrottle={200}
-        onMoveShouldSetResponderCapture={() => {this.onListTouch(); return false;}}
-        keyExtractor={(item, index) => String(index)}
+        onMoveShouldSetResponderCapture={() => {
+          this.onListTouch();
+          return false;
+        }}
+        onScroll={this.onScroll}
+        
         refreshControl={this.props.refreshControl}
-        refreshing={this.props.refreshing || false}
+        refreshing={this.props.refreshing}
         onRefresh={this.props.onRefresh}
         onScrollBeginDrag={this.props.onScrollBeginDrag}
         onScrollEndDrag={this.props.onScrollEndDrag}

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -26,12 +26,6 @@ class ReservationList extends Component {
     /** specify what should be rendered instead of ActivityIndicator */
     renderEmptyData: PropTypes.func,
 
-    /** A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. */
-    refreshControl: PropTypes.element,
-    /** Set this true while waiting for new data from a refresh. */
-    refreshing: PropTypes.bool,
-    /** If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the refreshing prop correctly. */
-    onRefresh: PropTypes.func,
     /** onScroll ListView event */
     onScroll: PropTypes.func,
     /** Called when the user begins dragging the agenda list. **/
@@ -41,11 +35,18 @@ class ReservationList extends Component {
     /** Called when the momentum scroll starts for the agenda list. **/
     onMomentumScrollBegin: PropTypes.func,
     /** Called when the momentum scroll stops for the agenda list. **/
-    onMomentumScrollEnd: PropTypes.func
+    onMomentumScrollEnd: PropTypes.func,
+    /** A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. */
+    refreshControl: PropTypes.element,
+    /** Set this true while waiting for new data from a refresh. */
+    refreshing: PropTypes.bool,
+    /** If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the refreshing prop correctly. */
+    onRefresh: PropTypes.func
   };
 
   static defaultProps = {
-    refreshing: false
+    refreshing: false,
+    selectedDay: XDate(true)
   };
 
   constructor(props) {
@@ -219,7 +220,6 @@ class ReservationList extends Component {
 
   render() {
     const {reservations, selectedDay, theme, style} = this.props;
-
     if (!reservations || !reservations[selectedDay.toString('yyyy-MM-dd')]) {
       _.invoke(this.props, 'renderEmptyData');
 

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -200,6 +200,11 @@ class ReservationList extends Component {
     this.heights[ind] = event.nativeEvent.layout.height;
   }
 
+  onMoveShouldSetResponderCapture = () => {
+    this.onListTouch();
+    return false;
+  }
+
   renderRow = ({item, index}) => {
     const reservationUserProps = extractComponentProps(Reservation, this.props);
 
@@ -229,10 +234,7 @@ class ReservationList extends Component {
         keyExtractor={(item, index) => String(index)}
         showsVerticalScrollIndicator={false}
         scrollEventThrottle={200}
-        onMoveShouldSetResponderCapture={() => {
-          this.onListTouch();
-          return false;
-        }}
+        onMoveShouldSetResponderCapture={this.onMoveShouldSetResponderCapture}
         onScroll={this.onScroll}
         
         refreshControl={this.props.refreshControl}

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -66,18 +66,18 @@ class ReservationList extends Component {
     this.updateDataSource(this.getReservations(this.props).reservations);
   }
 
-  UNSAFE_componentWillReceiveProps(props) {
-    if (!dateutils.sameDate(props.topDay, this.props.topDay)) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (!dateutils.sameDate(nextProps.topDay, this.props.topDay)) {
       this.setState(
         {
           reservations: []
         },
         () => {
-          this.updateReservations(props);
+          this.updateReservations(nextProps);
         }
       );
     } else {
-      this.updateReservations(props);
+      this.updateReservations(nextProps);
     }
   }
 
@@ -88,8 +88,9 @@ class ReservationList extends Component {
   }
 
   updateReservations(props) {
+    const {selectedDay} = props;
     const reservations = this.getReservations(props);
-    if (this.list && !dateutils.sameDate(props.selectedDay, this.selectedDay)) {
+    if (this.list && !dateutils.sameDate(selectedDay, this.selectedDay)) {
       let scrollPosition = 0;
       for (let i = 0; i < reservations.scrollPosition; i++) {
         scrollPosition += this.heights[i] || 0;
@@ -97,7 +98,7 @@ class ReservationList extends Component {
       this.scrollOver = false;
       this.list.scrollToOffset({offset: scrollPosition, animated: true});
     }
-    this.selectedDay = props.selectedDay;
+    this.selectedDay = selectedDay;
     this.updateDataSource(reservations.reservations);
   }
 
@@ -125,7 +126,8 @@ class ReservationList extends Component {
   }
 
   getReservations(props) {
-    if (!props.reservations || !props.selectedDay) {
+    const {selectedDay, showOnlySelectedDayItems} = props;
+    if (!props.reservations || !selectedDay) {
       return {reservations: [], scrollPosition: 0};
     }
 
@@ -133,7 +135,7 @@ class ReservationList extends Component {
     if (this.state.reservations && this.state.reservations.length) {
       const iterator = this.state.reservations[0].day.clone();
 
-      while (iterator.getTime() < props.selectedDay.getTime()) {
+      while (iterator.getTime() < selectedDay.getTime()) {
         const res = this.getReservationsForDay(iterator, props);
         if (!res) {
           reservations = [];
@@ -146,8 +148,8 @@ class ReservationList extends Component {
     }
 
     const scrollPosition = reservations.length;
-    const iterator = props.selectedDay.clone();
-    if (this.props.showOnlySelectedDayItems) {
+    const iterator = selectedDay.clone();
+    if (showOnlySelectedDayItems) {
       const res = this.getReservationsForDay(iterator, props);
 
       if (res) {
@@ -203,7 +205,7 @@ class ReservationList extends Component {
   onMoveShouldSetResponderCapture = () => {
     this.onListTouch();
     return false;
-  }
+  };
 
   renderRow = ({item, index}) => {
     const reservationUserProps = extractComponentProps(Reservation, this.props);
@@ -216,7 +218,7 @@ class ReservationList extends Component {
   };
 
   render() {
-    const {reservations, selectedDay, theme} = this.props;
+    const {reservations, selectedDay, theme, style} = this.props;
 
     if (!reservations || !reservations[selectedDay.toString('yyyy-MM-dd')]) {
       _.invoke(this.props, 'renderEmptyData');
@@ -227,7 +229,7 @@ class ReservationList extends Component {
     return (
       <FlatList
         ref={c => (this.list = c)}
-        style={this.props.style}
+        style={style}
         contentContainerStyle={this.style.content}
         data={this.state.reservations}
         renderItem={this.renderRow}

--- a/src/agenda/reservation-list/reservation.js
+++ b/src/agenda/reservation-list/reservation.js
@@ -1,16 +1,27 @@
 import _ from 'lodash';
+import PropTypes from 'prop-types';
+import XDate from 'xdate';
 import React, {Component} from 'react';
 import {View, Text} from 'react-native';
-
 import {xdateToData} from '../../interface';
-import XDate from 'xdate';
 import dateutils from '../../dateutils';
-import styleConstructor from './style';
 import {RESERVATION_DATE} from '../../testIDs';
-
+import styleConstructor from './style';
 
 class Reservation extends Component {
   static displayName = 'IGNORE';
+
+  static propTypes = {
+    item: PropTypes.any,
+    // specify your item comparison function for increased performance
+    rowHasChanged: PropTypes.func,
+    // specify how each date should be rendered. day can be undefined if the item is not first in that day.
+    renderDay: PropTypes.func,
+    // specify how each item should be rendered in agenda
+    renderItem: PropTypes.func,
+    // specify how empty date content with no items should be rendered
+    renderEmptyDate: PropTypes.func
+  };
 
   constructor(props) {
     super(props);
@@ -22,6 +33,7 @@ class Reservation extends Component {
     const r1 = this.props.item;
     const r2 = nextProps.item;
     let changed = true;
+
     if (!r1 && !r2) {
       changed = false;
     } else if (r1 && r2) {
@@ -44,24 +56,28 @@ class Reservation extends Component {
     if (_.isFunction(this.props.renderDay)) {
       return this.props.renderDay(date ? xdateToData(date) : undefined, item);
     }
+
     const today = dateutils.sameDate(date, XDate()) ? this.style.today : undefined;
     if (date) {
       return (
         <View style={this.style.day} testID={RESERVATION_DATE}>
-          <Text allowFontScaling={false} style={[this.style.dayNum, today]}>{date.getDate()}</Text>
-          <Text allowFontScaling={false} style={[this.style.dayText, today]}>{XDate.locales[XDate.defaultLocale].dayNamesShort[date.getDay()]}</Text>
+          <Text allowFontScaling={false} style={[this.style.dayNum, today]}>
+            {date.getDate()}
+          </Text>
+          <Text allowFontScaling={false} style={[this.style.dayText, today]}>
+            {XDate.locales[XDate.defaultLocale].dayNamesShort[date.getDay()]}
+          </Text>
         </View>
       );
     } else {
-      return (
-        <View style={this.style.day}/>
-      );
+      return <View style={this.style.day} />;
     }
   }
 
   render() {
     const {reservation, date} = this.props.item;
     let content;
+
     if (reservation) {
       const firstItem = date ? true : false;
       if (_.isFunction(this.props.renderItem)) {
@@ -70,12 +86,11 @@ class Reservation extends Component {
     } else if (_.isFunction(this.props.renderEmptyDate)) {
       content = this.props.renderEmptyDate(date);
     }
+
     return (
       <View style={this.style.container}>
         {this.renderDate(date, reservation)}
-        <View style={this.style.innerContainer}>
-          {content}
-        </View>
+        <View style={this.style.innerContainer}>{content}</View>
       </View>
     );
   }

--- a/src/agenda/reservation-list/style.js
+++ b/src/agenda/reservation-list/style.js
@@ -5,7 +5,7 @@ const STYLESHEET_ID = 'stylesheet.agenda.list';
 
 export default function styleConstructor(theme = {}) {
   const appStyle = {...defaultStyle, ...theme};
-  return  StyleSheet.create({
+  return StyleSheet.create({
     container: {
       flexDirection: 'row'
     },

--- a/src/agenda/style.js
+++ b/src/agenda/style.js
@@ -2,22 +2,21 @@ import {StyleSheet} from 'react-native';
 import * as defaultStyle from '../style';
 import platformStyles from './platform-style';
 
-
 const STYLESHEET_ID = 'stylesheet.agenda.main';
 
 export default function styleConstructor(theme = {}) {
   const appStyle = {...defaultStyle, ...theme};
   const {knob, weekdays} = platformStyles(appStyle);
-  
+
   return StyleSheet.create({
     knob,
     weekdays,
     header: {
       overflow: 'hidden',
       justifyContent: 'flex-end',
-      position:'absolute',
-      height:'100%',
-      width:'100%'
+      position: 'absolute',
+      height: '100%',
+      width: '100%'
     },
     knobContainer: {
       flex: 1,

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -297,6 +297,7 @@ class CalendarList extends Component {
           initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
           showsVerticalScrollIndicator={this.props.showScrollIndicator}
           showsHorizontalScrollIndicator={horizontal && this.props.showScrollIndicator}
+          
           testID={this.props.testID}
           onLayout={this.props.onLayout}
           horizontal={this.props.horizontal}

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -297,8 +297,8 @@ class CalendarList extends Component {
           initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
           showsVerticalScrollIndicator={this.props.showScrollIndicator}
           showsHorizontalScrollIndicator={horizontal && this.props.showScrollIndicator}
-          
           testID={this.props.testID}
+          
           onLayout={this.props.onLayout}
           horizontal={this.props.horizontal}
           pagingEnabled={this.props.pagingEnabled}

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -281,7 +281,7 @@ class CalendarList extends Component {
   }
 
   render() {
-    const {style, pastScrollRange, futureScrollRange, horizontal} = this.props;
+    const {style, pastScrollRange, futureScrollRange, horizontal, showScrollIndicator, testID} = this.props;
 
     return (
       <View>
@@ -295,18 +295,18 @@ class CalendarList extends Component {
           onViewableItemsChanged={this.onViewableItemsChanged}
           viewabilityConfig={this.viewabilityConfig}
           initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
-          showsVerticalScrollIndicator={this.props.showScrollIndicator}
-          showsHorizontalScrollIndicator={horizontal && this.props.showScrollIndicator}
-          testID={this.props.testID}
+          showsVerticalScrollIndicator={showScrollIndicator}
+          showsHorizontalScrollIndicator={horizontal && showScrollIndicator}
+          testID={testID}
           
           onLayout={this.props.onLayout}
-          horizontal={this.props.horizontal}
+          removeClippedSubviews={this.props.removeClippedSubviews}
           pagingEnabled={this.props.pagingEnabled}
           scrollEnabled={this.props.scrollEnabled}
           scrollsToTop={this.props.scrollsToTop}
-          keyExtractor={this.props.keyExtractor}
-          removeClippedSubviews={this.props.removeClippedSubviews}
+          horizontal={this.props.horizontal}
           keyboardShouldPersistTaps={this.props.keyboardShouldPersistTaps}
+          keyExtractor={this.props.keyExtractor}
           onEndReachedThreshold={this.props.onEndReachedThreshold}
           onEndReached={this.props.onEndReached}
         />

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -1,16 +1,16 @@
-import React, {Component} from 'react';
-import {FlatList, Platform, Dimensions, ActivityIndicator, View} from 'react-native';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
-
+import React, {Component} from 'react';
+import {FlatList, Platform, Dimensions, View} from 'react-native';
+import {extractComponentProps} from '../component-updater';
 import {xdateToData, parseDate} from '../interface';
-import styleConstructor from './style';
 import dateutils from '../dateutils';
+import {STATIC_HEADER} from '../testIDs';
+import styleConstructor from './style';
 import Calendar from '../calendar';
 import CalendarListItem from './item';
 import CalendarHeader from '../calendar/header/index';
-import {STATIC_HEADER} from '../testIDs';
-
 
 const {width} = Dimensions.get('window');
 
@@ -30,42 +30,47 @@ class CalendarList extends Component {
     pastScrollRange: PropTypes.number,
     /** Max amount of months allowed to scroll to the future. Default = 50 */
     futureScrollRange: PropTypes.number,
+    /** Used when calendar scroll is horizontal, default is device width, pagination should be disabled */
+    calendarWidth: PropTypes.number,
+    /** Dynamic calendar height */
+    calendarHeight: PropTypes.number,
+    /** Style for the List item (the calendar) */
+    calendarStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
+    /** Whether to use static header that will not scroll with the list (horizontal only) */
+    staticHeader: PropTypes.bool,
+    /** Enable or disable vertical / horizontal scroll indicator. Default = false */
+    showScrollIndicator: PropTypes.bool,
+
     /** Enable or disable scrolling of calendar list */
     scrollEnabled: PropTypes.bool,
-    /** Enable or disable vertical scroll indicator. Default = false */
-    showScrollIndicator: PropTypes.bool,
     /** When true, the calendar list scrolls to top when the status bar is tapped. Default = true */
     scrollsToTop: PropTypes.bool,
     /** Enable or disable paging on scroll */
     pagingEnabled: PropTypes.bool,
     /** Whether the scroll is horizontal */
     horizontal: PropTypes.bool,
-    /** Used when calendar scroll is horizontal, default is device width, pagination should be disabled */
-    calendarWidth: PropTypes.number,
-    /** Dynamic calendar height */
-    calendarHeight: PropTypes.number,
     /** Should Keyboard persist taps */
     keyboardShouldPersistTaps: PropTypes.oneOf(['never', 'always', 'handled']),
-    /** Style for the List item (the calendar) */
-    calendarStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
-    /** Whether to use static header that will not scroll with the list (horizontal only) */
-    staticHeader: PropTypes.bool,
     /** A custom key extractor for the generated calendar months */
-    keyExtractor: PropTypes.func
-  }
+    keyExtractor: PropTypes.func,
+    /** How far from the end to trigger the onEndReached callback */
+    onEndReachedThreshold: PropTypes.number,
+    /** Called once when the scroll position gets within onEndReachedThreshold */
+    onEndReached: PropTypes.func
+  };
 
   static defaultProps = {
-    horizontal: false,
     calendarWidth: width,
     calendarHeight: 360,
     pastScrollRange: 50,
     futureScrollRange: 50,
     showScrollIndicator: false,
-    scrollEnabled: true,
+    horizontal: false,
     scrollsToTop: false,
+    scrollEnabled: true,
     removeClippedSubviews: Platform.OS === 'android',
     keyExtractor: (item, index) => String(index)
-  }
+  };
 
   constructor(props) {
     super(props);
@@ -80,15 +85,18 @@ class CalendarList extends Component {
     const texts = [];
     const date = parseDate(props.current) || XDate();
 
-    for (let i = 0; i <= this.props.pastScrollRange + this.props.futureScrollRange; i++) {
-      const rangeDate = date.clone().addMonths(i - this.props.pastScrollRange, true);
+    for (let i = 0; i <= props.pastScrollRange + props.futureScrollRange; i++) {
+      const rangeDate = date.clone().addMonths(i - props.pastScrollRange, true);
       const rangeDateStr = rangeDate.toString('MMM yyyy');
       texts.push(rangeDateStr);
       /*
        * This selects range around current shown month [-0, +2] or [-1, +1] month for detail calendar rendering.
        * If `this.pastScrollRange` is `undefined` it's equal to `false` or 0 in next condition.
        */
-      if (this.props.pastScrollRange - 1 <= i && i <= this.props.pastScrollRange + 1 || !this.props.pastScrollRange && i <= this.props.pastScrollRange + 2) {
+      if (
+        (props.pastScrollRange - 1 <= i && i <= props.pastScrollRange + 1) ||
+        (!props.pastScrollRange && i <= props.pastScrollRange + 2)
+      ) {
         rows.push(rangeDate);
       } else {
         rows.push(rangeDateStr);
@@ -101,52 +109,11 @@ class CalendarList extends Component {
       openDate: date,
       currentMonth: parseDate(props.current)
     };
-
-    this.onViewableItemsChangedBound = this.onViewableItemsChanged.bind(this);
-    this.renderCalendarBound = this.renderCalendar.bind(this);
-    this.getItemLayout = this.getItemLayout.bind(this);
-    this.onLayout = this.onLayout.bind(this);
   }
 
-  onLayout(event) {
-    if (this.props.onLayout) {
-      this.props.onLayout(event);
-    }
-  }
-
-  scrollToDay(d, offset, animated) {
-    const day = parseDate(d);
-    const diffMonths = Math.round(this.state.openDate.clone().setDate(1).diffMonths(day.clone().setDate(1)));
-    const size = this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight;
-    let scrollAmount = (size * this.props.pastScrollRange) + (diffMonths * size) + (offset || 0);
-
-    if (!this.props.horizontal) {
-      let week = 0;
-      const days = dateutils.page(day, this.props.firstDay);
-      for (let i = 0; i < days.length; i++) {
-        week = Math.floor(i / 7);
-        if (dateutils.sameDate(days[i], day)) {
-          scrollAmount += 46 * week;
-          break;
-        }
-      }
-    }
-    this.listView.scrollToOffset({offset: scrollAmount, animated});
-  }
-
-  scrollToMonth(m) {
-    const month = parseDate(m);
-    const scrollTo = month || this.state.openDate;
-    let diffMonths = Math.round(this.state.openDate.clone().setDate(1).diffMonths(scrollTo.clone().setDate(1)));
-    const size = this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight;
-    const scrollAmount = (size * this.props.pastScrollRange) + (diffMonths * size);
-
-    this.listView.scrollToOffset({offset: scrollAmount, animated: false});
-  }
-
-  UNSAFE_componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const current = parseDate(this.props.current);
-    const nextCurrent = parseDate(props.current);
+    const nextCurrent = parseDate(nextProps.current);
 
     if (nextCurrent && current && nextCurrent.getTime() !== current.getTime()) {
       this.scrollToMonth(nextCurrent);
@@ -168,7 +135,80 @@ class CalendarList extends Component {
     });
   }
 
-  onViewableItemsChanged({viewableItems}) {
+  scrollToDay(d, offset, animated) {
+    const {horizontal, calendarHeight, calendarWidth, pastScrollRange, firstDay} = this.props;
+    const day = parseDate(d);
+    const diffMonths = Math.round(this.state.openDate.clone().setDate(1).diffMonths(day.clone().setDate(1)));
+    const size = horizontal ? calendarWidth : calendarHeight;
+    let scrollAmount = size * pastScrollRange + diffMonths * size + (offset || 0);
+
+    if (!horizontal) {
+      let week = 0;
+      const days = dateutils.page(day, firstDay);
+      for (let i = 0; i < days.length; i++) {
+        week = Math.floor(i / 7);
+        if (dateutils.sameDate(days[i], day)) {
+          scrollAmount += 46 * week;
+          break;
+        }
+      }
+    }
+    this.listView.scrollToOffset({offset: scrollAmount, animated});
+  }
+
+  scrollToMonth = m => {
+    const {horizontal, calendarHeight, calendarWidth, pastScrollRange} = this.props;
+    const month = parseDate(m);
+    const scrollTo = month || this.state.openDate;
+    let diffMonths = Math.round(this.state.openDate.clone().setDate(1).diffMonths(scrollTo.clone().setDate(1)));
+    const size = horizontal ? calendarWidth : calendarHeight;
+    const scrollAmount = size * pastScrollRange + diffMonths * size;
+
+    this.listView.scrollToOffset({offset: scrollAmount, animated: false});
+  };
+
+  getItemLayout = (data, index) => {
+    const {horizontal, calendarHeight, calendarWidth} = this.props;
+
+    return {
+      length: horizontal ? calendarWidth : calendarHeight,
+      offset: (horizontal ? calendarWidth : calendarHeight) * index,
+      index
+    };
+  };
+
+  getMonthIndex(month) {
+    let diffMonths = this.state.openDate.diffMonths(month) + this.props.pastScrollRange;
+    return diffMonths;
+  }
+
+  addMonth = count => {
+    this.updateMonth(this.state.currentMonth.clone().addMonths(count, true));
+  };
+
+  updateMonth(day, doNotTriggerListeners) {
+    if (day.toString('yyyy MM') === this.state.currentMonth.toString('yyyy MM')) {
+      return;
+    }
+
+    this.setState(
+      {
+        currentMonth: day.clone()
+      },
+      () => {
+        this.scrollToMonth(this.state.currentMonth);
+
+        if (!doNotTriggerListeners) {
+          const currMont = this.state.currentMonth.clone();
+
+          _.invoke(this.props, 'onMonthChange', xdateToData(currMont));
+          _.invoke(this.props, 'onVisibleMonthsChange', [xdateToData(currMont)]);
+        }
+      }
+    );
+  }
+
+  onViewableItemsChanged = ({viewableItems}) => {
     function rowIsCloseToViewable(index, distance) {
       for (let i = 0; i < viewableItems.length; i++) {
         if (Math.abs(index - parseInt(viewableItems[i].index)) <= distance) {
@@ -197,94 +237,42 @@ class CalendarList extends Component {
       }
     }
 
-    if (this.props.onVisibleMonthsChange) {
-      this.props.onVisibleMonthsChange(visibleMonths);
-    }
+    _.invoke(this.props, 'onVisibleMonthsChange', visibleMonths);
 
     this.setState({
       rows: newrows,
       currentMonth: parseDate(visibleMonths[0])
     });
-  }
+  };
 
-  renderCalendar({item}) {
+  renderItem = ({item}) => {
+    const {calendarStyle, horizontal, calendarWidth, testID, ...others} = this.props;
+    
     return (
       <CalendarListItem
-        testID={`${this.props.testID}_${item}`}
-        scrollToMonth={this.scrollToMonth.bind(this)}
+        {...others}
         item={item}
-        calendarHeight={this.props.calendarHeight}
-        calendarWidth={this.props.horizontal ? this.props.calendarWidth : undefined}
-        {...this.props}
-        style={this.props.calendarStyle}
+        testID={`${testID}_${item}`}
+        style={calendarStyle}
+        calendarWidth={horizontal ? calendarWidth : undefined}
+        scrollToMonth={this.scrollToMonth}
       />
     );
-  }
-
-  getItemLayout(data, index) {
-    return {
-      length: this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight,
-      offset: (this.props.horizontal ? this.props.calendarWidth : this.props.calendarHeight) * index, index
-    };
-  }
-
-  getMonthIndex(month) {
-    let diffMonths = this.state.openDate.diffMonths(month) + this.props.pastScrollRange;
-    return diffMonths;
-  }
-
-  addMonth = (count) => {
-    this.updateMonth(this.state.currentMonth.clone().addMonths(count, true));
-  }
-
-  updateMonth(day, doNotTriggerListeners) {
-    if (day.toString('yyyy MM') === this.state.currentMonth.toString('yyyy MM')) {
-      return;
-    }
-
-    this.setState({
-      currentMonth: day.clone()
-    }, () => {
-      this.scrollToMonth(this.state.currentMonth);
-
-      if (!doNotTriggerListeners) {
-        const currMont = this.state.currentMonth.clone();
-        if (this.props.onMonthChange) {
-          this.props.onMonthChange(xdateToData(currMont));
-        }
-        if (this.props.onVisibleMonthsChange) {
-          this.props.onVisibleMonthsChange([xdateToData(currMont)]);
-        }
-      }
-    });
-  }
+  };
 
   renderStaticHeader() {
-    const {staticHeader, horizontal} = this.props;
+    const {staticHeader, horizontal, headerStyle} = this.props;
     const useStaticHeader = staticHeader && horizontal;
+    const headerUserProps = extractComponentProps(CalendarHeader, this.props);
 
     if (useStaticHeader) {
-      let indicator;
-      if (this.props.showIndicator) {
-        indicator = <ActivityIndicator color={this.props.theme && this.props.theme.indicatorColor}/>;
-      }
-
       return (
         <CalendarHeader
-          style={[this.style.staticHeader, this.props.headerStyle]}
+          {...headerUserProps}
+          testID={STATIC_HEADER}
+          style={[this.style.staticHeader, headerStyle]}
           month={this.state.currentMonth}
           addMonth={this.addMonth}
-          showIndicator={indicator}
-          theme={this.props.theme}
-          hideArrows={this.props.hideArrows}
-          firstDay={this.props.firstDay}
-          renderArrow={this.props.renderArrow}
-          monthFormat={this.props.monthFormat}
-          hideDayNames={this.props.hideDayNames}
-          weekNumbers={this.props.showWeekNumbers}
-          onPressArrowLeft={this.props.onPressArrowLeft}
-          onPressArrowRight={this.props.onPressArrowRight}
-          testID={STATIC_HEADER}
           accessibilityElementsHidden={true} // iOS
           importantForAccessibility={'no-hide-descendants'} // Android
         />
@@ -293,35 +281,33 @@ class CalendarList extends Component {
   }
 
   render() {
+    const {style, pastScrollRange, futureScrollRange, horizontal} = this.props;
+
     return (
       <View>
         <FlatList
-          testID={this.props.testID}
-          onLayout={this.onLayout}
-          ref={(c) => this.listView = c}
-          //scrollEventThrottle={1000}
-          style={[this.style.container, this.props.style]}
-          initialListSize={this.props.pastScrollRange + this.props.futureScrollRange + 1} // ListView deprecated
+          ref={c => (this.listView = c)}
+          style={[this.style.container, style]}
+          initialListSize={pastScrollRange + futureScrollRange + 1} // ListView deprecated
           data={this.state.rows}
-          //snapToAlignment='start'
-          //snapToInterval={this.calendarHeight}
-          removeClippedSubviews={this.props.removeClippedSubviews}
-          pageSize={1} // ListView deprecated
+          renderItem={this.renderItem}
+          getItemLayout={this.getItemLayout}
+          onViewableItemsChanged={this.onViewableItemsChanged}
+          viewabilityConfig={this.viewabilityConfig}
+          initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
+          showsVerticalScrollIndicator={this.props.showScrollIndicator}
+          showsHorizontalScrollIndicator={horizontal && this.props.showScrollIndicator}
+          testID={this.props.testID}
+          onLayout={this.props.onLayout}
           horizontal={this.props.horizontal}
           pagingEnabled={this.props.pagingEnabled}
-          onViewableItemsChanged={this.onViewableItemsChangedBound}
-          viewabilityConfig={this.viewabilityConfig}
-          renderItem={this.renderCalendarBound}
-          showsVerticalScrollIndicator={this.props.showScrollIndicator}
-          showsHorizontalScrollIndicator={this.props.showScrollIndicator}
           scrollEnabled={this.props.scrollEnabled}
-          keyExtractor={this.props.keyExtractor}
-          initialScrollIndex={this.state.openDate ? this.getMonthIndex(this.state.openDate) : false}
-          getItemLayout={this.getItemLayout}
           scrollsToTop={this.props.scrollsToTop}
+          keyExtractor={this.props.keyExtractor}
+          removeClippedSubviews={this.props.removeClippedSubviews}
+          keyboardShouldPersistTaps={this.props.keyboardShouldPersistTaps}
           onEndReachedThreshold={this.props.onEndReachedThreshold}
           onEndReached={this.props.onEndReached}
-          keyboardShouldPersistTaps={this.props.keyboardShouldPersistTaps}
         />
         {this.renderStaticHeader()}
       </View>

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -1,11 +1,20 @@
+import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {Text, View} from 'react-native';
+import {extractComponentProps} from '../component-updater';
 import Calendar from '../calendar';
 import styleConstructor from './style';
 
-
 class CalendarListItem extends Component {
   static displayName = 'IGNORE';
+
+  static propTypes = {
+    ...Calendar.propTypes,
+    item: PropTypes.any,
+    calendarWidth: PropTypes.number,
+    calendarHeight: PropTypes.number,
+    horizontal: PropTypes.bool
+  };
 
   static defaultProps = {
     hideArrows: true,
@@ -21,15 +30,17 @@ class CalendarListItem extends Component {
   shouldComponentUpdate(nextProps) {
     const r1 = this.props.item;
     const r2 = nextProps.item;
+
     return r1.toString('yyyy MM') !== r2.toString('yyyy MM') || !!(r2.propbump && r2.propbump !== r1.propbump);
   }
 
   onPressArrowLeft = (_, month) => {
+    const {onPressArrowLeft, scrollToMonth} = this.props;
     const monthClone = month.clone();
 
-    if (this.props.onPressArrowLeft) {
-      this.props.onPressArrowLeft(_, monthClone);
-    } else if (this.props.scrollToMonth) {
+    if (onPressArrowLeft) {
+      onPressArrowLeft(_, monthClone);
+    } else if (scrollToMonth) {
       const currentMonth = monthClone.getMonth();
       monthClone.addMonths(-1);
 
@@ -38,65 +49,57 @@ class CalendarListItem extends Component {
         monthClone.setDate(monthClone.getDate() - 1);
       }
 
-      this.props.scrollToMonth(monthClone);
+      scrollToMonth(monthClone);
     }
-  }
+  };
 
   onPressArrowRight = (_, month) => {
+    const {onPressArrowRight, scrollToMonth} = this.props;
     const monthClone = month.clone();
 
-    if (this.props.onPressArrowRight) {
-      this.props.onPressArrowRight(_, monthClone);
-    } else if (this.props.scrollToMonth) {
+    if (onPressArrowRight) {
+      onPressArrowRight(_, monthClone);
+    } else if (scrollToMonth) {
       monthClone.addMonths(1);
-      this.props.scrollToMonth(monthClone);
+      scrollToMonth(monthClone);
     }
-  }
+  };
 
   render() {
-    const row = this.props.item;
+    const {
+      item,
+      horizontal,
+      calendarHeight,
+      calendarWidth,
+      testID,
+      style,
+      headerStyle,
+      onPressArrowLeft,
+      onPressArrowRight
+    } = this.props;
+    const calendarUserProps = extractComponentProps(Calendar, this.props);
 
-    if (row.getTime) {
+    if (item.getTime) {
       return (
         <Calendar
-          testID={`${this.props.testID}_${row}`}
-          theme={this.props.theme}
-          style={[{height: this.props.calendarHeight, width: this.props.calendarWidth}, this.style.calendar, this.props.style]}
-          current={row}
-          hideArrows={this.props.hideArrows}
-          hideExtraDays={this.props.hideExtraDays}
+          {...calendarUserProps}
+          current={item}
+          testID={`${testID}_${item}`}
+          style={[{height: calendarHeight, width: calendarWidth}, this.style.calendar, style]}
+          headerStyle={horizontal ? headerStyle : undefined}
           disableMonthChange
-          markedDates={this.props.markedDates}
-          markingType={this.props.markingType}
-          hideDayNames={this.props.hideDayNames}
-          onDayPress={this.props.onDayPress}
-          onDayLongPress={this.props.onDayLongPress}
-          displayLoadingIndicator={this.props.displayLoadingIndicator}
-          minDate={this.props.minDate}
-          maxDate={this.props.maxDate}
-          firstDay={this.props.firstDay}
-          monthFormat={this.props.monthFormat}
-          dayComponent={this.props.dayComponent}
-          disabledByDefault={this.props.disabledByDefault}
-          showWeekNumbers={this.props.showWeekNumbers}
-          renderArrow={this.props.renderArrow}
-          onPressArrowLeft={this.props.horizontal ? this.onPressArrowLeft : this.props.onPressArrowLeft}
-          onPressArrowRight={this.props.horizontal ? this.onPressArrowRight : this.props.onPressArrowRight}
-          headerStyle={this.props.horizontal ? this.props.headerStyle : undefined}
-          accessibilityElementsHidden={this.props.accessibilityElementsHidden} // iOS
-          importantForAccessibility={this.props.importantForAccessibility} // Android
-          customHeader={this.props.customHeader}
-          renderHeader={this.props.renderHeader}
-          disabledDaysIndexes={this.props.disabledDaysIndexes}
-          disableAllTouchEventsForDisabledDays={this.props.disableAllTouchEventsForDisabledDays}
+          onPressArrowLeft={horizontal ? this.onPressArrowLeft : onPressArrowLeft}
+          onPressArrowRight={horizontal ? this.onPressArrowRight : onPressArrowRight}
         />
       );
     } else {
-      const text = row.toString();
+      const text = item.toString();
 
       return (
-        <View style={[{height: this.props.calendarHeight, width: this.props.calendarWidth}, this.style.placeholder]}>
-          <Text allowFontScaling={false} style={this.style.placeholderText}>{text}</Text>
+        <View style={[{height: calendarHeight, width: calendarWidth}, this.style.placeholder]}>
+          <Text allowFontScaling={false} style={this.style.placeholderText}>
+            {text}
+          </Text>
         </View>
       );
     }

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -83,8 +83,8 @@ class CalendarListItem extends Component {
       return (
         <Calendar
           {...calendarUserProps}
+          testID={testID}
           current={item}
-          testID={`${testID}_${item}`}
           style={[{height: calendarHeight, width: calendarWidth}, this.style.calendar, style]}
           headerStyle={horizontal ? headerStyle : undefined}
           disableMonthChange

--- a/src/calendar-list/style.js
+++ b/src/calendar-list/style.js
@@ -3,7 +3,7 @@ import * as defaultStyle from '../style';
 
 const STYLESHEET_ID = 'stylesheet.calendar-list.main';
 
-export default function getStyle(theme={}) {
+export default function getStyle(theme = {}) {
   const appStyle = {...defaultStyle, ...theme};
   return StyleSheet.create({
     container: {
@@ -24,10 +24,10 @@ export default function getStyle(theme={}) {
       paddingRight: 15
     },
     staticHeader: {
-      position: 'absolute', 
-      left: 0, 
-      right: 0, 
-      top: 0, 
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      top: 0,
       backgroundColor: appStyle.calendarBackground,
       paddingLeft: 15,
       paddingRight: 15

--- a/src/calendar/dot/index.js
+++ b/src/calendar/dot/index.js
@@ -1,10 +1,9 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {View} from 'react-native';
 import styleConstructor from './style';
-import PropTypes from 'prop-types';
 
 const Dot = ({theme, isMarked, isDisabled, dotColor, isToday, isSelected}) => {
-
   const style = styleConstructor(theme);
   const dotStyle = [style.dot];
 
@@ -28,9 +27,7 @@ const Dot = ({theme, isMarked, isDisabled, dotColor, isToday, isSelected}) => {
     }
   }
 
-  return (
-    <View style={dotStyle}/>
-  );
+  return <View style={dotStyle}/>;
 };
 
 export default Dot;

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -42,16 +42,6 @@ class CalendarHeader extends Component {
     this.style = styleConstructor(props.theme);
   }
 
-  addMonth = () => {
-    const {addMonth} = this.props;
-    addMonth(1);
-  };
-
-  subtractMonth = () => {
-    const {addMonth} = this.props;
-    addMonth(-1);
-  };
-
   shouldComponentUpdate(nextProps) {
     if (nextProps.month.toString('yyyy MM') !== this.props.month.toString('yyyy MM')) {
       return true;
@@ -67,6 +57,16 @@ class CalendarHeader extends Component {
       'disableArrowRight'
     ]);
   }
+
+  addMonth = () => {
+    const {addMonth} = this.props;
+    addMonth(1);
+  };
+
+  subtractMonth = () => {
+    const {addMonth} = this.props;
+    addMonth(-1);
+  };
 
   onPressLeft = () => {
     const {onPressArrowLeft, month} = this.props;

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -126,18 +126,18 @@ class CalendarHeader extends Component {
     );
   };
 
-  renderArrow(left) {
+  renderArrow(direction) {
     const {hideArrows, disableArrowLeft, disableArrowRight, renderArrow, testID} = this.props;
     if (hideArrows) {
       return <View />;
     }
-
-    const id = left ? CHANGE_MONTH_LEFT_ARROW : CHANGE_MONTH_RIGHT_ARROW;
+    const isLeft = direction === 'left';
+    const id = isLeft ? CHANGE_MONTH_LEFT_ARROW : CHANGE_MONTH_RIGHT_ARROW;
     const testId = testID ? `${id}-${testID}` : id;
-    const onPress = left ? this.onPressLeft : this.onPressRight;
-    const imageSource = left ? require('../img/previous.png') : require('../img/next.png');
-    const renderArrowDirection = left ? 'left' : 'right';
-    const shouldDisable = left ? disableArrowLeft : disableArrowRight;
+    const onPress = isLeft ? this.onPressLeft : this.onPressRight;
+    const imageSource = isLeft ? require('../img/previous.png') : require('../img/next.png');
+    const renderArrowDirection = isLeft ? 'left' : 'right';
+    const shouldDisable = isLeft ? disableArrowLeft : disableArrowRight;
 
     return (
       <TouchableOpacity
@@ -196,12 +196,12 @@ class CalendarHeader extends Component {
         importantForAccessibility={this.props.importantForAccessibility} // Android
       >
         <View style={this.style.header}>
-          {this.renderArrow(true)}
+          {this.renderArrow('left')}
           <View style={this.style.headerContainer}>
             {this.renderHeader()}
             {this.renderIndicator()}
           </View>
-          {this.renderArrow(false)}
+          {this.renderArrow('right')}
         </View>
         {this.renderDayNames()}
       </View>

--- a/src/calendar/header/style.js
+++ b/src/calendar/header/style.js
@@ -3,7 +3,7 @@ import * as defaultStyle from '../../style';
 
 const STYLESHEET_ID = 'stylesheet.calendar.header';
 
-export default function(theme={}) {
+export default function (theme = {}) {
   const appStyle = {...defaultStyle, ...theme};
   return StyleSheet.create({
     header: {
@@ -35,7 +35,7 @@ export default function(theme={}) {
           width: appStyle.arrowWidth,
           height: appStyle.arrowHeight
         }
-      }),
+      })
     },
     disabledArrowImage: {
       tintColor: appStyle.disabledArrowColor

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -1,27 +1,26 @@
-import React, {Component} from 'react';
-import * as ReactNative from 'react-native';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
-
+import React, {Component} from 'react';
+import * as ReactNative from 'react-native';
+import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
 import dateutils from '../dateutils';
 import {xdateToData, parseDate} from '../interface';
+import shouldComponentUpdate from './updater';
+import {extractComponentProps} from '../component-updater';
+import {SELECT_DATE_SLOT} from '../testIDs';
 import styleConstructor from './style';
+import CalendarHeader from './header';
 import Day from './day/basic';
 import UnitDay from './day/period';
 import MultiDotDay from './day/multi-dot';
 import MultiPeriodDay from './day/multi-period';
 import SingleDay from './day/custom';
-import CalendarHeader from './header';
-import shouldComponentUpdate from './updater';
-import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
-import {SELECT_DATE_SLOT} from '../testIDs';
 
 //Fallback for react-native-web or when RN version is < 0.44
 const {View, ViewPropTypes} = ReactNative;
 const viewPropTypes =
-  typeof document !== 'undefined'
-    ? PropTypes.shape({style: PropTypes.object})
-    : ViewPropTypes || View.propTypes;
+  typeof document !== 'undefined' ? PropTypes.shape({style: PropTypes.object}) : ViewPropTypes || View.propTypes;
 const EmptyArray = [];
 
 /**
@@ -55,7 +54,7 @@ class Calendar extends Component {
     displayLoadingIndicator: PropTypes.bool,
     /** Do not show days of other months in month page. Default = false */
     hideExtraDays: PropTypes.bool,
-    /** Always show six weeks on each month. Default = false */
+    /** Always show six weeks on each month (only when hideExtraDays = false). Default = false */
     showSixWeeks: PropTypes.bool,
     /** Handler which gets executed on day press. Default = undefined */
     onDayPress: PropTypes.func,
@@ -110,42 +109,43 @@ class Calendar extends Component {
   constructor(props) {
     super(props);
 
-    this.style = styleConstructor(this.props.theme);
+    this.style = styleConstructor(props.theme);
+
     this.state = {
       currentMonth: props.current ? parseDate(props.current) : XDate()
     };
 
-    this.updateMonth = this.updateMonth.bind(this);
-    this.pressDay = this.pressDay.bind(this);
-    this.longPressDay = this.longPressDay.bind(this);
     this.shouldComponentUpdate = shouldComponentUpdate;
   }
 
-  updateMonth(day, doNotTriggerListeners) {
+  updateMonth = (day, doNotTriggerListeners) => {
     if (day.toString('yyyy MM') === this.state.currentMonth.toString('yyyy MM')) {
       return;
     }
-    this.setState({
-      currentMonth: day.clone()
-    }, () => {
-      if (!doNotTriggerListeners) {
-        const currMont = this.state.currentMonth.clone();
-        if (this.props.onMonthChange) {
-          this.props.onMonthChange(xdateToData(currMont));
-        }
-        if (this.props.onVisibleMonthsChange) {
-          this.props.onVisibleMonthsChange([xdateToData(currMont)]);
+
+    this.setState(
+      {
+        currentMonth: day.clone()
+      },
+      () => {
+        if (!doNotTriggerListeners) {
+          const currMont = this.state.currentMonth.clone();
+          _.invoke(this.props, 'onMonthChange', xdateToData(currMont));
+          _.invoke(this.props, 'onVisibleMonthsChange', [xdateToData(currMont)]);
         }
       }
-    });
-  }
+    );
+  };
 
   _handleDayInteraction(date, interaction) {
+    const {disableMonthChange} = this.props;
     const day = parseDate(date);
     const minDate = parseDate(this.props.minDate);
     const maxDate = parseDate(this.props.maxDate);
+
     if (!(minDate && !dateutils.isGTE(day, minDate)) && !(maxDate && !dateutils.isLTE(day, maxDate))) {
-      const shouldUpdateMonth = this.props.disableMonthChange === undefined || !this.props.disableMonthChange;
+      const shouldUpdateMonth = disableMonthChange === undefined || !disableMonthChange;
+
       if (shouldUpdateMonth) {
         this.updateMonth(day);
       }
@@ -155,21 +155,21 @@ class Calendar extends Component {
     }
   }
 
-  pressDay(date) {
+  pressDay = date => {
     this._handleDayInteraction(date, this.props.onDayPress);
-  }
+  };
 
-  longPressDay(date) {
+  longPressDay = date => {
     this._handleDayInteraction(date, this.props.onDayLongPress);
-  }
+  };
 
-  addMonth = (count) => {
+  addMonth = count => {
     this.updateMonth(this.state.currentMonth.clone().addMonths(count, true));
-  }
+  };
 
   isDateNotInTheRange = (minDate, maxDate, date) => {
     return (minDate && !dateutils.isGTE(date, minDate)) || (maxDate && !dateutils.isLTE(date, maxDate));
-  }
+  };
 
   getAccessibilityLabel = (state, day) => {
     const today = XDate.locales[XDate.defaultLocale].today;
@@ -182,50 +182,7 @@ class Calendar extends Component {
     }
 
     return `${isToday ? 'today' : ''} ${day.toString('dddd d MMMM yyyy')} ${markingLabel}`;
-  }
-
-
-  renderDay(day, id) {
-    const minDate = parseDate(this.props.minDate);
-    const maxDate = parseDate(this.props.maxDate);
-    let state = '';
-    if (this.props.disabledByDefault) {
-      state = 'disabled';
-    } else if (this.isDateNotInTheRange(minDate, maxDate, day)) {
-      state = 'disabled';
-    } else if (!dateutils.sameMonth(day, this.state.currentMonth)) {
-      state = 'disabled';
-    } else if (dateutils.sameDate(day, XDate())) {
-      state = 'today';
-    }
-
-    if (!dateutils.sameMonth(day, this.state.currentMonth) && this.props.hideExtraDays) {
-      return (<View key={id} style={this.style.emptyDayContainer}/>);
-    }
-
-    const DayComp = this.getDayComponent();
-    const date = day.getDate();
-    const dateAsObject = xdateToData(day);
-    const accessibilityLabel = this.getAccessibilityLabel(state, day);
-
-    return (
-      <View style={this.style.dayContainer} key={id}>
-        <DayComp
-          testID={`${SELECT_DATE_SLOT}-${dateAsObject.dateString}`}
-          state={state}
-          theme={this.props.theme}
-          onPress={this.pressDay}
-          onLongPress={this.longPressDay}
-          date={dateAsObject}
-          marking={this.getDateMarking(day)}
-          accessibilityLabel={accessibilityLabel}
-          disableAllTouchEventsForDisabledDays={this.props.disableAllTouchEventsForDisabledDays}
-        >
-          {date}
-        </DayComp>
-      </View>
-    );
-  }
+  };
 
   getMarkingLabel(day) {
     let label = '';
@@ -257,30 +214,35 @@ class Calendar extends Component {
   }
 
   getDayComponent() {
-    if (this.props.dayComponent) {
-      return this.props.dayComponent;
+    const {dayComponent, markingType} = this.props;
+
+    if (dayComponent) {
+      return dayComponent;
     }
 
-    switch (this.props.markingType) {
-    case 'period':
-      return UnitDay;
-    case 'multi-dot':
-      return MultiDotDay;
-    case 'multi-period':
-      return MultiPeriodDay;
-    case 'custom':
-      return SingleDay;
-    default:
-      return Day;
+    switch (markingType) {
+      case 'period':
+        return UnitDay;
+      case 'multi-dot':
+        return MultiDotDay;
+      case 'multi-period':
+        return MultiPeriodDay;
+      case 'custom':
+        return SingleDay;
+      default:
+        return Day;
     }
   }
 
   getDateMarking(day) {
-    if (!this.props.markedDates) {
+    const {markedDates} = this.props;
+
+    if (!markedDates) {
       return false;
     }
 
-    const dates = this.props.markedDates[day.toString('yyyy-MM-dd')] || EmptyArray;
+    const dates = markedDates[day.toString('yyyy-MM-dd')] || EmptyArray;
+
     if (dates.length || dates) {
       return dates;
     } else {
@@ -288,47 +250,87 @@ class Calendar extends Component {
     }
   }
 
-  onSwipe = (gestureName) => {
+  onSwipe = gestureName => {
     const {SWIPE_UP, SWIPE_DOWN, SWIPE_LEFT, SWIPE_RIGHT} = swipeDirections;
 
     switch (gestureName) {
-    case SWIPE_UP:
-    case SWIPE_DOWN:
-      break;
-    case SWIPE_LEFT:
-      this.onSwipeLeft();
-      break;
-    case SWIPE_RIGHT:
-      this.onSwipeRight();
-      break;
+      case SWIPE_UP:
+      case SWIPE_DOWN:
+        break;
+      case SWIPE_LEFT:
+        this.onSwipeLeft();
+        break;
+      case SWIPE_RIGHT:
+        this.onSwipeRight();
+        break;
     }
-  }
+  };
 
   onSwipeLeft = () => {
     this.header.onPressRight();
-  }
+  };
 
   onSwipeRight = () => {
     this.header.onPressLeft();
-  }
+  };
 
   renderWeekNumber(weekNumber) {
     return (
       <View style={this.style.dayContainer} key={`week-container-${weekNumber}`}>
-        <Day
-          key={`week-${weekNumber}`}
-          theme={this.props.theme}
-          marking={{disableTouchEvent: true}}
-          state='disabled'
-        >
+        <Day key={`week-${weekNumber}`} marking={{disableTouchEvent: true}} state="disabled" theme={this.props.theme}>
           {weekNumber}
         </Day>
       </View>
     );
   }
 
+  renderDay(day, id) {
+    const {disabledByDefault, hideExtraDays, theme, disableAllTouchEventsForDisabledDays} = this.props;
+    const minDate = parseDate(this.props.minDate);
+    const maxDate = parseDate(this.props.maxDate);
+    let state = '';
+
+    if (disabledByDefault) {
+      state = 'disabled';
+    } else if (this.isDateNotInTheRange(minDate, maxDate, day)) {
+      state = 'disabled';
+    } else if (!dateutils.sameMonth(day, this.state.currentMonth)) {
+      state = 'disabled';
+    } else if (dateutils.sameDate(day, XDate())) {
+      state = 'today';
+    }
+
+    if (!dateutils.sameMonth(day, this.state.currentMonth) && hideExtraDays) {
+      return <View key={id} style={this.style.emptyDayContainer} />;
+    }
+
+    const DayComp = this.getDayComponent();
+    const date = day.getDate();
+    const dateAsObject = xdateToData(day);
+    const accessibilityLabel = this.getAccessibilityLabel(state, day);
+
+    return (
+      <View style={this.style.dayContainer} key={id}>
+        <DayComp
+          testID={`${SELECT_DATE_SLOT}-${dateAsObject.dateString}`}
+          state={state}
+          onPress={this.pressDay}
+          onLongPress={this.longPressDay}
+          date={dateAsObject}
+          marking={this.getDateMarking(day)}
+          accessibilityLabel={accessibilityLabel}
+          theme={theme}
+          disableAllTouchEventsForDisabledDays={disableAllTouchEventsForDisabledDays}
+        >
+          {date}
+        </DayComp>
+      </View>
+    );
+  }
+
   renderWeek(days, id) {
     const week = [];
+
     days.forEach((day, id2) => {
       week.push(this.renderDay(day, id2));
     }, this);
@@ -337,69 +339,71 @@ class Calendar extends Component {
       week.unshift(this.renderWeekNumber(days[days.length - 1].getWeek()));
     }
 
-    return (<View style={this.style.week} key={id}>{week}</View>);
+    return (
+      <View style={this.style.week} key={id}>
+        {week}
+      </View>
+    );
   }
 
-  render() {
+  renderMonth() {
     const {currentMonth} = this.state;
-    const {firstDay, showSixWeeks, hideExtraDays, enableSwipeMonths} = this.props;
+    const {firstDay, showSixWeeks, hideExtraDays} = this.props;
     const shouldShowSixWeeks = showSixWeeks && !hideExtraDays;
     const days = dateutils.page(currentMonth, firstDay, shouldShowSixWeeks);
-
     const weeks = [];
+
     while (days.length) {
       weeks.push(this.renderWeek(days.splice(0, 7), weeks.length));
     }
 
-    let indicator;
+    return <View style={this.style.monthView}>{weeks}</View>;
+  }
+
+  renderHeader() {
+    const {customHeader, headerStyle, displayLoadingIndicator, markedDates, testID} = this.props;
     const current = parseDate(this.props.current);
+    let indicator;
+
     if (current) {
       const lastMonthOfDay = current.clone().addMonths(1, true).setDate(1).addDays(-1).toString('yyyy-MM-dd');
-      if (this.props.displayLoadingIndicator &&
-        !(this.props.markedDates && this.props.markedDates[lastMonthOfDay])) {
+      if (displayLoadingIndicator && !(markedDates && markedDates[lastMonthOfDay])) {
         indicator = true;
       }
     }
 
+    const headerUserProps = extractComponentProps(CalendarHeader, this.props);
+
+    const headerProps = {
+      ...headerUserProps,
+      testID: testID,
+      style: headerStyle,
+      ref: c => (this.header = c),
+      showIndicator: indicator,
+      month: this.state.currentMonth,
+      addMonth: this.addMonth
+    };
+
+    const CustomHeader = customHeader;
+    const HeaderComponent = customHeader ? CustomHeader : CalendarHeader;
+
+    return <HeaderComponent {...headerProps} />;
+  }
+
+  render() {
+    const {enableSwipeMonths, style} = this.props;
     const GestureComponent = enableSwipeMonths ? GestureRecognizer : View;
     const gestureProps = enableSwipeMonths ? {onSwipe: (direction, state) => this.onSwipe(direction, state)} : {};
 
-    const headerProps = {
-      testID: this.props.testID,
-      ref: c => this.header = c,
-      style: this.props.headerStyle,
-      theme: this.props.theme,
-      hideArrows: this.props.hideArrows,
-      month: this.state.currentMonth,
-      addMonth: this.addMonth,
-      showIndicator: indicator,
-      firstDay: this.props.firstDay,
-      showSixWeeks: this.props.showSixWeeks,
-      renderArrow: this.props.renderArrow,
-      monthFormat: this.props.monthFormat,
-      hideDayNames: this.props.hideDayNames,
-      weekNumbers: this.props.showWeekNumbers,
-      onPressArrowLeft: this.props.onPressArrowLeft,
-      onPressArrowRight: this.props.onPressArrowRight,
-      webAriaLevel: this.props.webAriaLevel,
-      disableArrowLeft: this.props.disableArrowLeft,
-      disableArrowRight: this.props.disableArrowRight,
-      disabledDaysIndexes: this.props.disabledDaysIndexes,
-      renderHeader: this.props.renderHeader
-    };
-    const CustomHeader = this.props.customHeader;
     return (
       <GestureComponent {...gestureProps}>
         <View
-          style={[this.style.container, this.props.style]}
+          style={[this.style.container, style]}
           accessibilityElementsHidden={this.props.accessibilityElementsHidden} // iOS
           importantForAccessibility={this.props.importantForAccessibility} // Android
         >
-          { CustomHeader
-            ? <CustomHeader {...headerProps}/>
-            : <CalendarHeader {...headerProps}/>
-          }
-          <View style={this.style.monthView}>{weeks}</View>
+          {this.renderHeader()}
+          {this.renderMonth()}
         </View>
       </GestureComponent>
     );

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -12,10 +12,10 @@ import {SELECT_DATE_SLOT} from '../testIDs';
 import styleConstructor from './style';
 import CalendarHeader from './header';
 import Day from './day/basic';
-import UnitDay from './day/period';
+import PeriodDay from './day/period';
 import MultiDotDay from './day/multi-dot';
 import MultiPeriodDay from './day/multi-period';
-import SingleDay from './day/custom';
+import CustomDay from './day/custom';
 
 //Fallback for react-native-web or when RN version is < 0.44
 const {View, ViewPropTypes} = ReactNative;
@@ -222,13 +222,13 @@ class Calendar extends Component {
 
     switch (markingType) {
       case 'period':
-        return UnitDay;
+        return PeriodDay;
       case 'multi-dot':
         return MultiDotDay;
       case 'multi-period':
         return MultiPeriodDay;
       case 'custom':
-        return SingleDay;
+        return CustomDay;
       default:
         return Day;
     }

--- a/src/calendar/style.js
+++ b/src/calendar/style.js
@@ -3,7 +3,7 @@ import * as defaultStyle from '../style';
 
 const STYLESHEET_ID = 'stylesheet.calendar.main';
 
-export default function getStyle(theme={}) {
+export default function getStyle(theme = {}) {
   const appStyle = {...defaultStyle, ...theme};
   return StyleSheet.create({
     container: {
@@ -12,7 +12,7 @@ export default function getStyle(theme={}) {
       backgroundColor: appStyle.calendarBackground
     },
     dayContainer: {
-      flex: 1, 
+      flex: 1,
       alignItems: 'center'
     },
     emptyDayContainer: {
@@ -30,4 +30,3 @@ export default function getStyle(theme={}) {
     ...(theme[STYLESHEET_ID] || {})
   });
 }
-

--- a/src/component-updater.js
+++ b/src/component-updater.js
@@ -13,13 +13,14 @@ function shouldUpdate(a, b, paths) {
 function extractComponentProps(component, props, ignoreProps) {
   const componentPropTypes = component.propTypes;
   if (componentPropTypes) {
+    const keys = Object.keys(componentPropTypes);
     const componentProps = _.chain(props)
-      .pickBy((_value, key) => _.includes(Object.keys(componentPropTypes), key))
+      .pickBy((_value, key) => _.includes(keys, key))
       .omit(ignoreProps)
       .value();
-  
     return componentProps;
   }
+  return {};
 }
 
 module.exports = {

--- a/src/component-updater.js
+++ b/src/component-updater.js
@@ -12,12 +12,14 @@ function shouldUpdate(a, b, paths) {
 
 function extractComponentProps(component, props, ignoreProps) {
   const componentPropTypes = component.propTypes;
-  const componentProps = _.chain(props)
-    .pickBy((_value, key) => _.includes(Object.keys(componentPropTypes), key))
-    .omit(ignoreProps)
-    .value();
-
-  return componentProps;
+  if (componentPropTypes) {
+    const componentProps = _.chain(props)
+      .pickBy((_value, key) => _.includes(Object.keys(componentPropTypes), key))
+      .omit(ignoreProps)
+      .value();
+  
+    return componentProps;
+  }
 }
 
 module.exports = {

--- a/src/component-updater.js
+++ b/src/component-updater.js
@@ -10,6 +10,17 @@ function shouldUpdate(a, b, paths) {
   return false;
 }
 
+function extractComponentProps(component, props, ignoreProps) {
+  const componentPropTypes = component.propTypes;
+  const componentProps = _.chain(props)
+    .pickBy((_value, key) => _.includes(Object.keys(componentPropTypes), key))
+    .omit(ignoreProps)
+    .value();
+
+  return componentProps;
+}
+
 module.exports = {
-  shouldUpdate
+  shouldUpdate,
+  extractComponentProps
 };

--- a/src/expandableCalendar/week.js
+++ b/src/expandableCalendar/week.js
@@ -1,20 +1,17 @@
-import React, {Component} from 'react';
-import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
-
+import React, {Component} from 'react';
+import {View} from 'react-native';
 import dateutils from '../dateutils';
 import {xdateToData, parseDate} from '../interface';
 import {SELECT_DATE_SLOT} from '../testIDs';
 import styleConstructor from './style';
-
+import Calendar from '../calendar';
 import Day from '../calendar/day/basic';
-import UnitDay from '../calendar/day/period';
+import PeriodDay from '../calendar/day/period';
 import MultiDotDay from '../calendar/day/multi-dot';
 import MultiPeriodDay from '../calendar/day/multi-period';
-import SingleDay from '../calendar/day/custom';
-import Calendar from '../calendar';
-
+import CustomDay from '../calendar/day/custom';
 
 const EmptyArray = [];
 
@@ -57,27 +54,29 @@ class Week extends Component {
         daysArray.push(newDate);
         index += 1;
       }
+
       return daysArray;
     }
   }
 
   getDayComponent() {
-    const {dayComponent} = this.props;
+    const {dayComponent, markingType} = this.props;
+    
     if (dayComponent) {
       return dayComponent;
     }
 
-    switch (this.props.markingType) {
-    case 'period':
-      return UnitDay;
-    case 'multi-dot':
-      return MultiDotDay;
-    case 'multi-period':
-      return MultiPeriodDay;
-    case 'custom':
-      return SingleDay;
-    default:
-      return Day;
+    switch (markingType) {
+      case 'period':
+        return PeriodDay;
+      case 'multi-dot':
+        return MultiDotDay;
+      case 'multi-period':
+        return MultiPeriodDay;
+      case 'custom':
+        return CustomDay;
+      default:
+        return Day;
     }
   }
 
@@ -100,7 +99,7 @@ class Week extends Component {
   // }
 
   renderDay(day, id) {
-    const {current, disableAllTouchEventsForDisabledDays} = this.props;
+    const {current} = this.props;
     const minDate = parseDate(this.props.minDate);
     const maxDate = parseDate(this.props.maxDate);
 
@@ -130,13 +129,13 @@ class Week extends Component {
       <View style={this.style.dayContainer} key={id}>
         <DayComp
           testID={`${SELECT_DATE_SLOT}-${dateAsObject.dateString}`}
+          date={dateAsObject}
+          marking={this.getDateMarking(day)}
           state={state}
           theme={this.props.theme}
           onPress={this.props.onDayPress}
           onLongPress={this.props.onDayPress}
-          date={dateAsObject}
-          marking={this.getDateMarking(day)}
-          disableAllTouchEventsForDisabledDays={disableAllTouchEventsForDisabledDays}
+          disableAllTouchEventsForDisabledDays={this.props.disableAllTouchEventsForDisabledDays}
         >
           {dayDate}
         </DayComp>

--- a/src/timeline/Packer.js
+++ b/src/timeline/Packer.js
@@ -1,16 +1,12 @@
 // @flow
 import moment from 'moment';
+
 const offset = 100;
 
 function buildEvent(column, left, width, dayStart) {
   const startTime = moment(column.start);
-  const endTime = column.end
-    ? moment(column.end)
-    : startTime.clone().add(1, 'hour');
-  const dayStartTime = startTime
-    .clone()
-    .hour(dayStart)
-    .minute(0);
+  const endTime = column.end ? moment(column.end) : startTime.clone().add(1, 'hour');
+  const dayStartTime = startTime.clone().hour(dayStart).minute(0);
   const diffHours = startTime.diff(dayStartTime, 'hours', true);
 
   column.top = diffHours * offset;
@@ -63,7 +59,7 @@ function populateEvents(events, screenWidth, dayStart) {
 
   events = events
     .map((ev, index) => ({...ev, index: index}))
-    .sort(function(a, b) {
+    .sort(function (a, b) {
       if (a.start < b.start) return -1;
       if (a.start > b.start) return 1;
       if (a.end < b.end) return -1;
@@ -74,7 +70,7 @@ function populateEvents(events, screenWidth, dayStart) {
   columns = [];
   lastEnd = null;
 
-  events.forEach(function(ev) {
+  events.forEach(function (ev) {
     if (lastEnd !== null && ev.start >= lastEnd) {
       pack(columns, screenWidth, calculatedEvents, dayStart);
       columns = [];

--- a/src/timeline/Timeline.js
+++ b/src/timeline/Timeline.js
@@ -1,17 +1,11 @@
 // @flow
-import {
-  View,
-  Text,
-  ScrollView,
-  TouchableOpacity,
-  Dimensions
-} from 'react-native';
-import PropTypes from 'prop-types';
-import populateEvents from './Packer';
-import React from 'react';
-import moment from 'moment';
 import _ from 'lodash';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import React from 'react';
+import {View, Text, ScrollView, TouchableOpacity, Dimensions} from 'react-native';
 import styleConstructor from './style';
+import populateEvents from './Packer';
 
 const LEFT_MARGIN = 60 - 1;
 const TEXT_LINE_HEIGHT = 17;
@@ -28,32 +22,37 @@ export default class Timeline extends React.PureComponent {
     end: PropTypes.number,
     eventTapped: PropTypes.func,
     format24h: PropTypes.bool,
-    events: PropTypes.arrayOf(PropTypes.shape({
-      start: PropTypes.string.isRequired,
-      end: PropTypes.string.isRequired,
-      title: PropTypes.string.isRequired,
-      summary: PropTypes.string.isRequired,
-      color: PropTypes.string
-    })).isRequired
-  }
+    events: PropTypes.arrayOf(
+      PropTypes.shape({
+        start: PropTypes.string.isRequired,
+        end: PropTypes.string.isRequired,
+        title: PropTypes.string.isRequired,
+        summary: PropTypes.string.isRequired,
+        color: PropTypes.string
+      })
+    ).isRequired
+  };
 
   static defaultProps = {
     start: 0,
     end: 24,
     events: [],
     format24h: true
-  }
+  };
 
   constructor(props) {
     super(props);
+
     const {start, end} = this.props;
     this.calendarHeight = (end - start) * 100;
+
     this.style = styleConstructor(props.styles, this.calendarHeight);
+
     const width = dimensionWidth - LEFT_MARGIN;
     const packedEvents = populateEvents(props.events, width, start);
-    let initPosition =
-      _.min(_.map(packedEvents, 'top')) - this.calendarHeight / (end - start);
+    let initPosition = _.min(_.map(packedEvents, 'top')) - this.calendarHeight / (end - start);
     const verifiedInitPosition = initPosition < 0 ? 0 : initPosition;
+
     this.state = {
       _scrollY: verifiedInitPosition,
       packedEvents
@@ -64,7 +63,8 @@ export default class Timeline extends React.PureComponent {
     const width = dimensionWidth - LEFT_MARGIN;
     const {events: prevEvents, start: prevStart = 0} = prevProps;
     const {events, start = 0} = this.props;
-    if(prevEvents !== events || prevStart !== start) {
+
+    if (prevEvents !== events || prevStart !== start) {
       this.setState({
         packedEvents: populateEvents(events, width, start)
       });
@@ -90,11 +90,11 @@ export default class Timeline extends React.PureComponent {
   _renderLines() {
     const {format24h, start = 0, end = 24} = this.props;
     const offset = this.calendarHeight / (end - start);
-
     const EVENT_DIFF = 20;
 
     return range(start, end + 1).map((i, index) => {
       let timeText;
+      
       if (i === start) {
         timeText = '';
       } else if (i < 12) {
@@ -106,34 +106,24 @@ export default class Timeline extends React.PureComponent {
       } else {
         timeText = !format24h ? `${i - 12} PM` : `${i}:00`;
       }
+
       return [
-        <Text
-          key={`timeLabel${i}`}
-          style={[this.style.timeLabel, {top: offset * index - 6}]}>
+        <Text key={`timeLabel${i}`} style={[this.style.timeLabel, {top: offset * index - 6}]}>
           {timeText}
         </Text>,
         i === start ? null : (
-          <View
-            key={`line${i}`}
-            style={[
-              this.style.line,
-              {top: offset * index, width: dimensionWidth - EVENT_DIFF}
-            ]}
-          />
+          <View key={`line${i}`} style={[this.style.line, {top: offset * index, width: dimensionWidth - EVENT_DIFF}]} />
         ),
         <View
           key={`lineHalf${i}`}
-          style={[
-            this.style.line,
-            {top: offset * (index + 0.5), width: dimensionWidth - EVENT_DIFF}
-          ]}
+          style={[this.style.line, {top: offset * (index + 0.5), width: dimensionWidth - EVENT_DIFF}]}
         />
       ];
     });
   }
 
   _onEventTapped(event) {
-    if(this.props.eventTapped) {
+    if (this.props.eventTapped) {
       this.props.eventTapped(event);
     }
   }
@@ -153,12 +143,14 @@ export default class Timeline extends React.PureComponent {
       // However it would make sense to overflow the title to a new line if needed
       const numberOfLines = Math.floor(event.height / TEXT_LINE_HEIGHT);
       const formatTime = this.props.format24h ? 'HH:mm' : 'hh:mm A';
+      
       return (
         <TouchableOpacity
           activeOpacity={0.9}
           onPress={() => this._onEventTapped(this.props.events[event.index])}
           key={i}
-          style={[this.style.event, style]}>
+          style={[this.style.event, style]}
+        >
           {this.props.renderEvent ? (
             this.props.renderEvent(event)
           ) : (
@@ -167,16 +159,13 @@ export default class Timeline extends React.PureComponent {
                 {event.title || 'Event'}
               </Text>
               {numberOfLines > 1 ? (
-                <Text
-                  numberOfLines={numberOfLines - 1}
-                  style={[this.style.eventSummary]}>
+                <Text numberOfLines={numberOfLines - 1} style={[this.style.eventSummary]}>
                   {event.summary || ' '}
                 </Text>
               ) : null}
               {numberOfLines > 2 ? (
                 <Text style={this.style.eventTimes} numberOfLines={1}>
-                  {moment(event.start).format(formatTime)} -{' '}
-                  {moment(event.end).format(formatTime)}
+                  {moment(event.start).format(formatTime)} - {moment(event.end).format(formatTime)}
                 </Text>
               ) : null}
             </View>
@@ -196,10 +185,8 @@ export default class Timeline extends React.PureComponent {
     return (
       <ScrollView
         ref={ref => (this._scrollView = ref)}
-        contentContainerStyle={[
-          this.style.contentStyle,
-          {width: dimensionWidth}
-        ]}>
+        contentContainerStyle={[this.style.contentStyle, {width: dimensionWidth}]}
+      >
         {this._renderLines()}
         {this._renderEvents()}
       </ScrollView>


### PR DESCRIPTION
This should NOT have any breaking changes. 
I cleaned the code for most of the components by doing the following:
1. Move .bind(this) to arrow function.
2. Move this.props repetitions to a single const extraction (i.e. const {} = this.props) where make sense.
3. Order of imports.
4. Order of methods.
5. Formatting document.
6. Split render functions when makes sense.
7. Use _.invoke instead of checking if a function prop is not undefined and call it.
8. Most important: Pass component props with spread by extracting the relevant props for the Component, instead of passing them one by one hardcoded.