### PR TITLE
Add swipeMonthsConfig prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # React Native Calendars 🗓️ 📆
+
 [![Version](https://img.shields.io/npm/v/react-native-calendars.svg)](https://www.npmjs.com/package/react-native-calendars)
 [![Build Status](https://travis-ci.org/wix/react-native-calendars.svg?branch=master)](https://travis-ci.org/wix/react-native-calendars)
 
@@ -54,11 +55,24 @@ Calendars can be localized by adding custom locales to `LocaleConfig` object:
 import {LocaleConfig} from 'react-native-calendars';
 
 LocaleConfig.locales['fr'] = {
-  monthNames: ['Janvier','Février','Mars','Avril','Mai','Juin','Juillet','Août','Septembre','Octobre','Novembre','Décembre'],
-  monthNamesShort: ['Janv.','Févr.','Mars','Avril','Mai','Juin','Juil.','Août','Sept.','Oct.','Nov.','Déc.'],
-  dayNames: ['Dimanche','Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi'],
-  dayNamesShort: ['Dim.','Lun.','Mar.','Mer.','Jeu.','Ven.','Sam.'],
-  today: 'Aujourd\'hui'
+  monthNames: [
+    'Janvier',
+    'Février',
+    'Mars',
+    'Avril',
+    'Mai',
+    'Juin',
+    'Juillet',
+    'Août',
+    'Septembre',
+    'Octobre',
+    'Novembre',
+    'Décembre'
+  ],
+  monthNamesShort: ['Janv.', 'Févr.', 'Mars', 'Avril', 'Mai', 'Juin', 'Juil.', 'Août', 'Sept.', 'Oct.', 'Nov.', 'Déc.'],
+  dayNames: ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi'],
+  dayNamesShort: ['Dim.', 'Lun.', 'Mar.', 'Mer.', 'Jeu.', 'Ven.', 'Sam.'],
+  today: "Aujourd'hui"
 };
 LocaleConfig.defaultLocale = 'fr';
 ```
@@ -80,17 +94,23 @@ LocaleConfig.defaultLocale = 'fr';
   // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
   maxDate={'2012-05-30'}
   // Handler which gets executed on day press. Default = undefined
-  onDayPress={(day) => {console.log('selected day', day)}}
+  onDayPress={day => {
+    console.log('selected day', day);
+  }}
   // Handler which gets executed on day long press. Default = undefined
-  onDayLongPress={(day) => {console.log('selected day', day)}}
+  onDayLongPress={day => {
+    console.log('selected day', day);
+  }}
   // Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting
   monthFormat={'yyyy MM'}
   // Handler which gets executed when visible month changes in calendar. Default = undefined
-  onMonthChange={(month) => {console.log('month changed', month)}}
+  onMonthChange={month => {
+    console.log('month changed', month);
+  }}
   // Hide month navigation arrows. Default = false
   hideArrows={true}
   // Replace default arrows with custom ones (direction can be 'left' or 'right')
-  renderArrow={(direction) => (<Arrow/>)}
+  renderArrow={direction => <Arrow />}
   // Do not show days of other months in month page. Default = false
   hideExtraDays={true}
   // If hideArrows=false and hideExtraDays=false do not switch month when tapping on greyed out
@@ -113,9 +133,13 @@ LocaleConfig.defaultLocale = 'fr';
   // Disable all touch events for disabled days. can be override with disableTouchEvent in markedDates
   disableAllTouchEventsForDisabledDays={true}
   // Replace default month and year title with custom one. the function receive a date as parameter.
-  renderHeader={(date) => {/*Return JSX*/}}
+  renderHeader={date => {
+    /*Return JSX*/
+  }}
   // Enable the option to swipe between months. Default = false
   enableSwipeMonths={true}
+  // A `react-native-swipe-gestures` config used to detect swipe of months. Default = undefined
+  swipeMonthsConfig={{velocityThreshold: 0.3, directionalOffsetThreshold: 80, gestureIsClickThreshold: 5}}
 />
 ```
 
@@ -151,13 +175,13 @@ Multi-Dot marking
 </kbd>
 <p></p>
 
-Use `markingType={'multi-dot'}` if you want to display more than one dot. Both the `<Calendar/>` and `<CalendarList/>` support multiple dots by using `dots` array in `markedDates` prop. 
+Use `markingType={'multi-dot'}` if you want to display more than one dot. Both the `<Calendar/>` and `<CalendarList/>` support multiple dots by using `dots` array in `markedDates` prop.
 The property `color` is mandatory while `key` and `selectedColor` are optional. If key is omitted then the array index is used as key. If `selectedColor` is omitted then `color` will be used for selected dates.
 
 ```javascript
-const vacation = {key:'vacation', color: 'red', selectedDotColor: 'blue'};
-const massage = {key:'massage', color: 'blue', selectedDotColor: 'blue'};
-const workout = {key:'workout', color: 'green'};
+const vacation = {key: 'vacation', color: 'red', selectedDotColor: 'blue'};
+const massage = {key: 'massage', color: 'blue', selectedDotColor: 'blue'};
+const workout = {key: 'workout', color: 'green'};
 
 <Calendar
   markedDates={{
@@ -165,7 +189,7 @@ const workout = {key:'workout', color: 'green'};
     '2017-10-26': {dots: [massage, workout], disabled: true}
   }}
   markingType={'multi-dot'}
-/>
+/>;
 ```
 
 Period marking
@@ -221,7 +245,7 @@ Multi-period marking
     }
   }}
   // Date marking style [simple/period/multi-dot/custom]. Default = 'simple'
-  markingType='multi-period'
+  markingType="multi-period"
 />
 ```
 
@@ -264,6 +288,7 @@ Custom marking allows you to customize each marker with custom styles.
 ```
 
 **NEW!** While we still don't support multi marking type, we add the possibility to combine between `period` and `simple`.
+
 ```javascript
 <Calendar
   markingType={'period'}
@@ -274,10 +299,11 @@ Custom marking allows you to customize each marker with custom styles.
     '2012-05-22': {color: '#70d7c7', textColor: 'white'},
     '2012-05-23': {color: '#70d7c7', textColor: 'white', marked: true, dotColor: 'white'},
     '2012-05-24': {color: '#70d7c7', textColor: 'white'},
-    '2012-05-25': {endingDay: true, color: '#50cebb', textColor: 'white'},
+    '2012-05-25': {endingDay: true, color: '#50cebb', textColor: 'white'}
   }}
 />
 ```
+
 <kbd>
   <img height=350 src="https://github.com/wix-private/wix-react-native-calendar/blob/master/demo/multi-marking.png?raw=true">
 </kbd>
@@ -333,16 +359,18 @@ The loading indicator next to the month name will be displayed if `<Calendar/>` 
   }}
 />
 ```
+
 #### Customize days titles with disabled styling
+
 ```javascript
 <Calendar
-    theme={{
-     textSectionTitleDisabledColor: '#d9e1e8'
-    }}
-    disabledDaysIndexes={[0, 6]}
-    markedDates={{
+  theme={{
+    textSectionTitleDisabledColor: '#d9e1e8'
+  }}
+  disabledDaysIndexes={[0, 6]}
+  markedDates={{
     ...this.getDisabledDates('2012-05-01', '2012-05-30', [0, 6])
-    }}
+  }}
 />
 ```
 
@@ -381,9 +409,7 @@ If you need custom functionality not supported by current day component implemen
   dayComponent={({date, state}) => {
     return (
       <View>
-        <Text style={{textAlign: 'center', color: state === 'disabled' ? 'gray' : 'black'}}>
-          {date.day}
-        </Text>
+        <Text style={{textAlign: 'center', color: state === 'disabled' ? 'gray' : 'black'}}>{date.day}</Text>
       </View>
     );
   }}
@@ -392,9 +418,9 @@ If you need custom functionality not supported by current day component implemen
 
 The `dayComponent` prop has to receive a RN component or a function that receive props. The `dayComponent` will receive such props:
 
-* state - disabled if the day should be disabled (this is decided by base calendar component).
-* marking - `markedDates` value for this day.
-* date - the date object representing this day.
+- state - disabled if the day should be disabled (this is decided by base calendar component).
+- marking - `markedDates` value for this day.
+- date - the date object representing this day.
 
 **Tip**: Don't forget to implement `shouldComponentUpdate()` for your custom day component to make the calendar perform better
 
@@ -448,6 +474,7 @@ You can also make the `CalendarList` scroll horizontally. To do that you need to
 ```
 
 ### Agenda
+
 <kbd>
   <img src="https://github.com/wix-private/wix-react-native-calendar/blob/master/demo/agenda.gif?raw=true">
 </kbd>
@@ -467,13 +494,21 @@ An advanced `Agenda` component that can display interactive listings for calenda
     '2012-05-25': [{name: 'item 3 - any js object'}, {name: 'any js object'}]
   }}
   // Callback that gets called when items for a certain month should be loaded (month became visible)
-  loadItemsForMonth={(month) => {console.log('trigger items loading')}}
+  loadItemsForMonth={month => {
+    console.log('trigger items loading');
+  }}
   // Callback that fires when the calendar is opened or closed
-  onCalendarToggled={(calendarOpened) => {console.log(calendarOpened)}}
+  onCalendarToggled={calendarOpened => {
+    console.log(calendarOpened);
+  }}
   // Callback that gets called on day press
-  onDayPress={(day)=>{console.log('day pressed')}}
+  onDayPress={day => {
+    console.log('day pressed');
+  }}
   // Callback that gets called when day changes while scrolling agenda list
-  onDayChange={(day)=>{console.log('day changed')}}
+  onDayChange={day => {
+    console.log('day changed');
+  }}
   // Initially selected day
   selected={'2012-05-16'}
   // Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined
@@ -485,17 +520,29 @@ An advanced `Agenda` component that can display interactive listings for calenda
   // Max amount of months allowed to scroll to the future. Default = 50
   futureScrollRange={50}
   // Specify how each item should be rendered in agenda
-  renderItem={(item, firstItemInDay) => {return (<View />);}}
+  renderItem={(item, firstItemInDay) => {
+    return <View />;
+  }}
   // Specify how each date should be rendered. day can be undefined if the item is not first in that day.
-  renderDay={(day, item) => {return (<View />);}}
+  renderDay={(day, item) => {
+    return <View />;
+  }}
   // Specify how empty date content with no items should be rendered
-  renderEmptyDate={() => {return (<View />);}}
+  renderEmptyDate={() => {
+    return <View />;
+  }}
   // Specify how agenda knob should look like
-  renderKnob={() => {return (<View />);}}
+  renderKnob={() => {
+    return <View />;
+  }}
   // Specify what should be rendered instead of ActivityIndicator
-  renderEmptyData = {() => {return (<View />);}}
+  renderEmptyData={() => {
+    return <View />;
+  }}
   // Specify your item comparison function for increased performance
-  rowHasChanged={(r1, r2) => {return r1.text !== r2.text}}
+  rowHasChanged={(r1, r2) => {
+    return r1.text !== r2.text;
+  }}
   // Hide knob button. Default = false
   hideKnob={true}
   // By default, agenda dates are marked if they have at least one item, but you can override this if needed
@@ -527,13 +574,13 @@ An advanced `Agenda` component that can display interactive listings for calenda
 
 ## Authors
 
-* [Tautvilas Mecinskas](https://github.com/tautvilas/) - Initial code - [@tautvilas](https://twitter.com/Tautvilas)
-* Katrin Zotchev - Initial design - [@katrin_zot](https://twitter.com/katrin_zot)
+- [Tautvilas Mecinskas](https://github.com/tautvilas/) - Initial code - [@tautvilas](https://twitter.com/Tautvilas)
+- Katrin Zotchev - Initial design - [@katrin_zot](https://twitter.com/katrin_zot)
 
 See also the list of [contributors](https://github.com/wix/react-native-calendar-components/contributors) who participated in this project.
 
 ## Contributing
 
-Pull requests are most welcome! 
+Pull requests are most welcome!
 Please `npm run test` and `npm run lint` before push.
 Don't forget to add a **title** and a **description** that explain the issue you're trying to solve and your suggested solution. Screenshots and gifs are very helpful.

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -71,6 +71,8 @@ class Calendar extends Component {
     disableMonthChange: PropTypes.bool,
     /** Enable the option to swipe between months. Default: false */
     enableSwipeMonths: PropTypes.bool,
+    /** A `react-native-swipe-gestures` config used to detect swipe of months. Default = undefined */
+    swipeMonthsConfig: PropTypes.object,
     /** Disable days by default. Default = false */
     disabledByDefault: PropTypes.bool,
     /** Disable all touch events for disabled days. can be override with disableTouchEvent in markedDates*/
@@ -376,9 +378,11 @@ class Calendar extends Component {
   }
 
   render() {
-    const {enableSwipeMonths, style} = this.props;
+    const {enableSwipeMonths, swipeMonthsConfig, style} = this.props;
     const GestureComponent = enableSwipeMonths ? GestureRecognizer : View;
-    const gestureProps = enableSwipeMonths ? {onSwipe: (direction, state) => this.onSwipe(direction, state)} : {};
+    const gestureProps = enableSwipeMonths
+      ? {onSwipe: (direction, state) => this.onSwipe(direction, state), config: swipeMonthsConfig}
+      : {};
 
     return (
       <GestureComponent {...gestureProps}>


### PR DESCRIPTION
Some users find the months swiping not sensible enough. I suggest allowing developer to customize the configuration of `react-native-swipe-gestures` via a prop `swipeMonthsConfig` that is passed to the prop `config`.

Note, that prehook lint made me lint README as well 🤔 