### PR TITLE
Fix Agenda's "renderEmptyData" not rendering and missing theme propType

### DIFF
--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -221,7 +221,9 @@ class ReservationList extends Component {
   render() {
     const {reservations, selectedDay, theme, style} = this.props;
     if (!reservations || !reservations[selectedDay.toString('yyyy-MM-dd')]) {
-      _.invoke(this.props, 'renderEmptyData');
+      if (_.isFunction(this.props.renderEmptyData)) {
+        return _.invoke(this.props, 'renderEmptyData');
+      }
 
       return <ActivityIndicator style={this.style.indicator} color={theme && theme.indicatorColor} />;
     }

--- a/src/agenda/reservation-list/reservation.js
+++ b/src/agenda/reservation-list/reservation.js
@@ -13,6 +13,8 @@ class Reservation extends Component {
 
   static propTypes = {
     item: PropTypes.any,
+    /** Specify theme properties to override specific styles for reservation parts. Default = {} */
+    theme: PropTypes.object,
     // specify your item comparison function for increased performance
     rowHasChanged: PropTypes.func,
     // specify how each date should be rendered. day can be undefined if the item is not first in that day.


### PR DESCRIPTION
This PR fixes the following things

1. The Agenda's **renderEmptyData**, when provided, is called but not renders anything
2. The Agenda's reservation component, is missing the **theme** propType and some theme overrides are not working