### PR TITLE
Avoid auto-select for disabled days

### DIFF
--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -207,13 +207,13 @@ class ExpandableCalendar extends Component {
   }
 
   getMarkedDates() {
-    const {context, markedDates} = this.props;
+    const {context, markedDates, disabledByDefault} = this.props;
 
     if (markedDates) {
       const marked = _.cloneDeep(markedDates);
       if (marked[context.date]) {
         marked[context.date].selected = true;
-      } else {
+      } else if (!disabledByDefault) {
         marked[context.date] = {selected: true};
       }
       return marked;


### PR DESCRIPTION
I was about to open an issue but opened this PR through Github without any major context. Feel free to contribute to this PR or take it as an issue.

Example code:

```
<ExpandableCalendar
          disabledByDefault
 />
```

Unexpected behaviour:

![gif](https://user-images.githubusercontent.com/12275263/102488467-5e705d80-406c-11eb-80d2-fee8d7dd4e3f.gif)
