### PR TITLE
fix 'calendar-list' not rendering on web

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -284,7 +284,7 @@ class CalendarList extends Component {
     const {style, pastScrollRange, futureScrollRange, horizontal, showScrollIndicator, testID} = this.props;
 
     return (
-      <View>
+      <View style={this.style.flatListContainer}>
         <FlatList
           ref={c => (this.listView = c)}
           style={[this.style.container, style]}

--- a/src/calendar-list/style.js
+++ b/src/calendar-list/style.js
@@ -1,4 +1,4 @@
-import {StyleSheet} from 'react-native';
+import {Platform, StyleSheet} from 'react-native';
 import * as defaultStyle from '../style';
 
 const STYLESHEET_ID = 'stylesheet.calendar-list.main';
@@ -6,6 +6,9 @@ const STYLESHEET_ID = 'stylesheet.calendar-list.main';
 export default function getStyle(theme = {}) {
   const appStyle = {...defaultStyle, ...theme};
   return StyleSheet.create({
+    flatListContainer: {
+      flex: Platform.OS === 'web' ? 1 : undefined
+    },
     container: {
       backgroundColor: appStyle.calendarBackground
     },


### PR DESCRIPTION
In reference to this https://github.com/wix/react-native-calendars/pull/1313
Original description:

> This fixes CalendarList / Agenda rendering when running on web via Expo.
> 
> Thanks to @bkniffler with his fix for touch support on web here: [bkniffler@7a0f986](https://github.com/bkniffler/react-native-calendars/commit/7a0f986bbef1f84b0fd6901af6974c8bcd7436c2)
> 
> The main issue was that `FlatList` scrolling only works on web if the parent component has a `flex` style. Source: [necolas/react-native-web#1436 (comment)](https://github.com/necolas/react-native-web/issues/1436#issuecomment-612845122)
> 
> Also incorporated fixes for some `PropTypes` errors on web, thanks @nandorojo: [#1033 (comment)](https://github.com/wix/react-native-calendars/issues/1033#issuecomment-712977254)
> 
> Fixes #924


The original author (@tedsta) stated that : 
> Sorry guys, I'm in a new job now and don't work with React anymore  Hopefully one of you guys can fork this and push it over the finish line. I'll leave this open but feel free to close.

So I went ahead a created a fix.