### PR TITLE
Fix undefined style props web

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -16,8 +16,8 @@ const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
 
 //Fallback for react-native-web or when RN version is < 0.44
-const {Text, View, Dimensions, Animated, ViewPropTypes} = ReactNative;
-const viewPropTypes = typeof document !== 'undefined' ? {style: PropTypes.object} : ViewPropTypes || View.propTypes;
+const {Text, View, Dimensions, Animated, ViewPropTypes, Platform} = ReactNative;
+const viewPropTypes = Platform.OS === "web" ? {style: PropTypes.object} : ViewPropTypes || View.propTypes;
 
 /**
  * @description: Agenda component

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -17,8 +17,7 @@ const KNOB_HEIGHT = 24;
 
 //Fallback for react-native-web or when RN version is < 0.44
 const {Text, View, Dimensions, Animated, ViewPropTypes} = ReactNative;
-const viewPropTypes =
-  typeof document !== 'undefined' ? PropTypes.shape({style: PropTypes.object}) : ViewPropTypes || View.propTypes;
+const viewPropTypes = typeof document !== 'undefined' ? {style: PropTypes.object} : ViewPropTypes || View.propTypes;
 
 /**
  * @description: Agenda component

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -16,7 +16,7 @@ import Day from './day/index';
 
 //Fallback for react-native-web or when RN version is < 0.44
 const {View, ViewPropTypes} = ReactNative;
-const viewPropTypes = typeof document !== 'undefined' ? {style: PropTypes.array} : ViewPropTypes || View.propTypes;
+const viewPropTypes = Platform.OS === "web" ? {style: PropTypes.array} : ViewPropTypes || View.propTypes;
 const EmptyArray = [];
 
 /**

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -16,8 +16,7 @@ import Day from './day/index';
 
 //Fallback for react-native-web or when RN version is < 0.44
 const {View, ViewPropTypes} = ReactNative;
-const viewPropTypes =
-  typeof document !== 'undefined' ? PropTypes.shape({style: PropTypes.object}) : ViewPropTypes || View.propTypes;
+const viewPropTypes = typeof document !== 'undefined' ? {style: PropTypes.array} : ViewPropTypes || View.propTypes;
 const EmptyArray = [];
 
 /**

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -15,7 +15,7 @@ import BasicDay from './day/basic';
 import Day from './day/index';
 
 //Fallback for react-native-web or when RN version is < 0.44
-const {View, ViewPropTypes} = ReactNative;
+const {View, ViewPropTypes, Platform} = ReactNative;
 const viewPropTypes = Platform.OS === "web" ? {style: PropTypes.array} : ViewPropTypes || View.propTypes;
 const EmptyArray = [];
 


### PR DESCRIPTION
Fixes #1360 

I fixed the style wrongly created for  Calendar and Agenda. I also went ahead and fixed the Platform check because `typeof document !== 'undefined'` is not a safe practice.

I was also confused by the way ReactNative is being imported and used. I guess some modules are not exported and could be undefined? That is my only comprehension.