### PR TITLE
remove usage of ViewPropTypes

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 import React, {Component} from 'react';
-import * as ReactNative from 'react-native';
+import {Text, View, Dimensions, Animated} from 'react-native';
 import {extractComponentProps} from '../component-updater';
 import {parseDate, xdateToData} from '../interface';
 import dateutils from '../dateutils';
@@ -14,11 +14,6 @@ import ReservationList from './reservation-list';
 
 const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
-
-//Fallback for react-native-web or when RN version is < 0.44
-const {Text, View, Dimensions, Animated, ViewPropTypes} = ReactNative;
-const viewPropTypes =
-  typeof document !== 'undefined' ? PropTypes.shape({style: PropTypes.object}) : ViewPropTypes || View.propTypes;
 
 /**
  * @description: Agenda component
@@ -34,7 +29,7 @@ export default class AgendaView extends Component {
     ...CalendarList.propTypes,
     ...ReservationList.propTypes,
     /** agenda container style */
-    style: viewPropTypes.style,
+    style: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.number]),
     /** the list of items that have to be displayed in agenda. If you want to render item as empty date
      the value of date key has to be an empty array []. If there exists no value for date key it is
      considered that the date in question is not yet loaded */

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 import React, {Component} from 'react';
-import * as ReactNative from 'react-native';
+import {View} from 'react-native';
 import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
 import dateutils from '../dateutils';
 import {xdateToData, parseDate} from '../interface';
@@ -14,10 +14,6 @@ import CalendarHeader from './header';
 import BasicDay from './day/basic';
 import Day from './day/index';
 
-//Fallback for react-native-web or when RN version is < 0.44
-const {View, ViewPropTypes} = ReactNative;
-const viewPropTypes =
-  typeof document !== 'undefined' ? PropTypes.shape({style: PropTypes.object}) : ViewPropTypes || View.propTypes;
 const EmptyArray = [];
 
 /**
@@ -34,7 +30,7 @@ class Calendar extends Component {
     /** Specify theme properties to override specific styles for calendar parts. Default = {} */
     theme: PropTypes.object,
     /** Specify style for calendar container element. Default = {} */
-    style: viewPropTypes.style,
+    style: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.number]),
     /** Initially visible month. Default = Date() */
     current: PropTypes.any,
     /** Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined */


### PR DESCRIPTION
`ViewPropTypes` are deprecated in `react-native` ( https://github.com/react-native-community/discussions-and-proposals/issues/29 , https://github.com/react-native-community/discussions-and-proposals/issues/29 ) and were already removed from `react-native-web`.

Supposedly #1236 should fix building with `react-native-web` 12+, however that did not work for me and many others (see #1033). I'm still getting the error `"Attempted import error: 'ViewPropTypes' is not exported from 'react-native' (imported as 'ReactNative')."` 

It seems to me that the usage of `ViewPropTypes` does not add a lot of value anyways, the generic types like `PropTypes.object` from the `prop-types` package are used for most type definitions in `Calendar` and `Agenda`.

Therefore, i propose removing the reliance on `ViewPropTypes` for the only two cases where it was used. This should make the package compatible with `react-native-web` today and a future version of `react-native` with `ViewPropTypes` removed.