### PR TITLE
Update `currentMonth` if `current` prop changes

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -88,6 +88,12 @@ class Calendar extends Component {
 
     this.shouldComponentUpdate = shouldComponentUpdate;
   }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.current && prevProps.current !== this.props.current) {
+      this.setState({currentMonth: parseDate(this.props.current)})
+    }
+  }
   
   addMonth = count => {
     this.updateMonth(this.state.currentMonth.clone().addMonths(count, true));


### PR DESCRIPTION
Let calendar be a managed component if user passes in `current` prop.

E.g. we have a filter screen that lets the user select a month to jump to:
<img width="397" alt="Screen Shot 2021-03-17 at 2 43 56 PM" src="https://user-images.githubusercontent.com/7525998/111542644-3bb71900-872f-11eb-82e0-c1f5e27b20ff.png">

So it requires us to be able to control which date the calendar is showing, if we don't want to force unmounting and remounting the component.