### PR TITLE
Fix issue with reversed scroll offset values on Android RTL

### DIFF
--- a/example/src/app.js
+++ b/example/src/app.js
@@ -1,9 +1,11 @@
 import './wdyr'; // <--- must be first import
 
 import {Navigation} from 'react-native-navigation';
+// import {I18nManager} from 'react-native'; // <--- In order to test RTL
 import {LocaleConfig} from 'react-native-calendars';
 import {registerScreens} from './screens';
 
+// I18nManager.forceRTL(true); // <--- In order to test RTL
 registerScreens();
 // eslint-disable-next-line no-console
 console.ignoredYellowBox = ['Remote debugger'];


### PR DESCRIPTION
On Android RTL there's a known issue with Scroll components returning wrong offset values. 
The value is actually reversed, which cause lots of miscalculations. 
The fix reverse the offset value back. 

Another issue I noticed (that is probably related to the whole RTL mess) is that on Android RTL there's an initial unexpected scroll event. 
I disabled this unwanted event to avoid weird issues on mounting 