### PR TITLE
Fixed undefined horizontal prop in CalendarListItem

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -254,6 +254,7 @@ class CalendarList extends Component {
         item={item}
         testID={`${testID}_${item}`}
         style={calendarStyle}
+        horizontal={horizontal}
         calendarWidth={horizontal ? calendarWidth : undefined}
         scrollToMonth={this.scrollToMonth}
       />


### PR DESCRIPTION
Fixed missing horizontal prop in CalenderList, otherwise "horizontal" is always undefined in CalendarListItem and therefore the standard onPressArrow... functions are never called.
This should fix the following issue: #1438 