### PR TITLE
ExpandableCalendar - fix static header updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -610,6 +610,14 @@
 ## [1.1255.0] - 2021-4-4
 ### Added
 - AgendaList - 'avoidDateUpdates' prop to block the date updates to CalendarContextProvider when list scrolls.
-- 
+
 ### Fix
 - ExpandableCalendar - Android RTL issues (PR #1449).
+
+
+## [1.1256.0] - 2021-4-19
+
+### Fix
+- Calendar & Agenda - fix undefined style props web (PR #1406).
+- ExpandableCalendar - static header month update.
+

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -191,11 +191,7 @@ class CalendarList extends Component {
       return;
     }
 
-    this.setState(
-      {
-        currentMonth: day.clone()
-      },
-      () => {
+    this.setState({currentMonth: day.clone()}, () => {
         this.scrollToMonth(this.state.currentMonth);
 
         if (!doNotTriggerListeners) {

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -91,6 +91,7 @@ class CalendarHeader extends Component {
     if (typeof onPressArrowLeft === 'function') {
       return onPressArrowLeft(this.subtractMonth, month);
     }
+
     return this.subtractMonth();
   };
 
@@ -100,6 +101,7 @@ class CalendarHeader extends Component {
     if (typeof onPressArrowRight === 'function') {
       return onPressArrowRight(this.addMonth, month);
     }
+    
     return this.addMonth();
   };
 

--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -340,11 +340,13 @@ class ExpandableCalendar extends Component {
 
   /** Events */
 
-  onPressArrowLeft = () => {
+  onPressArrowLeft = (addMonth) => {
+    addMonth();
     this.scrollPage(false);
   };
 
-  onPressArrowRight = () => {
+  onPressArrowRight = (addMonth) => {
+    addMonth();
     this.scrollPage(true);
   };
 


### PR DESCRIPTION
ExpandableCalendar - fix static header updates when pressing header arrows by calling addMonth() from onPressArrowLeft/Right callback