### PR TITLE
Move AGENDA_CALENDAR_KNOB testid to parent element

### DIFF
--- a/e2e/agenda.spec.js
+++ b/e2e/agenda.spec.js
@@ -22,4 +22,9 @@ describe('Agenda', () => {
 
     await element(by.text('OK')).tap();
   });
+
+  it('should tap knob and open calendar', async () => {
+    await element(by.id(AGENDA_CALENDAR_KNOB)).tap();
+    await element(by.id(`${SELECT_DATE_SLOT}-2017-05-21`)).tap();
+  });
 });

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -419,9 +419,9 @@ export default class AgendaView extends Component {
           onScrollBeginDrag={this.onStartDrag}
           onScrollEndDrag={this.onSnapAfterDrag}
           onScroll={Animated.event([{nativeEvent: {contentOffset: {y: this.state.scrollY}}}], {useNativeDriver: true})}
+          testID={AGENDA_CALENDAR_KNOB}
         >
           <View
-            testID={AGENDA_CALENDAR_KNOB}
             style={{height: agendaHeight + KNOB_HEIGHT}}
             onLayout={this.onScrollPadLayout}
           />


### PR DESCRIPTION
The `AGENDA_CALENDAR_KNOB` testid was in an element that could not receive any interaction. This PR moves the testid to the parent element that has the correct events.