### PR TITLE
Reduce wasteful renders by memoizing props passed to week component

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "hoist-non-react-statics": "^3.3.1",
     "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",
+    "memoize-one": "^5.2.1",
     "prop-types": "^15.5.10",
     "react-native-swipe-gestures": "^1.0.5",
     "xdate": "^0.8.0"

--- a/src/dateutils.js
+++ b/src/dateutils.js
@@ -1,16 +1,20 @@
 const XDate = require('xdate');
+import {parseDate} from './interface';
 
 function sameMonth(a, b) {
-  return a instanceof XDate && b instanceof XDate &&
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth();
+  return (
+    a instanceof XDate && b instanceof XDate && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth()
+  );
 }
 
 function sameDate(a, b) {
-  return a instanceof XDate && b instanceof XDate &&
+  return (
+    a instanceof XDate &&
+    b instanceof XDate &&
     a.getFullYear() === b.getFullYear() &&
     a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate();
+    a.getDate() === b.getDate()
+  );
 }
 
 function isGTE(a, b) {
@@ -23,7 +27,8 @@ function isLTE(a, b) {
 
 function fromTo(a, b) {
   const days = [];
-  let from = +a, to = +b;
+  let from = +a,
+    to = +b;
   for (; from <= to; from = new XDate(from, true).addDays(1).getTime()) {
     days.push(new XDate(from, true));
   }
@@ -31,7 +36,8 @@ function fromTo(a, b) {
 }
 
 function month(xd) {
-  const year = xd.getFullYear(), month = xd.getMonth();
+  const year = xd.getFullYear(),
+    month = xd.getMonth();
   const days = new Date(year, month + 1, 0).getDate();
 
   const firstDay = new XDate(year, month, 1, 0, 0, 0, true);
@@ -51,9 +57,10 @@ function weekDayNames(firstDayOfWeek = 0) {
 
 function page(xd, firstDayOfWeek, showSixWeeks) {
   const days = month(xd);
-  let before = [], after = [];
+  let before = [],
+    after = [];
 
-  const fdow = ((7 + firstDayOfWeek) % 7) || 7;
+  const fdow = (7 + firstDayOfWeek) % 7 || 7;
   const ldow = (fdow + 6) % 7;
 
   firstDayOfWeek = firstDayOfWeek || 0;
@@ -71,7 +78,7 @@ function page(xd, firstDayOfWeek, showSixWeeks) {
     to.addDays((ldow + 7 - day) % 7);
   }
 
-  const daysForSixWeeks = (((daysBefore + days.length) / 6) >= 6);
+  const daysForSixWeeks = (daysBefore + days.length) / 6 >= 6;
 
   if (showSixWeeks && !daysForSixWeeks) {
     to.addDays(7);
@@ -92,6 +99,39 @@ function isDateNotInTheRange(minDate, maxDate, date) {
   return (minDate && !isGTE(date, minDate)) || (maxDate && !isLTE(date, maxDate));
 }
 
+function getWeekDates(date, firstDay, format) {
+  if (date) {
+    const current = parseDate(date);
+    const daysArray = [current];
+    let dayOfTheWeek = current.getDay() - firstDay;
+    if (dayOfTheWeek < 0) {
+      // to handle firstDay > 0
+      dayOfTheWeek = 7 + dayOfTheWeek;
+    }
+
+    let newDate = current;
+    let index = dayOfTheWeek - 1;
+    while (index >= 0) {
+      newDate = parseDate(newDate).addDays(-1);
+      daysArray.unshift(newDate);
+      index -= 1;
+    }
+
+    newDate = current;
+    index = dayOfTheWeek + 1;
+    while (index < 7) {
+      newDate = parseDate(newDate).addDays(1);
+      daysArray.push(newDate);
+      index += 1;
+    }
+
+    if (format) {
+      return daysArray.map(d => d.toString(format));
+    }
+
+    return daysArray;
+  }
+}
 
 module.exports = {
   weekDayNames,
@@ -102,5 +142,6 @@ module.exports = {
   fromTo,
   isLTE,
   isGTE,
-  isDateNotInTheRange
+  isDateNotInTheRange,
+  getWeekDates
 };

--- a/src/expandableCalendar/week.js
+++ b/src/expandableCalendar/week.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import {View} from 'react-native';
 import dateutils from '../dateutils';
 import {parseDate} from '../interface';
@@ -10,10 +10,9 @@ import Calendar from '../calendar';
 import Day from '../calendar/day/index';
 // import BasicDay from '../calendar/day/basic';
 
-
 const EmptyArray = [];
 
-class Week extends Component {
+class Week extends PureComponent {
   static displayName = 'IGNORE';
 
   static propTypes = {
@@ -29,32 +28,7 @@ class Week extends Component {
   }
 
   getWeek(date) {
-    if (date) {
-      const current = parseDate(date);
-      const daysArray = [current];
-      let dayOfTheWeek = current.getDay() - this.props.firstDay;
-      if (dayOfTheWeek < 0) { // to handle firstDay > 0
-        dayOfTheWeek = 7 + dayOfTheWeek;
-      }
-
-      let newDate = current;
-      let index = dayOfTheWeek - 1;
-      while (index >= 0) {
-        newDate = parseDate(newDate).addDays(-1);
-        daysArray.unshift(newDate);
-        index -= 1;
-      }
-
-      newDate = current;
-      index = dayOfTheWeek + 1;
-      while (index < 7) {
-        newDate = parseDate(newDate).addDays(1);
-        daysArray.push(newDate);
-        index += 1;
-      }
-
-      return daysArray;
-    }
+    return dateutils.getWeekDates(date, this.props.firstDay);
   }
 
   getDateMarking(day) {
@@ -92,7 +66,7 @@ class Week extends Component {
   // renderWeekNumber (weekNumber) {
   //   return <BasicDay key={`week-${weekNumber}`} theme={this.props.theme} marking={{disableTouchEvent: true}} state='disabled'>{weekNumber}</Day>;
   // }
-  
+
   renderDay(day, id) {
     const {current, hideExtraDays} = this.props;
     const dayProps = extractComponentProps(Day, this.props);
@@ -100,7 +74,7 @@ class Week extends Component {
     // hide extra days
     if (current && hideExtraDays) {
       if (!dateutils.sameMonth(day, parseDate(current))) {
-        return (<View key={id} style={this.style.emptyDayContainer}/>);
+        return <View key={id} style={this.style.emptyDayContainer} />;
       }
     }
 

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -182,7 +182,7 @@ class WeekCalendar extends Component {
   };
 
   renderItem = ({item}) => {
-    const {calendarWidth, style, onDayPress, markedDates, ...others} = extractComponentProps(Week, this.props);
+    const {style, onDayPress, markedDates, ...others} = extractComponentProps(Week, this.props);
 
     const weekDates = getWeekDates(item, others.firstDay, 'yyyy-MM-dd');
     const currentWeek = _.includes(weekDates, this.props.context.date);
@@ -193,7 +193,7 @@ class WeekCalendar extends Component {
         {...others}
         key={item}
         current={item}
-        style={this.getWeekStyle(calendarWidth || this.containerWidth, style)}
+        style={this.getWeekStyle(this.containerWidth, style)}
         markedDates={fixedMarkedDates}
         onDayPress={onDayPress || this.onDayPress}
       />

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -4,12 +4,14 @@ import {FlatList, View, Text} from 'react-native';
 import {Map} from 'immutable';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
+import memoize from 'memoize-one';
 
 import styleConstructor from './style';
 import CalendarList from '../calendar-list';
 import Week from '../expandableCalendar/week';
 import asCalendarConsumer from './asCalendarConsumer';
-import {weekDayNames} from '../dateutils';
+import {weekDayNames, getWeekDates} from '../dateutils';
+import {extractComponentProps} from '../component-updater';
 
 const commons = require('./commons');
 const UPDATE_SOURCES = commons.UPDATE_SOURCES;
@@ -91,9 +93,8 @@ class WeekCalendar extends Component {
     return newDate.toString('yyyy-MM-dd');
   }
 
-  getMarkedDates() {
+  getMarkedDates = () => {
     const {context, markedDates} = this.props;
-
     if (markedDates) {
       const marked = _.cloneDeep(markedDates);
 
@@ -105,7 +106,11 @@ class WeekCalendar extends Component {
       return marked;
     }
     return {[context.date]: {selected: true}};
-  }
+  };
+
+  getWeekStyle = memoize((width, style) => {
+    return [{width}, style];
+  });
 
   onDayPress = value => {
     _.invoke(this.props.context, 'setDate', value.dateString, UPDATE_SOURCES.DAY_PRESS);
@@ -177,15 +182,19 @@ class WeekCalendar extends Component {
   };
 
   renderItem = ({item}) => {
-    const {calendarWidth, style, onDayPress, ...others} = this.props;
+    const {calendarWidth, style, onDayPress, markedDates, ...others} = extractComponentProps(Week, this.props);
+
+    const weekDates = getWeekDates(item, others.firstDay, 'yyyy-MM-dd');
+    const currentWeek = _.includes(weekDates, this.props.context.date);
+    const fixedMarkedDates = currentWeek ? this.getMarkedDates() : markedDates;
 
     return (
       <Week
         {...others}
         key={item}
         current={item}
-        style={[{width: calendarWidth || this.containerWidth}, style]}
-        markedDates={this.getMarkedDates()}
+        style={this.getWeekStyle(calendarWidth || this.containerWidth, style)}
+        markedDates={fixedMarkedDates}
         onDayPress={onDayPress || this.onDayPress}
       />
     );


### PR DESCRIPTION
Few props triggered wasteful render in the Week component that being rendered in the WeekCalendar component. 
- style 
- context
- markedOptions

I fixed `style` by memoizing its value, this is almost never change so the memoization here make sense. 
For `context`, I used `extractComponentProps` util to avoid passing irrelevant props to Week component
And last, most complicated one, `markedDates` I noticed that it changes usually only for the present/current week. 
So what I did is pass the "fixed" markedDates only for the current week. 

This fix prevents rendering of all weeks when changing selected date in the current week

