### PR TITLE
avoid updating WeekCalendar when stayin on the same week

### DIFF
--- a/src/dateutils.js
+++ b/src/dateutils.js
@@ -17,6 +17,11 @@ function sameDate(a, b) {
   );
 }
 
+function sameWeek(d1, d2, firstDayOfWeek) {
+  const weekDates = getWeekDates(d1, firstDayOfWeek, 'yyyy-MM-dd');
+  return weekDates?.includes(d2);
+}
+
 function isGTE(a, b) {
   return b.diffDays(a) > -1;
 }
@@ -136,6 +141,7 @@ function getWeekDates(date, firstDay, format) {
 module.exports = {
   weekDayNames,
   sameMonth,
+  sameWeek,
   sameDate,
   month,
   page,

--- a/src/expandableCalendar/calendarProvider.js
+++ b/src/expandableCalendar/calendarProvider.js
@@ -9,7 +9,6 @@ import {xdateToData} from '../interface';
 import styleConstructor from './style';
 import CalendarContext from './calendarContext';
 
-
 const commons = require('./commons');
 const UPDATE_SOURCES = commons.UPDATE_SOURCES;
 const iconDown = require('../img/down.png');
@@ -38,13 +37,14 @@ class CalendarProvider extends Component {
     todayButtonStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
     /** The opacity for the disabled today button (0-1) */
     disabledOpacity: PropTypes.number
-  }
+  };
 
   constructor(props) {
     super(props);
     this.style = styleConstructor(props.theme);
 
     this.state = {
+      prevDate: this.props.date || XDate().toString('yyyy-MM-dd'),
       date: this.props.date || XDate().toString('yyyy-MM-dd'),
       updateSource: UPDATE_SOURCES.CALENDAR_INIT,
       buttonY: new Animated.Value(-props.todayBottomMargin || -TOP_POSITION),
@@ -64,6 +64,7 @@ class CalendarProvider extends Component {
     return {
       setDate: this.setDate,
       date: this.state.date,
+      prevDate: this.state.prevDate,
       updateSource: this.state.updateSource,
       setDisabled: this.setDisabled
     };
@@ -72,7 +73,7 @@ class CalendarProvider extends Component {
   setDate = (date, updateSource) => {
     const sameMonth = dateutils.sameMonth(XDate(date), XDate(this.state.date));
 
-    this.setState({date, updateSource, buttonIcon: this.getButtonIcon(date)}, () => {
+    this.setState({date, prevDate: this.state.date, updateSource, buttonIcon: this.getButtonIcon(date)}, () => {
       this.animateTodayButton(date);
     });
 
@@ -81,14 +82,14 @@ class CalendarProvider extends Component {
     if (!sameMonth) {
       _.invoke(this.props, 'onMonthChange', xdateToData(XDate(date)), updateSource);
     }
-  }
+  };
 
-  setDisabled = (disabled) => {
+  setDisabled = disabled => {
     if (this.props.showTodayButton && disabled !== this.state.disabled) {
       this.setState({disabled});
       this.animateOpacity(disabled);
     }
-  }
+  };
 
   getButtonIcon(date) {
     if (!this.props.showTodayButton) {
@@ -146,7 +147,7 @@ class CalendarProvider extends Component {
   onTodayPress = () => {
     const today = XDate().toString('yyyy-MM-dd');
     this.setDate(today, UPDATE_SOURCES.TODAY_PRESS);
-  }
+  };
 
   renderTodayButton() {
     const {disabled, opacity, buttonY, buttonIcon} = this.state;
@@ -155,9 +156,15 @@ class CalendarProvider extends Component {
 
     return (
       <Animated.View style={[this.style.todayButtonContainer, {transform: [{translateY: buttonY}]}]}>
-        <TouchableOpacity style={[this.style.todayButton, this.props.todayButtonStyle]} onPress={this.onTodayPress} disabled={disabled}>
-          <Animated.Image style={[this.style.todayButtonImage, {opacity}]} source={buttonIcon}/>
-          <Animated.Text allowFontScaling={false} style={[this.style.todayButtonText, {opacity}]}>{today}</Animated.Text>
+        <TouchableOpacity
+          style={[this.style.todayButton, this.props.todayButtonStyle]}
+          onPress={this.onTodayPress}
+          disabled={disabled}
+        >
+          <Animated.Image style={[this.style.todayButtonImage, {opacity}]} source={buttonIcon} />
+          <Animated.Text allowFontScaling={false} style={[this.style.todayButtonText, {opacity}]}>
+            {today}
+          </Animated.Text>
         </TouchableOpacity>
       </Animated.View>
     );
@@ -166,9 +173,7 @@ class CalendarProvider extends Component {
   render() {
     return (
       <CalendarContext.Provider value={this.getProviderContextValue()}>
-        <View style={[styles.container, this.props.style]}>
-          {this.props.children}
-        </View>
+        <View style={[styles.container, this.props.style]}>{this.props.children}</View>
         {this.props.showTodayButton && this.renderTodayButton()}
       </CalendarContext.Provider>
     );

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -57,9 +57,13 @@ class WeekCalendar extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const {updateSource, date} = this.props.context;
+    const {firstDay, context} = this.props;
+    const {updateSource, date, prevDate} = context;
 
-    if (date !== prevProps.context.date && updateSource !== UPDATE_SOURCES.WEEK_SCROLL) {
+    const weekDates = getWeekDates(date, firstDay, 'yyyy-MM-dd');
+    const isSameWeek = _.includes(weekDates, prevDate);
+
+    if (date !== prevProps.context.date && updateSource !== UPDATE_SOURCES.WEEK_SCROLL && !isSameWeek) {
       this.setState({items: this.getDatesArray()});
       this.list.current.scrollToIndex({animated: false, index: NUMBER_OF_PAGES});
     }

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -10,7 +10,7 @@ import styleConstructor from './style';
 import CalendarList from '../calendar-list';
 import Week from '../expandableCalendar/week';
 import asCalendarConsumer from './asCalendarConsumer';
-import {weekDayNames, getWeekDates} from '../dateutils';
+import {weekDayNames, sameWeek} from '../dateutils';
 import {extractComponentProps} from '../component-updater';
 
 const commons = require('./commons');
@@ -59,9 +59,7 @@ class WeekCalendar extends Component {
   componentDidUpdate(prevProps) {
     const {firstDay, context} = this.props;
     const {updateSource, date, prevDate} = context;
-
-    const weekDates = getWeekDates(date, firstDay, 'yyyy-MM-dd');
-    const isSameWeek = _.includes(weekDates, prevDate);
+    const isSameWeek = sameWeek(date, prevDate, firstDay);
 
     if (date !== prevProps.context.date && updateSource !== UPDATE_SOURCES.WEEK_SCROLL && !isSameWeek) {
       this.setState({items: this.getDatesArray()});
@@ -187,10 +185,8 @@ class WeekCalendar extends Component {
 
   renderItem = ({item}) => {
     const {style, onDayPress, markedDates, ...others} = extractComponentProps(Week, this.props);
-
-    const weekDates = getWeekDates(item, others.firstDay, 'yyyy-MM-dd');
-    const currentWeek = _.includes(weekDates, this.props.context.date);
-    const fixedMarkedDates = currentWeek ? this.getMarkedDates() : markedDates;
+    const isCurrentWeek = sameWeek(item, this.props.context.date, others.firstDay);
+    const fixedMarkedDates = isCurrentWeek ? this.getMarkedDates() : markedDates;
 
     return (
       <Week


### PR DESCRIPTION
In WeekCalendar component, the `componentDidUpdate` trigger a state change when it's not necessary. 
In the case I change between days on the same week by pressing, there's no need to update the items of the week 