### PR TITLE
Fix: Arrow press callbacks on expandable calendar

### DIFF
--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -350,10 +350,18 @@ class ExpandableCalendar extends Component {
   /** Events */
 
   onPressArrowLeft = () => {
+    const { onPressArrowLeft } = this.props;
+    if (onPressArrowLeft) {
+      onPressArrowLeft();
+    }
     this.scrollPage(false);
   };
 
   onPressArrowRight = () => {
+    const { onPressArrowLeft } = this.props;
+    if (onPressArrowLeft) {
+      onPressArrowLeft();
+    }
     this.scrollPage(true);
   };
 


### PR DESCRIPTION
Fix the broken prop drilling on the `onPressArrowLeft` and `onPressArrowRight` props for  the `ExpandableCalendar`.

See the issue commented below.