### PR TITLE
Fix: Arrow press callbacks on expandable calendar

### DIFF
--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -350,10 +350,18 @@ class ExpandableCalendar extends Component {
   /** Events */
 
   onPressArrowLeft = () => {
+    const {onPressArrowLeft} = this.props;
+    if (onPressArrowLeft) {
+      onPressArrowLeft();
+    }
     this.scrollPage(false);
   };
 
   onPressArrowRight = () => {
+    const {onPressArrowLeft} = this.props;
+    if (onPressArrowLeft) {
+      onPressArrowLeft();
+    }
     this.scrollPage(true);
   };
 

--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -350,18 +350,12 @@ class ExpandableCalendar extends Component {
   /** Events */
 
   onPressArrowLeft = () => {
-    const {onPressArrowLeft} = this.props;
-    if (onPressArrowLeft) {
-      onPressArrowLeft();
-    }
+    _.invoke(this.props, 'onPressArrowLeft');
     this.scrollPage(false);
   };
 
   onPressArrowRight = () => {
-    const {onPressArrowLeft} = this.props;
-    if (onPressArrowLeft) {
-      onPressArrowLeft();
-    }
+    _.invoke(this.props, 'onPressArrowRight');
     this.scrollPage(true);
   };
 


### PR DESCRIPTION
Resolve https://github.com/wix/react-native-calendars/issues/1488.

This is a release blocking issue for us sadly, so any feedback would be hugely appreciated.

As prop drilling is not happening for `onPressArrowLeft` and `onPressArrowRight` in  the `ExpandableCalendar` component, it should be included in the custom function which are being passed.

As a result, it is not possible to use these props in the `ExpandableCalendar` component. They just aren't called.