### PR TITLE
Memoize and prop objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -641,7 +641,7 @@
 ### Added
 - CalendarList - 'animateScroll' prop to allow animation on ato list scroll (i.e. on arrow press).
 
-## [1.1260.0] - 2021-5-2
+## [1.1260.0] - 2021-5-5
 
 ### Added
 - CalendarHeader - individual day header style overrides (PR #1465).
@@ -651,3 +651,8 @@
 ### Changed
 - Update gradle version to 6.3 (PR #1479).
 - Moving inline styles to StyleSheet.
+- CalendarList example screen - adding functionality.
+
+### Fix
+- WeekCalendar - avoid updating when staying on the same week (PR #1482).
+- ExpandableCalendar - fix the markedDates we pass to WeekCalendar (PR #1483).

--- a/example/src/screens/calendars.js
+++ b/example/src/screens/calendars.js
@@ -5,7 +5,7 @@ import {StyleSheet, View, ScrollView, Text, TouchableOpacity, Switch} from 'reac
 import {Calendar} from 'react-native-calendars';
 
 const testIDs = require('../testIDs');
-const INITIAL_DATE = '2021-05-05';
+const INITIAL_DATE = '2020-02-02';
 
 const CalendarsScreen = () => {
   const [selected, setSelected] = useState(INITIAL_DATE);

--- a/example/src/screens/calendars.js
+++ b/example/src/screens/calendars.js
@@ -5,9 +5,10 @@ import {StyleSheet, View, ScrollView, Text, TouchableOpacity, Switch} from 'reac
 import {Calendar} from 'react-native-calendars';
 
 const testIDs = require('../testIDs');
+const INITIAL_DATE = '2021-05-05';
 
 const CalendarsScreen = () => {
-  const [selected, setSelected] = useState('');
+  const [selected, setSelected] = useState(INITIAL_DATE);
   const [showMarkedDatesExamples, setShowMarkedDatesExamples] = useState(false);
 
   const toggleSwitch = () => {
@@ -37,7 +38,7 @@ const CalendarsScreen = () => {
         <Text style={styles.text}>Calendar with selectable date</Text>
         <Calendar
           testID={testIDs.calendars.FIRST}
-          current={'2020-02-02'}
+          current={INITIAL_DATE}
           style={styles.calendar}
           onDayPress={onDayPress}
           markedDates={{

--- a/example/src/screens/expandableCalendar.js
+++ b/example/src/screens/expandableCalendar.js
@@ -76,7 +76,65 @@ const ITEMS = [
   {title: dates[10], data: [{hour: '12am', duration: '1h', title: 'Last Yoga'}]}
 ];
 
+function getMarkedDates(items) {
+  const marked = {};
+  items.forEach(item => {
+    // NOTE: only mark dates with data
+    if (item.data && item.data.length > 0 && !_.isEmpty(item.data[0])) {
+      marked[item.title] = {marked: true};
+    } else {
+      marked[item.title] = {disabled: true};
+    }
+  });
+  return marked;
+}
+
+function getTheme() {
+  const disabledColor = 'grey';
+
+  return {
+    // arrows
+    arrowColor: 'black',
+    arrowStyle: {padding: 0},
+    // month
+    monthTextColor: 'black',
+    textMonthFontSize: 16,
+    textMonthFontFamily: 'HelveticaNeue',
+    textMonthFontWeight: 'bold',
+    // day names
+    textSectionTitleColor: 'black',
+    textDayHeaderFontSize: 12,
+    textDayHeaderFontFamily: 'HelveticaNeue',
+    textDayHeaderFontWeight: 'normal',
+    // dates
+    dayTextColor: themeColor,
+    textDayFontSize: 18,
+    textDayFontFamily: 'HelveticaNeue',
+    textDayFontWeight: '500',
+    textDayStyle: {marginTop: Platform.OS === 'android' ? 2 : 4},
+    // selected date
+    selectedDayBackgroundColor: themeColor,
+    selectedDayTextColor: 'white',
+    // disabled date
+    textDisabledColor: disabledColor,
+    // dot (marked date)
+    dotColor: themeColor,
+    selectedDotColor: 'white',
+    disabledDotColor: disabledColor,
+    dotStyle: {marginTop: -2}
+  };
+}
+
+const leftArrowIcon = require('../img/previous.png');
+const rightArrowIcon = require('../img/next.png');
+
 export default class ExpandableCalendarScreen extends Component {
+  marked = getMarkedDates(ITEMS);
+  theme = getTheme();
+  todayBtnTheme = {
+    todayButtonTextColor: themeColor
+  }
+
   onDateChanged = (/* date, updateSource */) => {
     // console.warn('ExpandableCalendarScreen onDateChanged: ', date, updateSource);
     // fetch and set data for date + week ahead
@@ -121,55 +179,6 @@ export default class ExpandableCalendarScreen extends Component {
     );
   };
 
-  getMarkedDates = () => {
-    const marked = {};
-    ITEMS.forEach(item => {
-      // NOTE: only mark dates with data
-      if (item.data && item.data.length > 0 && !_.isEmpty(item.data[0])) {
-        marked[item.title] = {marked: true};
-      } else {
-        marked[item.title] = {disabled: true};
-      }
-    });
-    return marked;
-  };
-
-  getTheme = () => {
-    const disabledColor = 'grey';
-
-    return {
-      // arrows
-      arrowColor: 'black',
-      arrowStyle: {padding: 0},
-      // month
-      monthTextColor: 'black',
-      textMonthFontSize: 16,
-      textMonthFontFamily: 'HelveticaNeue',
-      textMonthFontWeight: 'bold',
-      // day names
-      textSectionTitleColor: 'black',
-      textDayHeaderFontSize: 12,
-      textDayHeaderFontFamily: 'HelveticaNeue',
-      textDayHeaderFontWeight: 'normal',
-      // dates
-      dayTextColor: themeColor,
-      textDayFontSize: 18,
-      textDayFontFamily: 'HelveticaNeue',
-      textDayFontWeight: '500',
-      textDayStyle: {marginTop: Platform.OS === 'android' ? 2 : 4},
-      // selected date
-      selectedDayBackgroundColor: themeColor,
-      selectedDayTextColor: 'white',
-      // disabled date
-      textDisabledColor: disabledColor,
-      // dot (marked date)
-      dotColor: themeColor,
-      selectedDotColor: 'white',
-      disabledDotColor: disabledColor,
-      dotStyle: {marginTop: -2}
-    };
-  };
-
   render() {
     return (
       <CalendarProvider
@@ -178,13 +187,11 @@ export default class ExpandableCalendarScreen extends Component {
         onMonthChange={this.onMonthChange}
         showTodayButton
         disabledOpacity={0.6}
-        // theme={{
-        //   todayButtonTextColor: themeColor
-        // }}
+        // theme={this.todayBtnTheme}
         // todayBottomMargin={16}
       >
         {this.props.weekView ? (
-          <WeekCalendar testID={testIDs.weekCalendar.CONTAINER} firstDay={1} markedDates={this.getMarkedDates()} />
+          <WeekCalendar testID={testIDs.weekCalendar.CONTAINER} firstDay={1} markedDates={this.marked}/>
         ) : (
           <ExpandableCalendar
             testID={testIDs.expandableCalendar.CONTAINER}
@@ -196,12 +203,12 @@ export default class ExpandableCalendarScreen extends Component {
             // calendarStyle={styles.calendar}
             // headerStyle={styles.calendar} // for horizontal only
             // disableWeekScroll
-            // theme={this.getTheme()}
+            // theme={this.theme}
             disableAllTouchEventsForDisabledDays
             firstDay={1}
-            markedDates={this.getMarkedDates()} // {'2019-06-01': {marked: true}, '2019-06-02': {marked: true}, '2019-06-03': {marked: true}};
-            leftArrowImageSource={require('../img/previous.png')}
-            rightArrowImageSource={require('../img/next.png')}
+            markedDates={this.marked}
+            leftArrowImageSource={leftArrowIcon}
+            rightArrowImageSource={rightArrowIcon}
             // animateScroll
           />
         )}

--- a/example/src/screens/horizontalCalendarList.js
+++ b/example/src/screens/horizontalCalendarList.js
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 import {CalendarList} from 'react-native-calendars';
 
 const testIDs = require('../testIDs');
-const initialDate = '2020-03-15';
+const initialDate = '2020-05-16';
 
 
 const HorizontalCalendarList = () => {

--- a/example/src/screens/horizontalCalendarList.js
+++ b/example/src/screens/horizontalCalendarList.js
@@ -1,34 +1,33 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {CalendarList} from 'react-native-calendars';
 
 const testIDs = require('../testIDs');
+const initialDate = '2020-03-15';
+
 
 const HorizontalCalendarList = () => {
-  const [selectedDate, setSelectedDate] = React.useState('2020-05-16');
-  const [markedDates, setMarkedDates] = React.useState({});
-
-  const setNewDaySelected = date => {
-    const markedDate = Object.assign({});
-    markedDate[date] = {
+  const [selected, setSelected] = useState(initialDate);
+  const markedDates = {
+    [selected]: {
       selected: true,
       selectedColor: '#DFA460'
-    };
-    setSelectedDate(date);
-    setMarkedDates(markedDate);
+    }
+  };
+  
+  const onDayPress = day => {
+    setSelected(day.dateString);
   };
 
   return (
     <CalendarList
       testID={testIDs.horizontalList.CONTAINER}
       markedDates={markedDates}
-      current={selectedDate}
+      current={initialDate}
       pastScrollRange={24}
       futureScrollRange={24}
       horizontal
       pagingEnabled
-      onDayPress={day => {
-        setNewDaySelected(day.dateString);
-      }}
+      onDayPress={onDayPress}
     />
   );
 };

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -1,16 +1,20 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
+import memoize from 'memoize-one';
+
 import React, {Component} from 'react';
 import {Text, View, Dimensions, Animated} from 'react-native';
+
 import {extractComponentProps} from '../component-updater';
-import {parseDate, xdateToData} from '../interface';
+import {parseDate, xdateToData, toMarkingFormat} from '../interface';
 import dateutils from '../dateutils';
 import {AGENDA_CALENDAR_KNOB} from '../testIDs';
 import {VelocityTracker} from '../input';
 import styleConstructor from './style';
 import CalendarList from '../calendar-list';
 import ReservationList from './reservation-list';
+
 
 const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
@@ -178,22 +182,19 @@ export default class AgendaView extends Component {
     _.invoke(this.props, 'onDayPress', xdateToData(day));
   }
 
-  generateMarkings = () => {
-    const {markedDates, items} = this.props;
-    let markings = markedDates;
-
-    if (!markings) {
-      markings = {};
-      Object.keys(items || {}).forEach(key => {
+  generateMarkings = memoize((selectedDay, markedDates, items = {}) => {
+    if (!markedDates) {
+      markedDates = {};
+      Object.keys(items).forEach(key => {
         if (items[key] && items[key].length) {
-          markings[key] = {marked: true};
+          markedDates[key] = {marked: true};
         }
       });
     }
 
-    const key = this.state.selectedDay.toString('yyyy-MM-dd');
-    return {...markings, [key]: {...(markings[key] || {}), ...{selected: true}}};
-  };
+    const key = toMarkingFormat(selectedDay);
+    return {...markedDates, [key]: {...(markedDates[key] || {}), ...{selected: true}}};
+  });
 
   onScrollPadLayout = () => {
     // When user touches knob, the actual component that receives touch events is a ScrollView.
@@ -297,6 +298,7 @@ export default class AgendaView extends Component {
   }
 
   renderCalendarList() {
+    const {markedDates, items} = this.props;
     const shouldHideExtraDays = this.state.calendarScrollable ? this.props.hideExtraDays : false;
     const calendarListProps = extractComponentProps(CalendarList, this.props);
 
@@ -305,7 +307,7 @@ export default class AgendaView extends Component {
         {...calendarListProps}
         ref={c => (this.calendar = c)}
         current={this.currentMonth}
-        markedDates={this.generateMarkings()}
+        markedDates={this.generateMarkings(this.state.selectedDay, markedDates, items)}
         calendarWidth={this.viewWidth}
         scrollEnabled={this.state.calendarScrollable}
         hideExtraDays={shouldHideExtraDays}
@@ -331,10 +333,22 @@ export default class AgendaView extends Component {
     return knob;
   }
 
+  renderWeekDaysNames = memoize((weekDaysNames) => {    
+    return weekDaysNames.map((day, index) => (
+      <Text allowFontScaling={false} key={day + index} style={this.style.weekday} numberOfLines={1}>
+        {day}
+      </Text>
+    ));
+  });
+
+  renderWeekNumbersSpace = () => {
+    return this.props.showWeekNumbers && <View allowFontScaling={false} style={this.style.weekday} numberOfLines={1}/>;
+  };
+
   render() {
-    const {firstDay, hideKnob, showWeekNumbers, style, testID} = this.props;
-    const agendaHeight = this.initialScrollPadPosition();
+    const {firstDay, hideKnob, style, testID} = this.props;
     const weekDaysNames = dateutils.weekDayNames(firstDay);
+    const agendaHeight = this.initialScrollPadPosition();
     const weekdaysStyle = [
       this.style.weekdays,
       {
@@ -399,12 +413,8 @@ export default class AgendaView extends Component {
           {this.renderKnob()}
         </Animated.View>
         <Animated.View style={weekdaysStyle}>
-          {showWeekNumbers && <Text allowFontScaling={false} style={this.style.weekday} numberOfLines={1}></Text>}
-          {weekDaysNames.map((day, index) => (
-            <Text allowFontScaling={false} key={day + index} style={this.style.weekday} numberOfLines={1}>
-              {day}
-            </Text>
-          ))}
+          {this.renderWeekNumbersSpace()}
+          {this.renderWeekDaysNames(weekDaysNames)}
         </Animated.View>
         <Animated.ScrollView
           ref={ref => (this.scrollPad = ref)}

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -1,10 +1,13 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
+
 import React, {Component} from 'react';
 import {FlatList, ActivityIndicator, View} from 'react-native';
+
 import {extractComponentProps} from '../../component-updater';
 import dateutils from '../../dateutils';
+import {toMarkingFormat} from '../../interface';
 import styleConstructor from './style';
 import Reservation from './reservation';
 
@@ -105,7 +108,7 @@ class ReservationList extends Component {
 
   getReservationsForDay(iterator, props) {
     const day = iterator.clone();
-    const res = props.reservations[day.toString('yyyy-MM-dd')];
+    const res = props.reservations[toMarkingFormat(day)];
     if (res && res.length) {
       return res.map((reservation, i) => {
         return {
@@ -218,9 +221,11 @@ class ReservationList extends Component {
     );
   };
 
+  keyExtractor = (item, index) => String(index);
+
   render() {
     const {reservations, selectedDay, theme, style} = this.props;
-    if (!reservations || !reservations[selectedDay.toString('yyyy-MM-dd')]) {
+    if (!reservations || !reservations[toMarkingFormat(selectedDay)]) {
       if (_.isFunction(this.props.renderEmptyData)) {
         return _.invoke(this.props, 'renderEmptyData');
       }
@@ -235,7 +240,7 @@ class ReservationList extends Component {
         contentContainerStyle={this.style.content}
         data={this.state.reservations}
         renderItem={this.renderRow}
-        keyExtractor={(item, index) => String(index)}
+        keyExtractor={this.keyExtractor}
         showsVerticalScrollIndicator={false}
         scrollEventThrottle={200}
         onMoveShouldSetResponderCapture={this.onMoveShouldSetResponderCapture}

--- a/src/agenda/reservation-list/reservation.js
+++ b/src/agenda/reservation-list/reservation.js
@@ -59,7 +59,8 @@ class Reservation extends Component {
       return this.props.renderDay(date ? xdateToData(date) : undefined, item);
     }
 
-    const today = dateutils.sameDate(date, XDate()) ? this.style.today : undefined;
+    const today = dateutils.isToday(date) ? this.style.today : undefined;
+    
     if (date) {
       return (
         <View style={this.style.day} testID={RESERVATION_DATE}>

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -1,8 +1,10 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
+
 import React, {Component} from 'react';
 import {FlatList, Platform, Dimensions, View} from 'react-native';
+
 import {extractComponentProps} from '../component-updater';
 import {xdateToData, parseDate} from '../interface';
 import dateutils from '../dateutils';

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -83,7 +83,8 @@ class CalendarListItem extends Component {
       style,
       headerStyle,
       onPressArrowLeft,
-      onPressArrowRight
+      onPressArrowRight,
+      context
     } = this.props;
     const calendarProps = extractComponentProps(Calendar, this.props);
     const calStyle = this.getCalendarStyle(calendarWidth, calendarHeight, style);
@@ -99,6 +100,7 @@ class CalendarListItem extends Component {
           disableMonthChange
           onPressArrowLeft={horizontal ? this.onPressArrowLeft : onPressArrowLeft}
           onPressArrowRight={horizontal ? this.onPressArrowRight : onPressArrowRight}
+          context={context}
         />
       );
     } else {

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -1,9 +1,13 @@
 import PropTypes from 'prop-types';
+import memoize from 'memoize-one';
+
 import React, {Component} from 'react';
 import {Text, View} from 'react-native';
+
 import {extractComponentProps} from '../component-updater';
 import Calendar from '../calendar';
 import styleConstructor from './style';
+
 
 class CalendarListItem extends Component {
   static displayName = 'IGNORE';
@@ -65,6 +69,10 @@ class CalendarListItem extends Component {
     }
   };
 
+  getCalendarStyle = memoize((width, height, style) => {
+    return [{width, height}, this.style.calendar, style];
+  });
+
   render() {
     const {
       item,
@@ -78,14 +86,14 @@ class CalendarListItem extends Component {
       onPressArrowRight
     } = this.props;
     const calendarProps = extractComponentProps(Calendar, this.props);
-
+    
     if (item.getTime) {
       return (
         <Calendar
           {...calendarProps}
           testID={testID}
           current={item}
-          style={[{height: calendarHeight, width: calendarWidth}, this.style.calendar, style]}
+          style={this.getCalendarStyle(calendarWidth, calendarHeight, style)}
           headerStyle={horizontal ? headerStyle : undefined}
           disableMonthChange
           onPressArrowLeft={horizontal ? this.onPressArrowLeft : onPressArrowLeft}

--- a/src/calendar-list/item.js
+++ b/src/calendar-list/item.js
@@ -86,14 +86,15 @@ class CalendarListItem extends Component {
       onPressArrowRight
     } = this.props;
     const calendarProps = extractComponentProps(Calendar, this.props);
-    
+    const calStyle = this.getCalendarStyle(calendarWidth, calendarHeight, style);
+
     if (item.getTime) {
       return (
         <Calendar
           {...calendarProps}
           testID={testID}
           current={item}
-          style={this.getCalendarStyle(calendarWidth, calendarHeight, style)}
+          style={calStyle}
           headerStyle={horizontal ? headerStyle : undefined}
           disableMonthChange
           onPressArrowLeft={horizontal ? this.onPressArrowLeft : onPressArrowLeft}

--- a/src/calendar/day/basic/index.js
+++ b/src/calendar/day/basic/index.js
@@ -13,7 +13,7 @@ export default class BasicDay extends Component {
   static displayName = 'IGNORE';
 
   static propTypes = {
-    state: PropTypes.oneOf(['disabled', 'today', '']),
+    state: PropTypes.oneOf(['selected', 'disabled', 'today', '']),
     /** The marking object */
     marking: PropTypes.any,
     /** Date marking style [simple/period/multi-dot/multi-period]. Default = 'simple' */
@@ -71,6 +71,10 @@ export default class BasicDay extends Component {
     return disableTouch;
   }
 
+  isSelected() {
+    return this.marking.selected || this.props.state === 'selected';
+  }
+
   isDisabled() {
     return typeof this.marking.disabled !== 'undefined' ? this.marking.disabled : this.props.state === 'disabled';
   }
@@ -92,10 +96,10 @@ export default class BasicDay extends Component {
   }
 
   getContainerStyle() {
-    const {customStyles, selected, selectedColor} = this.marking;
+    const {customStyles, selectedColor} = this.marking;
     const style = [this.style.base];
 
-    if (selected) {
+    if (this.isSelected()) {
       style.push(this.style.selected);
       if (selectedColor) {
         style.push({backgroundColor: selectedColor});
@@ -116,10 +120,10 @@ export default class BasicDay extends Component {
   }
 
   getTextStyle() {
-    const {customStyles, selected, selectedTextColor} = this.marking;
+    const {customStyles, selectedTextColor} = this.marking;
     const style = [this.style.text];
 
-    if (selected) {
+    if (this.isSelected()) {
       style.push(this.style.selectedText);
       if (selectedTextColor) {
         style.push({color: selectedTextColor});
@@ -140,14 +144,14 @@ export default class BasicDay extends Component {
 
   renderMarking() {
     const {theme, markingType} = this.props;
-    const {selected, marked, dotColor, dots, periods} = this.marking;
+    const {marked, dotColor, dots, periods} = this.marking;
 
     return (
       <Marking
         type={markingType}
         theme={theme}
         marked={this.isMultiDot() ? true : marked}
-        selected={selected}
+        selected={this.isSelected()}
         disabled={this.isDisabled()}
         today={this.isToday()}
         dotColor={dotColor}

--- a/src/calendar/day/basic/index.js
+++ b/src/calendar/day/basic/index.js
@@ -1,7 +1,9 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
+
 import React, {Component, Fragment} from 'react';
 import {TouchableOpacity, Text, View} from 'react-native';
+
 import {shouldUpdate} from '../../../component-updater';
 import styleConstructor from './style';
 import Marking from '../marking';
@@ -11,7 +13,7 @@ export default class BasicDay extends Component {
   static displayName = 'IGNORE';
 
   static propTypes = {
-    state: PropTypes.oneOf(['disabled', 'today', '']), //TODO: deprecate
+    state: PropTypes.oneOf(['disabled', 'today', '']),
     /** The marking object */
     marking: PropTypes.any,
     /** Date marking style [simple/period/multi-dot/multi-period]. Default = 'simple' */
@@ -90,7 +92,7 @@ export default class BasicDay extends Component {
   }
 
   getContainerStyle() {
-    const {customStyles, selected, selectedColor} = this.props.marking;
+    const {customStyles, selected, selectedColor} = this.marking;
     const style = [this.style.base];
 
     if (selected) {
@@ -114,7 +116,7 @@ export default class BasicDay extends Component {
   }
 
   getTextStyle() {
-    const {customStyles, selected, selectedTextColor} = this.props.marking;
+    const {customStyles, selected, selectedTextColor} = this.marking;
     const style = [this.style.text];
 
     if (selected) {

--- a/src/calendar/day/index.js
+++ b/src/calendar/day/index.js
@@ -1,8 +1,12 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
+import memoize from 'memoize-one';
+
 import React, {Component} from 'react';
+
 import {shouldUpdate, extractComponentProps} from '../../component-updater';
+import dateutils from '../../dateutils';
 import {xdateToData} from '../../interface';
 import {SELECT_DATE_SLOT} from '../../testIDs';
 import BasicDay from './basic';
@@ -26,48 +30,47 @@ export default class Day extends Component {
     return shouldUpdate(this.props, nextProps, ['day', 'dayComponent', 'markingType', 'marking', 'onPress', 'onLongPress']);
   }
 
-  getMarkingLabel() {
-    const {marking} = this.props;
+  getMarkingLabel(marking) {
     let label = '';
-
-    if (marking.accessibilityLabel) {
-      return marking.accessibilityLabel;
-    }
-
-    if (marking.selected) {
-      label += 'selected ';
-      if (!marking.marked) {
-        label += 'You have no entries for this day ';
+    
+    if (marking) {
+      if (marking.accessibilityLabel) {
+        return marking.accessibilityLabel;
       }
-    }
-    if (marking.marked) {
-      label += 'You have entries for this day ';
-    }
-    if (marking.startingDay) {
-      label += 'period start ';
-    }
-    if (marking.endingDay) {
-      label += 'period end ';
-    }
-    if (marking.disabled || marking.disableTouchEvent) {
-      label += 'disabled ';
+  
+      if (marking.selected) {
+        label += 'selected ';
+        if (!marking.marked) {
+          label += 'You have no entries for this day ';
+        }
+      }
+      if (marking.marked) {
+        label += 'You have entries for this day ';
+      }
+      if (marking.startingDay) {
+        label += 'period start ';
+      }
+      if (marking.endingDay) {
+        label += 'period end ';
+      }
+      if (marking.disabled || marking.disableTouchEvent) {
+        label += 'disabled ';
+      }
     }
     return label;
   }
 
-  getAccessibilityLabel = (day) => {
-    const {state} = this.props;
+  getAccessibilityLabel = memoize((day, marking, isToday) => {
     const today = XDate.locales[XDate.defaultLocale].today;
-    const isToday = state === 'today'; //TODO: check if 'day' equals 'today' and remove 'state' check
     const formatAccessibilityLabel = XDate.locales[XDate.defaultLocale].formatAccessibilityLabel;
-    const markingLabel = this.getMarkingLabel(day);
+    const markingLabel = this.getMarkingLabel(marking);
 
     if (formatAccessibilityLabel) {
       return `${isToday ? today : ''} ${day.toString(formatAccessibilityLabel)} ${markingLabel}`;
     }
 
     return `${isToday ? 'today' : ''} ${day.toString('dddd d MMMM yyyy')} ${markingLabel}`;
-  };
+  });
 
   getDayComponent() {
     const {dayComponent, markingType} = this.props;
@@ -79,17 +82,19 @@ export default class Day extends Component {
   }
 
   render() {
-    const {day} = this.props;
+    const {day, marking} = this.props;
     const date = xdateToData(day);
+    const isToday = dateutils.isToday(day);
     const Component = this.getDayComponent();
     const dayProps = extractComponentProps(Component, this.props);
+    const accessibilityLabel = this.getAccessibilityLabel(day, marking, isToday);
 
     return (
       <Component
           {...dayProps}
           date={date}
           testID={`${SELECT_DATE_SLOT}-${date.dateString}`}
-          accessibilityLabel={this.getAccessibilityLabel(day)}
+          accessibilityLabel={accessibilityLabel}
         >
           {date ? day.getDate() : day}
       </Component>

--- a/src/calendar/day/index.js
+++ b/src/calendar/day/index.js
@@ -27,7 +27,7 @@ export default class Day extends Component {
   };
 
   shouldComponentUpdate(nextProps) {
-    return shouldUpdate(this.props, nextProps, ['day', 'dayComponent', 'markingType', 'marking', 'onPress', 'onLongPress']);
+    return shouldUpdate(this.props, nextProps, ['day', 'dayComponent', 'state', 'markingType', 'marking', 'onPress', 'onLongPress']);
   }
 
   getMarkingLabel(marking) {

--- a/src/calendar/day/period/index.js
+++ b/src/calendar/day/period/index.js
@@ -1,7 +1,9 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
+
 import React, {Component} from 'react';
 import {TouchableWithoutFeedback, Text, View} from 'react-native';
+
 import {shouldUpdate} from '../../../component-updater';
 import * as defaultStyle from '../../../style';
 import styleConstructor from './style';
@@ -12,7 +14,7 @@ export default class PeriodDay extends Component {
   static displayName = 'IGNORE';
 
   static propTypes = {
-    state: PropTypes.oneOf(['selected', 'disabled', 'today', '']), //TODO: deprecate
+    state: PropTypes.oneOf(['selected', 'disabled', 'today', '']),
     marking: PropTypes.any,
     theme: PropTypes.object,
     onPress: PropTypes.func,
@@ -189,16 +191,16 @@ export default class PeriodDay extends Component {
       );
     }
 
-    const {marking: {marked, dotColor, disableTouchEvent}, theme, accessibilityLabel, testID} = this.props;
+    const {theme, accessibilityLabel, testID} = this.props;
 
     return (
       <TouchableWithoutFeedback
         testID={testID}
         onPress={this.onPress}
         onLongPress={this.onLongPress}
-        disabled={disableTouchEvent}
+        disabled={marking?.disableTouchEvent}
         accessible
-        accessibilityRole={disableTouchEvent ? undefined : 'button'}
+        accessibilityRole={marking?.disableTouchEvent ? undefined : 'button'}
         accessibilityLabel={accessibilityLabel}
       >
         <View style={this.style.wrapper}>
@@ -207,8 +209,8 @@ export default class PeriodDay extends Component {
             <Text allowFontScaling={false} style={textStyle}>{String(this.props.children)}</Text>
             <Dot
               theme={theme}
-              color={dotColor}
-              marked={marked}
+              color={marking?.dotColor}
+              marked={marking?.marked}
             />
           </View>
         </View>

--- a/src/calendar/header/index.js
+++ b/src/calendar/header/index.js
@@ -1,8 +1,11 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
+import memoize from 'memoize-one';
 import XDate from 'xdate';
+
 import React, {Component, Fragment} from 'react';
 import {ActivityIndicator, Platform, View, Text, TouchableOpacity, Image} from 'react-native';
+
 import {shouldUpdate} from '../../component-updater';
 import {weekDayNames} from '../../dateutils';
 import {
@@ -13,6 +16,7 @@ import {
   HEADER_MONTH_NAME
 } from '../../testIDs';
 import styleConstructor from './style';
+
 
 class CalendarHeader extends Component {
   static displayName = 'IGNORE';
@@ -105,7 +109,7 @@ class CalendarHeader extends Component {
     return this.addMonth();
   };
 
-  renderWeekDays = weekDaysNames => {
+  renderWeekDays = memoize(weekDaysNames => {
     const {disabledDaysIndexes} = this.props;
 
     return weekDaysNames.map((day, idx) => {
@@ -125,7 +129,7 @@ class CalendarHeader extends Component {
         </Text>
       );
     });
-  };
+  });
 
   renderHeader = () => {
     const {renderHeader, month, monthFormat, testID, webAriaLevel} = this.props;

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -141,6 +141,8 @@ class Calendar extends Component {
     
     if (context?.date === toMarkingFormat(day)) {
       state = 'selected';
+    } else if (dateutils.isToday(day)) {
+      state = 'today';
     }
     if (disabledByDefault) {
       state = 'disabled';
@@ -148,9 +150,8 @@ class Calendar extends Component {
       state = 'disabled';
     } else if (!dateutils.sameMonth(day, this.state.currentMonth)) {
       state = 'disabled';
-    } else if (dateutils.isToday(day)) {
-      state = 'today';
     }
+
     return state;
   }
 

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -187,7 +187,7 @@ class Calendar extends Component {
         <BasicDay
           key={`week-${weekNumber}`}
           marking={{disabled: true, disableTouchEvent: true}}
-          // state="disabled"
+          // state='disabled'
           theme={this.props.theme}
           testID={`${WEEK_NUMBER}-${weekNumber}`}
         >

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -132,12 +132,16 @@ class Calendar extends Component {
     this.handleDayInteraction(date, this.props.onDayLongPress);
   };
 
+  //TODO: this method has a duplication in Week component - consider moving to presenter/state manager
   getState(day) {
-    const {disabledByDefault} = this.props;
+    const {disabledByDefault, context} = this.props;
     const minDate = parseDate(this.props.minDate);
     const maxDate = parseDate(this.props.maxDate);
     let state = '';
-
+    
+    if (context?.date === toMarkingFormat(day)) {
+      state = 'selected';
+    }
     if (disabledByDefault) {
       state = 'disabled';
     } else if (dateutils.isDateNotInTheRange(minDate, maxDate, day)) {

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -211,7 +211,7 @@ class Calendar extends Component {
           {...dayProps}
           day={day}
           state={this.getState(day)}
-          marking={markedDates && markedDates[toMarkingFormat(day)]}
+          marking={markedDates?.[toMarkingFormat(day)]}
           onPress={this.pressDay}
           onLongPress={this.longPressDay}
         />

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -9,6 +9,7 @@ import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
 
 import dateutils from '../dateutils';
 import {xdateToData, parseDate, toMarkingFormat} from '../interface';
+import {getState} from '../day-state-manager';
 // import shouldComponentUpdate from './updater';
 import {extractComponentProps} from '../component-updater';
 import {WEEK_NUMBER} from '../testIDs';
@@ -132,29 +133,6 @@ class Calendar extends Component {
     this.handleDayInteraction(date, this.props.onDayLongPress);
   };
 
-  //TODO: this method has a duplication in Week component - consider moving to presenter/state manager
-  getState(day) {
-    const {disabledByDefault, context} = this.props;
-    const minDate = parseDate(this.props.minDate);
-    const maxDate = parseDate(this.props.maxDate);
-    let state = '';
-    
-    if (context?.date === toMarkingFormat(day)) {
-      state = 'selected';
-    } else if (dateutils.isToday(day)) {
-      state = 'today';
-    }
-    if (disabledByDefault) {
-      state = 'disabled';
-    } else if (dateutils.isDateNotInTheRange(minDate, maxDate, day)) {
-      state = 'disabled';
-    } else if (!dateutils.sameMonth(day, this.state.currentMonth)) {
-      state = 'disabled';
-    }
-
-    return state;
-  }
-
   swipeProps = {onSwipe: (direction, state) => this.onSwipe(direction, state)};
 
   onSwipe = gestureName => {
@@ -210,7 +188,7 @@ class Calendar extends Component {
         <Day
           {...dayProps}
           day={day}
-          state={this.getState(day)}
+          state={getState(day, this.state.currentMonth, this.props)}
           marking={markedDates?.[toMarkingFormat(day)]}
           onPress={this.pressDay}
           onLongPress={this.longPressDay}

--- a/src/dateutils.js
+++ b/src/dateutils.js
@@ -1,6 +1,7 @@
 const XDate = require('xdate');
 import {parseDate} from './interface';
 
+
 function sameMonth(a, b) {
   return (
     a instanceof XDate && b instanceof XDate && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth()
@@ -20,6 +21,10 @@ function sameDate(a, b) {
 function sameWeek(d1, d2, firstDayOfWeek) {
   const weekDates = getWeekDates(d1, firstDayOfWeek, 'yyyy-MM-dd');
   return weekDates?.includes(d2);
+}
+
+function isToday(day) {
+  return sameDate(XDate(day), XDate.today());
 }
 
 function isGTE(a, b) {
@@ -146,6 +151,7 @@ module.exports = {
   month,
   page,
   fromTo,
+  isToday,
   isLTE,
   isGTE,
   isDateNotInTheRange,

--- a/src/day-state-manager.js
+++ b/src/day-state-manager.js
@@ -1,0 +1,29 @@
+import {isToday, isDateNotInTheRange, sameMonth} from './dateutils';
+import {parseDate, toMarkingFormat} from './interface';
+
+
+function getState(day, current, props) {
+  const {minDate, maxDate, disabledByDefault, context} = props;
+  const _minDate = parseDate(minDate);
+  const _maxDate = parseDate(maxDate);
+  let state = '';
+  
+  if (context?.date === toMarkingFormat(day)) {
+    state = 'selected';
+  } else if (isToday(day)) {
+    state = 'today';
+  }
+  if (disabledByDefault) {
+    state = 'disabled';
+  } else if (isDateNotInTheRange(_minDate, _maxDate, day)) {
+    state = 'disabled';
+  } else if (!sameMonth(day, current)) {
+    state = 'disabled';
+  }
+
+  return state;
+}
+
+module.exports = {
+  getState
+};

--- a/src/expandableCalendar/agendaList.js
+++ b/src/expandableCalendar/agendaList.js
@@ -162,7 +162,7 @@ class AgendaList extends Component {
 
     if (markToday) {
       const todayString = XDate.locales[XDate.defaultLocale].today || commons.todayString;
-      const isToday = dateutils.sameDate(XDate(), XDate(title));
+      const isToday = dateutils.isToday(XDate(title));
       sectionTitle = isToday ? `${todayString}, ${sectionTitle}` : sectionTitle;
     }
 

--- a/src/expandableCalendar/calendarProvider.js
+++ b/src/expandableCalendar/calendarProvider.js
@@ -1,13 +1,15 @@
 import _ from 'lodash';
-import React, {Component} from 'react';
-import {StyleSheet, Animated, TouchableOpacity, View} from 'react-native';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
+import React, {Component} from 'react';
+import {StyleSheet, Animated, TouchableOpacity, View} from 'react-native';
+
 import dateutils from '../dateutils';
-import {xdateToData} from '../interface';
+import {xdateToData, toMarkingFormat} from '../interface';
 import styleConstructor from './style';
 import CalendarContext from './calendarContext';
+
 
 const commons = require('./commons');
 const UPDATE_SOURCES = commons.UPDATE_SOURCES;
@@ -44,8 +46,8 @@ class CalendarProvider extends Component {
     this.style = styleConstructor(props.theme);
 
     this.state = {
-      prevDate: this.props.date || XDate().toString('yyyy-MM-dd'),
-      date: this.props.date || XDate().toString('yyyy-MM-dd'),
+      prevDate: this.props.date || toMarkingFormat(XDate()),
+      date: this.props.date || toMarkingFormat(XDate()),
       updateSource: UPDATE_SOURCES.CALENDAR_INIT,
       buttonY: new Animated.Value(-props.todayBottomMargin || -TOP_POSITION),
       buttonIcon: this.getButtonIcon(props.date),
@@ -121,7 +123,7 @@ class CalendarProvider extends Component {
 
   animateTodayButton(date) {
     if (this.props.showTodayButton) {
-      const today = XDate().toString('yyyy-MM-dd');
+      const today = toMarkingFormat(XDate());
       const isToday = today === date;
 
       Animated.spring(this.state.buttonY, {
@@ -145,7 +147,7 @@ class CalendarProvider extends Component {
   }
 
   onTodayPress = () => {
-    const today = XDate().toString('yyyy-MM-dd');
+    const today = toMarkingFormat(XDate());
     this.setDate(today, UPDATE_SOURCES.TODAY_PRESS);
   };
 

--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -91,6 +91,7 @@ class ExpandableCalendar extends Component {
     this._wrapperStyles = {style: {height: startHeight}};
     this._headerStyles = {style: {top: props.initialPosition === POSITIONS.CLOSED ? 0 : -HEADER_HEIGHT}};
     this._weekCalendarStyles = {style: {}};
+
     this.wrapper = undefined;
     this.calendar = undefined;
     this.visibleMonth = this.getMonth(this.props.context.date);
@@ -209,22 +210,6 @@ class ExpandableCalendar extends Component {
   getNumberOfWeeksInMonth(month) {
     const days = dateutils.page(month, this.props.firstDay);
     return days.length / 7;
-  }
-
-  // TODO: this logic repeat itself in WeekCalendar - consider moving to a presenter
-  getMarkedDates() {
-    const {context, markedDates} = this.props;
-
-    if (markedDates) {
-      const marked = _.cloneDeep(markedDates);
-      if (marked[context.date]) {
-        marked[context.date].selected = true;
-      } else {
-        marked[context.date] = {selected: true};
-      }
-      return marked;
-    }
-    return {[context.date]: {selected: true}};
   }
 
   shouldHideArrows() {
@@ -440,9 +425,8 @@ class ExpandableCalendar extends Component {
 
   renderWeekCalendar() {
     const {position} = this.state;
-    const {disableWeekScroll, markedDates: propsMarkedDates} = this.props;
+    const {disableWeekScroll, markedDates} = this.props;
     const WeekComponent = disableWeekScroll ? Week : WeekCalendar;
-    const markedDates = disableWeekScroll ? this.getMarkedDates() : propsMarkedDates;
 
     return (
       <Animated.View
@@ -502,7 +486,6 @@ class ExpandableCalendar extends Component {
             {...others}
             theme={themeObject}
             onDayPress={this.onDayPress}
-            markedDates={this.getMarkedDates()}
             hideExtraDays
             renderArrow={this.renderArrow}
           />
@@ -525,7 +508,6 @@ class ExpandableCalendar extends Component {
               onVisibleMonthsChange={this.onVisibleMonthsChange}
               pagingEnabled
               scrollEnabled={isOpen}
-              markedDates={this.getMarkedDates()}
               hideArrows={this.shouldHideArrows()}
               onPressArrowLeft={this.onPressArrowLeft}
               onPressArrowRight={this.onPressArrowRight}

--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -425,7 +425,7 @@ class ExpandableCalendar extends Component {
 
   renderWeekCalendar() {
     const {position} = this.state;
-    const {disableWeekScroll, markedDates} = this.props;
+    const {disableWeekScroll} = this.props;
     const WeekComponent = disableWeekScroll ? Week : WeekCalendar;
 
     return (
@@ -438,7 +438,6 @@ class ExpandableCalendar extends Component {
           {...this.props}
           current={this.props.context.date}
           onDayPress={this.onDayPress}
-          markedDates={markedDates} // for Week component
           style={this.props.calendarStyle}
           allowShadow={false}
           hideDayNames={true}

--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -147,7 +147,7 @@ class ExpandableCalendar extends Component {
   };
 
   updateNativeStyles() {
-    this.wrapper && this.wrapper.setNativeProps(this._wrapperStyles);
+    this.wrapper?.setNativeProps(this._wrapperStyles);
     if (!this.props.horizontal) {
       this.header && this.header.setNativeProps(this._headerStyles);
     } else {
@@ -382,20 +382,18 @@ class ExpandableCalendar extends Component {
 
   /** Renders */
   getWeekDaysStyle = memoize((calendarStyle) => {
-    return {
-      paddingLeft: calendarStyle?.paddingLeft + 6 || DAY_NAMES_PADDING,
-      paddingRight: calendarStyle?.paddingRight + 6 || DAY_NAMES_PADDING
-    };
+    return [
+      this.style.weekDayNames,
+      {
+        paddingLeft: calendarStyle?.paddingLeft + 6 || DAY_NAMES_PADDING,
+        paddingRight: calendarStyle?.paddingRight + 6 || DAY_NAMES_PADDING
+      }
+    ];
   });
 
   renderWeekDaysNames = memoize((weekDaysNames, calendarStyle) => {
     return (
-      <View
-        style={[
-          this.style.weekDayNames,
-          this.getWeekDaysStyle(calendarStyle)
-        ]}
-      >
+      <View style={this.getWeekDaysStyle(calendarStyle)}>
         {weekDaysNames.map((day, index) => (
           <Text allowFontScaling={false} key={day + index} style={this.style.weekday} numberOfLines={1}>
             {day}
@@ -490,9 +488,7 @@ class ExpandableCalendar extends Component {
           />
         ) : (
           <Animated.View
-            ref={e => {
-              this.wrapper = e;
-            }}
+            ref={e => this.wrapper = e}
             style={{height: deltaY}}
             {...this.panResponder.panHandlers}
           >
@@ -501,7 +497,7 @@ class ExpandableCalendar extends Component {
               horizontal={horizontal}
               {...others}
               theme={themeObject}
-              ref={r => (this.calendar = r)}
+              ref={r => this.calendar = r}
               current={this.initialDate}
               onDayPress={this.onDayPress}
               onVisibleMonthsChange={this.onVisibleMonthsChange}

--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -396,16 +396,19 @@ class ExpandableCalendar extends Component {
   };
 
   /** Renders */
+  getWeekDaysStyle = memoize((calendarStyle) => {
+    return {
+      paddingLeft: calendarStyle?.paddingLeft + 6 || DAY_NAMES_PADDING,
+      paddingRight: calendarStyle?.paddingRight + 6 || DAY_NAMES_PADDING
+    };
+  });
 
-  renderWeekDaysNames = memoize((weekDaysNames) => {
+  renderWeekDaysNames = memoize((weekDaysNames, calendarStyle) => {
     return (
       <View
         style={[
           this.style.weekDayNames,
-          {
-            paddingLeft: (this.props.calendarStyle?.paddingLeft + 6) || DAY_NAMES_PADDING,
-            paddingRight: (this.props.calendarStyle?.paddingRight + 6) || DAY_NAMES_PADDING
-          }
+          this.getWeekDaysStyle(calendarStyle)
         ]}
       >
         {weekDaysNames.map((day, index) => (
@@ -430,7 +433,7 @@ class ExpandableCalendar extends Component {
         <Text allowFontScaling={false} style={this.style.headerTitle}>
           {monthYear}
         </Text>
-        {this.renderWeekDaysNames(weekDaysNames)}
+        {this.renderWeekDaysNames(weekDaysNames, this.props.calendarStyle)}
       </Animated.View>
     );
   }

--- a/src/expandableCalendar/week.js
+++ b/src/expandableCalendar/week.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import XDate from 'xdate';
 
 import React, {PureComponent} from 'react';
 import {View} from 'react-native';
@@ -12,7 +11,6 @@ import Calendar from '../calendar';
 import Day from '../calendar/day/index';
 // import BasicDay from '../calendar/day/basic';
 
-const EmptyArray = [];
 
 class Week extends PureComponent {
   static displayName = 'IGNORE';

--- a/src/expandableCalendar/week.js
+++ b/src/expandableCalendar/week.js
@@ -5,6 +5,7 @@ import {View} from 'react-native';
 
 import dateutils from '../dateutils';
 import {parseDate, toMarkingFormat} from '../interface';
+import {getState} from '../day-state-manager';
 import {extractComponentProps} from '../component-updater';
 import styleConstructor from './style';
 import Calendar from '../calendar';
@@ -31,28 +32,6 @@ class Week extends PureComponent {
     return dateutils.getWeekDates(date, this.props.firstDay);
   }
 
-  getState(day) {
-    const {current, disabledByDefault, context} = this.props;
-    const minDate = parseDate(this.props.minDate);
-    const maxDate = parseDate(this.props.maxDate);
-    let state = '';
-
-    if (context?.date === toMarkingFormat(day)) {
-      state = 'selected';
-    } else if (dateutils.isToday(day)) {
-      state = 'today';
-    }
-    if (disabledByDefault) {
-      state = 'disabled';
-    } else if (dateutils.isDateNotInTheRange(minDate, maxDate, day)) {
-      state = 'disabled';
-    } else if (!dateutils.sameMonth(day, parseDate(current))) {
-      state = 'disabled';
-    } 
-    
-    return state;
-  }
-
   // renderWeekNumber (weekNumber) {
   //   return <BasicDay key={`week-${weekNumber}`} theme={this.props.theme} marking={{disableTouchEvent: true}} state='disabled'>{weekNumber}</BasicDay>;
   // }
@@ -73,7 +52,7 @@ class Week extends PureComponent {
         <Day
           {...dayProps}
           day={day}
-          state={this.getState(day)}
+          state={getState(day, parseDate(current), this.props)}
           marking={markedDates?.[toMarkingFormat(day)]}
           onPress={this.props.onDayPress}
           onLongPress={this.props.onDayPress}

--- a/src/expandableCalendar/week.js
+++ b/src/expandableCalendar/week.js
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
+
 import React, {PureComponent} from 'react';
 import {View} from 'react-native';
+
 import dateutils from '../dateutils';
-import {parseDate} from '../interface';
+import {parseDate, toMarkingFormat} from '../interface';
 import {extractComponentProps} from '../component-updater';
 import styleConstructor from './style';
 import Calendar from '../calendar';
@@ -31,20 +33,6 @@ class Week extends PureComponent {
     return dateutils.getWeekDates(date, this.props.firstDay);
   }
 
-  getDateMarking(day) {
-    const {markedDates} = this.props;
-    if (!markedDates) {
-      return false;
-    }
-
-    const dates = markedDates[day.toString('yyyy-MM-dd')] || EmptyArray;
-    if (dates.length || dates) {
-      return dates;
-    } else {
-      return false;
-    }
-  }
-
   getState(day) {
     const {current, disabledByDefault} = this.props;
     const minDate = parseDate(this.props.minDate);
@@ -57,18 +45,18 @@ class Week extends PureComponent {
       state = 'disabled';
     } else if (!dateutils.sameMonth(day, parseDate(current))) {
       state = 'disabled';
-    } else if (dateutils.sameDate(day, XDate())) {
+    } else if (dateutils.isToday(day)) {
       state = 'today';
     }
     return state;
   }
 
   // renderWeekNumber (weekNumber) {
-  //   return <BasicDay key={`week-${weekNumber}`} theme={this.props.theme} marking={{disableTouchEvent: true}} state='disabled'>{weekNumber}</Day>;
+  //   return <BasicDay key={`week-${weekNumber}`} theme={this.props.theme} marking={{disableTouchEvent: true}} state='disabled'>{weekNumber}</BasicDay>;
   // }
 
   renderDay(day, id) {
-    const {current, hideExtraDays} = this.props;
+    const {current, hideExtraDays, markedDates} = this.props;
     const dayProps = extractComponentProps(Day, this.props);
 
     // hide extra days
@@ -84,7 +72,7 @@ class Week extends PureComponent {
           {...dayProps}
           day={day}
           state={this.getState(day)}
-          marking={this.getDateMarking(day)}
+          marking={markedDates && markedDates[toMarkingFormat(day)]}
           onPress={this.props.onDayPress}
           onLongPress={this.props.onDayPress}
         />

--- a/src/expandableCalendar/week.js
+++ b/src/expandableCalendar/week.js
@@ -39,6 +39,8 @@ class Week extends PureComponent {
 
     if (context?.date === toMarkingFormat(day)) {
       state = 'selected';
+    } else if (dateutils.isToday(day)) {
+      state = 'today';
     }
     if (disabledByDefault) {
       state = 'disabled';
@@ -46,9 +48,8 @@ class Week extends PureComponent {
       state = 'disabled';
     } else if (!dateutils.sameMonth(day, parseDate(current))) {
       state = 'disabled';
-    } else if (dateutils.isToday(day)) {
-      state = 'today';
-    }
+    } 
+    
     return state;
   }
 

--- a/src/expandableCalendar/week.js
+++ b/src/expandableCalendar/week.js
@@ -32,11 +32,14 @@ class Week extends PureComponent {
   }
 
   getState(day) {
-    const {current, disabledByDefault} = this.props;
+    const {current, disabledByDefault, context} = this.props;
     const minDate = parseDate(this.props.minDate);
     const maxDate = parseDate(this.props.maxDate);
     let state = '';
 
+    if (context?.date === toMarkingFormat(day)) {
+      state = 'selected';
+    }
     if (disabledByDefault) {
       state = 'disabled';
     } else if (dateutils.isDateNotInTheRange(minDate, maxDate, day)) {

--- a/src/expandableCalendar/week.js
+++ b/src/expandableCalendar/week.js
@@ -74,7 +74,7 @@ class Week extends PureComponent {
           {...dayProps}
           day={day}
           state={this.getState(day)}
-          marking={markedDates && markedDates[toMarkingFormat(day)]}
+          marking={markedDates?.[toMarkingFormat(day)]}
           onPress={this.props.onDayPress}
           onLongPress={this.props.onDayPress}
         />

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -174,6 +174,10 @@ class WeekCalendar extends Component {
   renderItem = ({item}) => {
     const {style, onDayPress, markedDates, ...others} = extractComponentProps(Week, this.props);
 
+    const {context, firstDay} = this.props;
+    const isCurrentWeek = sameWeek(item, context.date, firstDay);
+    const currentContext = isCurrentWeek ? context : undefined;
+
     return (
       <Week
         {...others}
@@ -182,7 +186,7 @@ class WeekCalendar extends Component {
         style={this.getWeekStyle(this.containerWidth, style)}
         markedDates={markedDates}
         onDayPress={onDayPress || this.onDayPress}
-        context={this.props.context}
+        context={currentContext}
       />
     );
   };

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -98,21 +98,6 @@ class WeekCalendar extends Component {
     return toMarkingFormat(newDate);
   }
 
-  getMarkedDates = () => {
-    const {context, markedDates} = this.props;
-    if (markedDates) {
-      const marked = _.cloneDeep(markedDates);
-
-      if (marked[context.date]) {
-        marked[context.date].selected = true;
-      } else {
-        marked[context.date] = {selected: true};
-      }
-      return marked;
-    }
-    return {[context.date]: {selected: true}};
-  };
-
   getWeekStyle = memoize((width, style) => {
     return [{width}, style];
   });
@@ -188,8 +173,6 @@ class WeekCalendar extends Component {
 
   renderItem = ({item}) => {
     const {style, onDayPress, markedDates, ...others} = extractComponentProps(Week, this.props);
-    const isCurrentWeek = sameWeek(item, this.props.context.date, others.firstDay);
-    const fixedMarkedDates = isCurrentWeek ? this.getMarkedDates() : markedDates;
 
     return (
       <Week
@@ -197,8 +180,9 @@ class WeekCalendar extends Component {
         key={item}
         current={item}
         style={this.getWeekStyle(this.containerWidth, style)}
-        markedDates={fixedMarkedDates}
+        markedDates={markedDates}
         onDayPress={onDayPress || this.onDayPress}
+        context={this.props.context}
       />
     );
   };

--- a/src/expandableCalendar/weekCalendar.js
+++ b/src/expandableCalendar/weekCalendar.js
@@ -1,17 +1,20 @@
 import _ from 'lodash';
+import memoize from 'memoize-one';
+import PropTypes from 'prop-types';
+import XDate from 'xdate';
+
 import React, {Component} from 'react';
 import {FlatList, View, Text} from 'react-native';
 import {Map} from 'immutable';
-import PropTypes from 'prop-types';
-import XDate from 'xdate';
-import memoize from 'memoize-one';
 
+import {extractComponentProps} from '../component-updater';
+import {weekDayNames, sameWeek} from '../dateutils';
+import {toMarkingFormat} from '../interface';
 import styleConstructor from './style';
+import asCalendarConsumer from './asCalendarConsumer';
 import CalendarList from '../calendar-list';
 import Week from '../expandableCalendar/week';
-import asCalendarConsumer from './asCalendarConsumer';
-import {weekDayNames, sameWeek} from '../dateutils';
-import {extractComponentProps} from '../component-updater';
+
 
 const commons = require('./commons');
 const UPDATE_SOURCES = commons.UPDATE_SOURCES;
@@ -92,7 +95,7 @@ class WeekCalendar extends Component {
     // leave the current date in the visible week as is
     const dd = weekIndex === 0 ? d : d.addDays(firstDay - dayOfTheWeek);
     const newDate = dd.addWeeks(weekIndex);
-    return newDate.toString('yyyy-MM-dd');
+    return toMarkingFormat(newDate);
   }
 
   getMarkedDates = () => {
@@ -210,15 +213,32 @@ class WeekCalendar extends Component {
 
   keyExtractor = (item, index) => index.toString();
 
+  renderWeekDaysNames = memoize((weekDaysNames) => {
+    return weekDaysNames.map((day, idx) => (
+      <Text
+        allowFontScaling={false}
+        key={idx}
+        style={this.style.dayHeader}
+        numberOfLines={1}
+        accessibilityLabel={''}
+        // accessible={false} // not working
+        // importantForAccessibility='no'
+      >
+        {day}
+      </Text>
+    ));
+  });
+
   render() {
     const {allowShadow, firstDay, hideDayNames, current, context} = this.props;
     const {items} = this.state;
-    let weekDaysNames = weekDayNames(firstDay);
+    const weekDaysNames = weekDayNames(firstDay);
     const extraData = Map({
       current,
       date: context.date,
       firstDay
     });
+    
     return (
       <View
         testID={this.props.testID}
@@ -227,19 +247,7 @@ class WeekCalendar extends Component {
         {!hideDayNames && (
           <View style={[this.style.week, this.style.weekCalendar]}>
             {/* {this.props.weekNumbers && <Text allowFontScaling={false} style={this.style.dayHeader}></Text>} */}
-            {weekDaysNames.map((day, idx) => (
-              <Text
-                allowFontScaling={false}
-                key={idx}
-                style={this.style.dayHeader}
-                numberOfLines={1}
-                accessibilityLabel={''}
-                // accessible={false} // not working
-                // importantForAccessibility='no'
-              >
-                {day}
-              </Text>
-            ))}
+            {this.renderWeekDaysNames(weekDaysNames)}
           </View>
         )}
         <FlatList

--- a/src/interface.js
+++ b/src/interface.js
@@ -7,12 +7,12 @@ function padNumber(n) {
   return n;
 }
 
-function xdateToData(xdate) {
-  const dateString = xdate.toString('yyyy-MM-dd');
+function xdateToData(d) {
+  const dateString = toMarkingFormat(d);
   return {
-    year: xdate.getFullYear(),
-    month: xdate.getMonth() + 1,
-    day: xdate.getDate(),
+    year: d.getFullYear(),
+    month: d.getMonth() + 1,
+    day: d.getDate(),
     timestamp: XDate(dateString, true).getTime(),
     dateString: dateString
   };
@@ -24,7 +24,7 @@ function parseDate(d) {
   } else if (d.timestamp) { // conventional data timestamp
     return XDate(d.timestamp, true);
   } else if (d instanceof XDate) { // xdate
-    return XDate(d.toString('yyyy-MM-dd'), true);
+    return XDate(toMarkingFormat(d), true);
   } else if (d.getTime) { // javascript date
     const dateString = d.getFullYear() + '-' + padNumber((d.getMonth() + 1)) + '-' + padNumber(d.getDate());
     return XDate(dateString, true);
@@ -36,8 +36,13 @@ function parseDate(d) {
   }
 }
 
+function toMarkingFormat(d) {
+  return d instanceof XDate && d.toString('yyyy-MM-dd');
+}
+
 module.exports = {
   xdateToData,
-  parseDate
+  parseDate,
+  toMarkingFormat
 };
 

--- a/src/interface.spec.js
+++ b/src/interface.spec.js
@@ -70,7 +70,7 @@ describe('calendar interface', () => {
     it('should convert date to yyyy-MM-dd format string', () => {
       const time = 1479772800000;
       const testDate = XDate(time);
-      expect(iface.toMarkingFormat(testDate)).toEqual('2016-11-22');
+      expect(iface.toMarkingFormat(testDate)).toEqual(testDate.toString('yyyy-MM-dd'));
     });
   });
 });

--- a/src/interface.spec.js
+++ b/src/interface.spec.js
@@ -65,4 +65,12 @@ describe('calendar interface', () => {
       });
     });
   });
+
+  describe('toMarkingFormat', () => {
+    it('should convert date to yyyy-MM-dd format string', () => {
+      const time = 1479772800000;
+      const testDate = XDate(time);
+      expect(iface.toMarkingFormat(testDate)).toEqual('2016-11-22');
+    });
+  });
 });


### PR DESCRIPTION
The idea of this PR is to reduce renders by memoizing render calls and object creation and reducing new object creation to avoid new refs.
I also added functionality to the demo screens, move toString() calls to `toMarkingFormat` in the `interface` file, and is today checks to `isToday` in `dateutils` file.
Small bugs fix in Period and Basic days 'marking'.
ExpandableCalendar and WeekCalendar - changing the way the selected date is marked. Instead of using 'markedDates' now using 'state' and 'context'. 