### PR TITLE
Fix timeline event height and top calculations

### DIFF
--- a/src/timeline/Packer.js
+++ b/src/timeline/Packer.js
@@ -7,10 +7,10 @@ function buildEvent(column, left, width, dayStart) {
   const startTime = XDate(column.start);
   const endTime = column.end ? XDate(column.end) : XDate(startTime).addHours(1);
 
-  const dayStartTime = XDate(dayStart).clearTime();
+  const dayStartTime = XDate(startTime).clearTime();
 
-  column.top = startTime.diffHours(dayStartTime) * offset;
-  column.height = endTime.diffHours(startTime) * offset;
+  column.top = (dayStartTime.diffHours(startTime) - dayStart) * offset;
+  column.height = startTime.diffHours(endTime) * offset;
   column.width = width;
   column.left = left;
   return column;


### PR DESCRIPTION
I've met a problem where my events did not appear on the timeline calendar. I've dug into the code and found the `buildEvent` function which calculates event height and top in the wrong way and always returns negative values.

![Screenshot 2021-05-10 at 12 43 15](https://user-images.githubusercontent.com/7254847/117640168-6a7cc900-b18d-11eb-9551-973d49c5872d.png)
