### PR TITLE
AgendaList - omit 'context' from props passed to SectionList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -641,7 +641,13 @@
 ### Added
 - CalendarList - 'animateScroll' prop to allow animation on ato list scroll (i.e. on arrow press).
 
-## [1.1260.0] - 2021-5-20
+
+## [1.1260.0] - 2021-5-5
+
+### Added
+- Export CalendarContext.
+
+## [1.1261.0] - 2021-5-20
 
 ### Added
 - CalendarHeader - individual day header style overrides (PR #1465).
@@ -650,7 +656,6 @@
 
 ### Changed
 - Update gradle version to 6.3 (PR #1479).
-- Moving inline styles to StyleSheet.
 - CalendarList example screen - adding functionality.
 
 ### Fix
@@ -659,8 +664,14 @@
 
 ### Performance
 - Remove inline style.
-- Remove Remove object creation on passed props.
+- Remove object creation on passed props.
 - Improve examples.
 - Memoize methods and styles.
-- Additional tools - toMarkingFormat, isToday.
+- Additional tools - 'toMarkingFormat', 'isToday'.
 - ExpandableCalendar - setting selected date using 'state' prop instead of 'markedDates'.
+
+## [1.1262.0] - 2021-5-23
+
+### Changed
+- AgendaList demo - replace alerts with console.
+- AgendaList - Remove arrow function from `onScrollToIndexFailed` and omit `context` passed to SectionList.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,5 +673,4 @@
 ## [1.1262.0] - 2021-5-23
 
 ### Changed
-- AgendaList demo - replace alerts with console.
 - AgendaList - Remove arrow function from `onScrollToIndexFailed` and omit `context` passed to SectionList.

--- a/example/src/screens/expandableCalendar.js
+++ b/example/src/screens/expandableCalendar.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, {Component} from 'react';
-import {Platform, Alert, StyleSheet, View, Text, TouchableOpacity, Button} from 'react-native';
+import {Platform, StyleSheet, View, Text, TouchableOpacity, Button} from 'react-native';
 import {ExpandableCalendar, AgendaList, CalendarProvider, WeekCalendar} from 'react-native-calendars';
 
 const testIDs = require('../testIDs');
@@ -145,11 +145,11 @@ export default class ExpandableCalendarScreen extends Component {
   };
 
   buttonPressed() {
-    Alert.alert('show more');
+    console.warn('show more');
   }
 
   itemPressed(id) {
-    Alert.alert(id);
+    console.warn(id);
   }
 
   renderEmptyItem() {
@@ -214,7 +214,6 @@ export default class ExpandableCalendarScreen extends Component {
         )}
         <AgendaList
           sections={ITEMS}
-          extraData={this.state}
           renderItem={this.renderItem}
           // sectionStyle={styles.section}
         />

--- a/example/src/screens/expandableCalendar.js
+++ b/example/src/screens/expandableCalendar.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, {Component} from 'react';
-import {Platform, StyleSheet, View, Text, TouchableOpacity, Button} from 'react-native';
+import {Platform, StyleSheet, Alert, View, Text, TouchableOpacity, Button} from 'react-native';
 import {ExpandableCalendar, AgendaList, CalendarProvider, WeekCalendar} from 'react-native-calendars';
 
 const testIDs = require('../testIDs');
@@ -145,11 +145,11 @@ export default class ExpandableCalendarScreen extends Component {
   };
 
   buttonPressed() {
-    console.warn('show more');
+    Alert.alert('show more');
   }
 
   itemPressed(id) {
-    console.warn(id);
+    Alert.alert(id);
   }
 
   renderEmptyItem() {

--- a/src/expandableCalendar/agendaList.js
+++ b/src/expandableCalendar/agendaList.js
@@ -90,6 +90,32 @@ class AgendaList extends Component {
     }
   }
 
+  getSectionTitle(title) {
+    if (!title) return;
+
+    const {dayFormatter, dayFormat, useMoment, markToday} = this.props;
+    let sectionTitle = title;
+
+    if (dayFormatter) {
+      sectionTitle = dayFormatter(title);
+    } else if (dayFormat) {
+      if (useMoment) {
+        const moment = getMoment();
+        sectionTitle = moment(title).format(dayFormat);
+      } else {
+        sectionTitle = XDate(title).toString(dayFormat);
+      }
+    }
+
+    if (markToday) {
+      const todayString = XDate.locales[XDate.defaultLocale].today || commons.todayString;
+      const isToday = dateutils.isToday(XDate(title));
+      sectionTitle = isToday ? `${todayString}, ${sectionTitle}` : sectionTitle;
+    }
+
+    return sectionTitle;
+  }
+
   scrollToSection(sectionIndex) {
     if (this.list.current && sectionIndex !== undefined) {
       this.sectionScroll = true; // to avoid setDate() in onViewableItemsChanged
@@ -136,39 +162,24 @@ class AgendaList extends Component {
     _.invoke(this.props, 'onMomentumScrollEnd', event);
   };
 
+  onScrollToIndexFailed = (info) => {
+    console.warn('onScrollToIndexFailed info: ', info);
+  }
+
   onHeaderLayout = ({nativeEvent}) => {
     this.sectionHeight = nativeEvent.layout.height;
   };
 
   renderSectionHeader = ({section: {title}}) => {
-    const {renderSectionHeader, dayFormatter, dayFormat, useMoment, markToday, sectionStyle} = this.props;
+    const {renderSectionHeader, sectionStyle} = this.props;
 
     if (renderSectionHeader) {
       return renderSectionHeader(title);
     }
 
-    let sectionTitle = title;
-
-    if (dayFormatter) {
-      sectionTitle = dayFormatter(title);
-    } else if (dayFormat) {
-      if (useMoment) {
-        const moment = getMoment();
-        sectionTitle = moment(title).format(dayFormat);
-      } else {
-        sectionTitle = XDate(title).toString(dayFormat);
-      }
-    }
-
-    if (markToday) {
-      const todayString = XDate.locales[XDate.defaultLocale].today || commons.todayString;
-      const isToday = dateutils.isToday(XDate(title));
-      sectionTitle = isToday ? `${todayString}, ${sectionTitle}` : sectionTitle;
-    }
-
     return (
       <Text allowFontScaling={false} style={[this.style.sectionText, sectionStyle]} onLayout={this.onHeaderLayout}>
-        {sectionTitle}
+        {this.getSectionTitle(title)}
       </Text>
     );
   };
@@ -179,9 +190,11 @@ class AgendaList extends Component {
   };
 
   render() {
+    const props = _.omit(this.props, 'context');
+
     return (
       <SectionList
-        {...this.props}
+        {...props}
         ref={this.list}
         keyExtractor={this.keyExtractor}
         showsVerticalScrollIndicator={false}
@@ -191,9 +204,7 @@ class AgendaList extends Component {
         onScroll={this.onScroll}
         onMomentumScrollBegin={this.onMomentumScrollBegin}
         onMomentumScrollEnd={this.onMomentumScrollEnd}
-        onScrollToIndexFailed={info => {
-          console.warn('onScrollToIndexFailed info: ', info);
-        }}
+        onScrollToIndexFailed={this.onScrollToIndexFailed}
         // getItemLayout={this.getItemLayout} // onViewableItemsChanged is not updated when list scrolls!!!
       />
     );


### PR DESCRIPTION
1) Omit 'context' from props passed to SectionList.
2) Remove arrow function from `onScrollToIndexFailed`.
3) Demo - replace Alerts with console.