### PR TITLE
feat: Do not disable dates on different months

### DIFF
--- a/src/day-state-manager.js
+++ b/src/day-state-manager.js
@@ -1,4 +1,4 @@
-import {isToday, isDateNotInTheRange, sameMonth} from './dateutils';
+import {isToday, isDateNotInTheRange} from './dateutils';
 import {parseDate, toMarkingFormat} from './interface';
 
 function getState(day, current, props) {
@@ -15,8 +15,6 @@ function getState(day, current, props) {
   if (disabledByDefault) {
     state = 'disabled';
   } else if (isDateNotInTheRange(_minDate, _maxDate, day)) {
-    state = 'disabled';
-  } else if (!sameMonth(day, current)) {
     state = 'disabled';
   }
 


### PR DESCRIPTION
Whether or not dates should be disabled should be decided by marked dates, showing otherwise available dates in the next or previous month as disabled is not really a good user experience, because they're not disabled, they're just days of a different month.