### PR TITLE
fix: error 'cannot read month of undefined' when scrolling in the AgendaList inside of CalendarProvider

### DIFF
--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -235,12 +235,14 @@ class CalendarList extends Component {
       }
     }
 
-    _.invoke(this.props, 'onVisibleMonthsChange', visibleMonths);
+    if (visibleMonths.length > 0) {
+      _.invoke(this.props, 'onVisibleMonthsChange', visibleMonths);
 
-    this.setState({
-      rows: newrows,
-      currentMonth: parseDate(visibleMonths[0])
-    });
+      this.setState({
+        rows: newrows,
+        currentMonth: parseDate(visibleMonths[0])
+      });
+    }
   };
 
   renderItem = ({item}) => {


### PR DESCRIPTION
**CASE TO REPRODUCE**:
Wrapping `ExpandableCalendar` and `AgendaList` inside of `CalendarProvider` ( as mentioned in the usage example of `ExpandableCalendar` ) then adding items `AgendaList` and scrolling up and down multiple times
**ERROR**: 
I get the an error saying `cannot read month of undefined` 
**INSPECTION**:
when debugging I saw that when invoking `onVisibleMonthsChange` inside of dir `src\calendar-list\index.js` we get at first `undefined` as value then after some milliseconds we get the desired value
**SOLUTION**: 
wrapping the setState and the invoked function together inside of an `if` statement