### PR TITLE
Fix relesae script

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -5,7 +5,8 @@ const semver = require('semver');
 const exec = require('shell-utils').exec;
 
 const ONLY_ON_BRANCH = 'origin/release';
-const isSnapshotBuild = process.env.RELEASE_SNAPSHOT_VERSION;
+console.log('ethan - type of snapshot', typeof process.env.RELEASE_SNAPSHOT_VERSION);
+const isSnapshotBuild = process.env.RELEASE_SNAPSHOT_VERSION === 'true';
 const VERSION_TAG = isSnapshotBuild ? 'snapshot' : 'latest';
 const VERSION_INC = 'minor';
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -5,7 +5,6 @@ const semver = require('semver');
 const exec = require('shell-utils').exec;
 
 const ONLY_ON_BRANCH = 'origin/release';
-console.log('ethan - type of snapshot', typeof process.env.RELEASE_SNAPSHOT_VERSION);
 const isSnapshotBuild = process.env.RELEASE_SNAPSHOT_VERSION === 'true';
 const VERSION_TAG = isSnapshotBuild ? 'snapshot' : 'latest';
 const VERSION_INC = 'minor';


### PR DESCRIPTION
Fix release script. 
Apparently boolean env vars in jenkins are strings and not boolean. 
So both `'false'` and `'true'` are truthy