### PR TITLE
Fix build process of TS

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -256,3 +256,9 @@ demo/
 # eslint-rules/
 scripts/
 
+# Typescript
+# ignore the .ts files
+*.ts
+*.tsx
+# include the .d.ts files
+!*.d.ts 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "React Native Calendar Components",
   "scripts": {
     "build": "xcodebuild -project ios/CalendarsExample.xcodeproj build",
+    "build:ts": "tsc",
     "e2e": "node ./scripts/test-e2e.js --release",
     "test": "npm run lint && npm run unit && npm run e2e",
     "unit": "jest",

--- a/src/calendar/day/basic/index.tsx
+++ b/src/calendar/day/basic/index.tsx
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 
 import React, {Component, Fragment} from 'react';
 import {TouchableOpacity, Text, View} from 'react-native';
-
+// @ts-expect-error
 import {shouldUpdate} from '../../../component-updater';
 import styleConstructor from './style';
+// @ts-expect-error
 import Marking from '../marking';
 
 interface BasicDayProps {

--- a/src/calendar/day/basic/style.ts
+++ b/src/calendar/day/basic/style.ts
@@ -1,4 +1,5 @@
 import {StyleSheet, Platform} from 'react-native';
+// @ts-expect-error
 import * as defaultStyle from '../../../style';
 
 const STYLESHEET_ID = 'stylesheet.day.basic';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,16 +11,16 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noEmit": true,
+    "noEmit": false,
     "checkJs": false,
-    "allowJs": true,
+    "allowJs": false,
     // "emitDeclarationOnly": true,
     // "noImplicitAny": false
     "declaration": true,
-    "declarationDir": "./generatedTypes",
-    "baseUrl": ".",
+    "baseUrl": "src",
     "paths": {}
   },
-  "include": ["src/calendar/day/basic", "src/global.d.ts"],
-  "exclude": ["node_modules"]
+  // "include": ["src/calendar/day/basic", "src/global.d.ts"],
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "test"]
 }


### PR DESCRIPTION
Since the current published version of calendars include ts files it causes issues for dependent modules' tests. 
In order to fix it, I updated the build process (it similar now to what we have in uilib)

- I added a `build:ts` command for building typescript 
- The build generates `js/jsx` files out `ts/tsx` files and also add appropriate `d.ts` files (for files that were migrated)
- In `.npmignore` I ignore `ts/tsx` files so they won't be included in the published version of calendars lib
- In our Jenkins configuration I added the `build:ts` step - meaning that from now on if there are TS build issues the build will fail (which is good)
