### PR TITLE
change import to require - Cannot assign to read only property 'exports' of object '#<Object>'

### DIFF
--- a/src/dateutils.js
+++ b/src/dateutils.js
@@ -1,5 +1,5 @@
 const XDate = require('xdate');
-import {parseDate} from './interface';
+const {parseDate} = require('./interface');
 
 function sameMonth(a, b) {
   return (

--- a/src/day-state-manager.js
+++ b/src/day-state-manager.js
@@ -1,5 +1,5 @@
-import {isToday, isDateNotInTheRange, sameMonth} from './dateutils';
-import {parseDate, toMarkingFormat} from './interface';
+const {isToday, isDateNotInTheRange, sameMonth} = require('./dateutils');
+const {parseDate, toMarkingFormat} = require('./interface');
 
 function getState(day, current, props) {
   const {minDate, maxDate, disabledByDefault, context} = props;


### PR DESCRIPTION
Don't mix import and module.exports in the same file:
[https://github.com/webpack/webpack/issues/4039#issuecomment-419284940](https://github.com/webpack/webpack/issues/4039#issuecomment-419284940)

PR to resolve this error: `Cannot assign to read only property 'exports' of object '#<Object>'`