### PR TITLE
js types - for mapping

### DIFF
--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import XDate from 'xdate';
+import PropTypes from 'prop-types';
 
 import React, {Component} from 'react';
 import {FlatList, Platform, Dimensions, View} from 'react-native';
@@ -14,7 +15,7 @@ import {STATIC_HEADER} from '../testIDs';
 import styleConstructor from './style';
 
 // @ts-expect-error
-import {CalendarProps} from '../calendar';
+import Calendar, {CalendarProps} from '../calendar';
 import CalendarListItem from './item';
 // @ts-expect-error
 import CalendarHeader from '../calendar/header/index';
@@ -74,6 +75,42 @@ type CalendarListState = {
  */
 class CalendarList extends Component<CalendarListProps, CalendarListState> {
   static displayName = 'CalendarList';
+
+  static propTypes = {
+    ...Calendar.propTypes,
+    /** Max amount of months allowed to scroll to the past. Default = 50 */
+    pastScrollRange: PropTypes.number,
+    /** Max amount of months allowed to scroll to the future. Default = 50 */
+    futureScrollRange: PropTypes.number,
+    /** Used when calendar scroll is horizontal, default is device width, pagination should be disabled */
+    calendarWidth: PropTypes.number,
+    /** Dynamic calendar height */
+    calendarHeight: PropTypes.number,
+    /** Style for the List item (the calendar) */
+    calendarStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
+    /** Whether to use static header that will not scroll with the list (horizontal only) */
+    staticHeader: PropTypes.bool,
+    /** Enable or disable vertical / horizontal scroll indicator. Default = false */
+    showScrollIndicator: PropTypes.bool,
+    /** Whether to animate the auto month scroll */
+    animateScroll: PropTypes.bool,
+    /** Enable or disable scrolling of calendar list */
+    scrollEnabled: PropTypes.bool,
+    /** When true, the calendar list scrolls to top when the status bar is tapped. Default = true */
+    scrollsToTop: PropTypes.bool,
+    /** Enable or disable paging on scroll */
+    pagingEnabled: PropTypes.bool,
+    /** Whether the scroll is horizontal */
+    horizontal: PropTypes.bool,
+    /** Should Keyboard persist taps */
+    keyboardShouldPersistTaps: PropTypes.oneOf(['never', 'always', 'handled']),
+    /** A custom key extractor for the generated calendar months */
+    keyExtractor: PropTypes.func,
+    /** How far from the end to trigger the onEndReached callback */
+    onEndReachedThreshold: PropTypes.number,
+    /** Called once when the scroll position gets within onEndReachedThreshold */
+    onEndReached: PropTypes.func
+  };
 
   static defaultProps = {
     calendarWidth: width,

--- a/src/calendar-list/item.tsx
+++ b/src/calendar-list/item.tsx
@@ -1,6 +1,7 @@
 import memoize from 'memoize-one';
 import React, {Component} from 'react';
 import {Text, View} from 'react-native';
+import PropTypes from 'prop-types';
 
 // @ts-expect-error
 import {extractComponentProps} from '../component-updater';
@@ -24,6 +25,14 @@ type CalendarListItemState = {
 
 class CalendarListItem extends Component<CalendarListItemProps, CalendarListItemState> {
   static displayName = 'IGNORE';
+
+  static propTypes = {
+    ...Calendar.propTypes,
+    item: PropTypes.any,
+    calendarWidth: PropTypes.number,
+    calendarHeight: PropTypes.number,
+    horizontal: PropTypes.bool
+  };
 
   static defaultProps = {
     hideArrows: true,


### PR DESCRIPTION
Got back `prop-types` since it's in use for mapping for performance reasons.