### PR TITLE
make module tree shakable

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.22.0",
   "main": "src/index.js",
   "description": "React Native Calendar Components",
+  "sideEffects": false,
   "scripts": {
     "build": "xcodebuild -project ios/CalendarsExample.xcodeproj build",
     "build:ts": "tsc",


### PR DESCRIPTION
Webpack would include moment.js and other unnecessary files if they bundle the library. This is especially relevant for web builds.