### PR TITLE
ExpandableCalendar fix onDayPress not working

### DIFF
--- a/src/expandableCalendar/index.js
+++ b/src/expandableCalendar/index.js
@@ -352,6 +352,10 @@ class ExpandableCalendar extends Component {
         this.bounceToPosition(this.closedHeight);
       }
     }, 0);
+    
+    if (this.props.onDayPress) {
+      this.props.onDayPress(value);
+    }
   };
 
   onVisibleMonthsChange = value => {


### PR DESCRIPTION
fixes #1102 #1370

`onDayPress` is currently overriden so it is never called.
This fix calls `this.props.onDayPress` if present.