### PR TITLE
feat: Allow 2 themes over one calendar date element in custom marking

### DIFF
--- a/src/calendar/day/basic/index.tsx
+++ b/src/calendar/day/basic/index.tsx
@@ -145,6 +145,16 @@ export default class BasicDay extends Component<BasicDayProps> {
     return style;
   }
 
+  getOuterContainerStyle() {
+        const { customStyles } = this.marking;
+        const style = [];
+        if (this.isCustom() && customStyles && customStyles.outerContainer) {
+            style.push(customStyles.outerContainer);
+        }
+
+        return style;
+    }
+
   getTextStyle() {
     const {customStyles, selectedTextColor} = this.marking;
     const style = [this.style.text];
@@ -207,20 +217,23 @@ export default class BasicDay extends Component<BasicDayProps> {
   renderContainer() {
     const {activeOpacity} = this.marking;
 
+
     return (
-      <TouchableOpacity
-        testID={this.props.testID}
-        style={this.getContainerStyle()}
-        disabled={this.shouldDisableTouchEvent()}
-        activeOpacity={activeOpacity}
-        onPress={!this.shouldDisableTouchEvent() ? this.onPress : undefined}
-        onLongPress={!this.shouldDisableTouchEvent() ? this.onLongPress : undefined}
-        accessible
-        accessibilityRole={this.isDisabled() ? undefined : 'button'}
-        accessibilityLabel={this.props.accessibilityLabel}
-      >
-        {this.isMultiPeriod() ? this.renderText() : this.renderContent()}
-      </TouchableOpacity>
+      <View style={this.getOuterContainerStyle()}>
+        <TouchableOpacity
+          testID={this.props.testID}
+          style={this.getContainerStyle()}
+          disabled={this.shouldDisableTouchEvent()}
+          activeOpacity={activeOpacity}
+          onPress={!this.shouldDisableTouchEvent() ? this.onPress : undefined}
+          onLongPress={!this.shouldDisableTouchEvent() ? this.onLongPress : undefined}
+          accessible
+          accessibilityRole={this.isDisabled() ? undefined : 'button'}
+          accessibilityLabel={this.props.accessibilityLabel}
+        >
+          {this.isMultiPeriod() ? this.renderText() : this.renderContent()}
+        </TouchableOpacity>
+      </View>
     );
   }
 


### PR DESCRIPTION
**Marking Type** : Custom 

**Issue** : How to have a custom theme where we can have a period theme with a custom theme for selected date.

We wanted to be able to select a date in a period without losing the period theme. The period theme act here as a background.

![image](https://user-images.githubusercontent.com/63585162/127019931-f9083d69-b049-469e-bcde-90d6a16dd28d.png)


