### PR TITLE
Solution of TypeError: Cannot assign to read only property 'exports' of object '#<Object>' 

### DIFF
--- a/src/dateutils.js
+++ b/src/dateutils.js
@@ -142,7 +142,7 @@ function getWeekDates(date, firstDay, format) {
   }
 }
 
-module.exports = {
+export default {
   weekDayNames,
   sameMonth,
   sameWeek,
@@ -155,4 +155,4 @@ module.exports = {
   isGTE,
   isDateNotInTheRange,
   getWeekDates
-};
+}

--- a/src/day-state-manager.js
+++ b/src/day-state-manager.js
@@ -23,6 +23,6 @@ function getState(day, current, props) {
   return state;
 }
 
-module.exports = {
+export default  {
   getState
-};
+}


### PR DESCRIPTION
module.exports changed to export default