### PR TITLE
agendaList - remove onScrollToIndexFailed

### DIFF
--- a/src/expandableCalendar/agendaList.js
+++ b/src/expandableCalendar/agendaList.js
@@ -163,6 +163,12 @@ class AgendaList extends Component {
     _.invoke(this.props, 'onMomentumScrollEnd', event);
   };
 
+  onScrollToIndexFailed = info => {
+    if (this.props.onScrollToIndexFailed) {
+      this.props.onScrollToIndexFailed(info);
+    }
+  };
+
   onHeaderLayout = ({nativeEvent}) => {
     this.sectionHeight = nativeEvent.layout.height;
   };
@@ -201,6 +207,7 @@ class AgendaList extends Component {
         onScroll={this.onScroll}
         onMomentumScrollBegin={this.onMomentumScrollBegin}
         onMomentumScrollEnd={this.onMomentumScrollEnd}
+        onScrollToIndexFailed={this.onScrollToIndexFailed}
         // getItemLayout={this.getItemLayout} // onViewableItemsChanged is not updated when list scrolls!!!
       />
     );

--- a/src/expandableCalendar/agendaList.js
+++ b/src/expandableCalendar/agendaList.js
@@ -163,10 +163,6 @@ class AgendaList extends Component {
     _.invoke(this.props, 'onMomentumScrollEnd', event);
   };
 
-  onScrollToIndexFailed = info => {
-    console.warn('onScrollToIndexFailed info: ', info);
-  };
-
   onHeaderLayout = ({nativeEvent}) => {
     this.sectionHeight = nativeEvent.layout.height;
   };
@@ -205,7 +201,6 @@ class AgendaList extends Component {
         onScroll={this.onScroll}
         onMomentumScrollBegin={this.onMomentumScrollBegin}
         onMomentumScrollEnd={this.onMomentumScrollEnd}
-        onScrollToIndexFailed={this.onScrollToIndexFailed}
         // getItemLayout={this.getItemLayout} // onViewableItemsChanged is not updated when list scrolls!!!
       />
     );

--- a/src/expandableCalendar/agendaList.js
+++ b/src/expandableCalendar/agendaList.js
@@ -166,6 +166,8 @@ class AgendaList extends Component {
   onScrollToIndexFailed = info => {
     if (this.props.onScrollToIndexFailed) {
       this.props.onScrollToIndexFailed(info);
+    } else {
+      console.warn('onScrollToIndexFailed info: ', info);
     }
   };
 


### PR DESCRIPTION
Allow `onScrollToIndexFailed` to be passed via props.
We are facing the same issue as mentioned in https://github.com/wix/react-native-calendars/issues/962. This issue can be fixed by calling `scrollToIndex` (to the failed scroll index) inside the `onScrollToIndexFailed` method. Currently, there is no way to override this prop.