### PR TITLE
Fix README links for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,13 +344,13 @@ The loading indicator next to the month name will be displayed if `<Calendar/>` 
 
 #### Advanced styling
 
-If you want to have complete control over the calendar styles you can do it by overriding default `style.js` files. For example, if you want to override `<CalendarHeader/>` style first you have to find stylesheet id for this file:
+If you want to have complete control over the calendar styles you can do it by overriding default `style.ts` files. For example, if you want to override `<CalendarHeader/>` style first you have to find stylesheet id for this file:
 
-https://github.com/wix/react-native-calendars/blob/master/src/calendar/header/style.js#L4
+https://github.com/wix/react-native-calendars/blob/master/src/calendar/header/style.ts#L60
 
 In this case it is `stylesheet.calendar.header`. Next you can add overriding stylesheet to your theme with this id.
 
-https://github.com/wix/react-native-calendars/blob/master/example/src/screens/calendars.js#L56
+https://github.com/wix/react-native-calendars/blob/master/example/src/screens/calendars.tsx#L142
 
 ```javascript
 theme={{


### PR DESCRIPTION
@lidord-wix you may want to review since you [removed](https://github.com/wix/react-native-calendars/commit/785b07da836a93bd4d2183a82cb47153d0c8bd08#diff-14f587f4d3b549c25438c22da7463bb3b7862c24b008fe7cb5d816a5d34536d9) the `STYLESHEET_ID` const that was referenced previously