### PR TITLE
change lodash import way to make more tree-shakeable

### DIFF
--- a/example/src/screens/expandableCalendar.tsx
+++ b/example/src/screens/expandableCalendar.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React, {Component, useCallback} from 'react';
 import {Platform, StyleSheet, Alert, View, Text, TouchableOpacity, Button} from 'react-native';
 // @ts-expect-error
@@ -82,7 +82,7 @@ function getMarkedDates(items) {
   const marked = {};
   items.forEach(item => {
     // NOTE: only mark dates with data
-    if (item.data && item.data.length > 0 && !_.isEmpty(item.data[0])) {
+    if (item.data && item.data.length > 0 && !isEmpty(item.data[0])) {
       marked[item.title] = {marked: true};
     } else {
       marked[item.title] = {disabled: true};
@@ -213,7 +213,7 @@ const AgendaItem = React.memo(function AgendaItem(props: ItemProps) {
     Alert.alert(item.title);
   }, []);
 
-  if (_.isEmpty(item)) {
+  if (isEmpty(item)) {
     return(
       <View style={styles.emptyItem}>
         <Text style={styles.emptyItemText}>No Events Planned Today</Text>

--- a/src/agenda/index.tsx
+++ b/src/agenda/index.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import invoke from 'lodash/invoke';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 import memoize from 'memoize-one';
@@ -207,7 +207,7 @@ export default class Agenda extends Component<AgendaProps, AgendaState> {
       calendarScrollable: enable
     });
 
-    _.invoke(this.props, 'onCalendarToggled', enable);
+    invoke(this.props, 'onCalendarToggled', enable);
 
     // Enlarge calendarOffset here as a workaround on iOS to force repaint.
     // Otherwise the month after current one or before current one remains invisible.
@@ -227,7 +227,7 @@ export default class Agenda extends Component<AgendaProps, AgendaState> {
           firstReservationLoad: true
         },
         () => {
-          _.invoke(this.props, 'loadItemsForMonth', xdateToData(this.state.selectedDay));
+          invoke(this.props, 'loadItemsForMonth', xdateToData(this.state.selectedDay));
         }
       );
     }
@@ -245,7 +245,7 @@ export default class Agenda extends Component<AgendaProps, AgendaState> {
       selectedDay: day.clone()
     });
 
-    _.invoke(this.props, 'onCalendarToggled', false);
+    invoke(this.props, 'onCalendarToggled', false);
 
     if (!optimisticScroll) {
       this.setState({
@@ -256,8 +256,8 @@ export default class Agenda extends Component<AgendaProps, AgendaState> {
     this.setScrollPadPosition(this.initialScrollPadPosition(), true);
     this.calendar?.current?.scrollToDay(day, this.calendarOffset(), true);
 
-    _.invoke(this.props, 'loadItemsForMonth', xdateToData(day));
-    _.invoke(this.props, 'onDayPress', xdateToData(day));
+    invoke(this.props, 'loadItemsForMonth', xdateToData(day));
+    invoke(this.props, 'onDayPress', xdateToData(day));
   }
 
   generateMarkings = memoize((selectedDay, markedDates, items = {}) => {
@@ -328,14 +328,14 @@ export default class Agenda extends Component<AgendaProps, AgendaState> {
   };
 
   onVisibleMonthsChange = (months: DateData[]) => {
-    _.invoke(this.props, 'onVisibleMonthsChange', months);
+    invoke(this.props, 'onVisibleMonthsChange', months);
 
     if (this.props.items && !this.state.firstReservationLoad) {
       clearTimeout(this.scrollTimeout);
 
       this.scrollTimeout = setTimeout(() => {
         if (this._isMounted) {
-          _.invoke(this.props, 'loadItemsForMonth', months[0]);
+          invoke(this.props, 'loadItemsForMonth', months[0]);
         }
       }, 200);
     }
@@ -350,7 +350,7 @@ export default class Agenda extends Component<AgendaProps, AgendaState> {
       selectedDay: newDate
     });
 
-    _.invoke(this.props, 'onDayChange', xdateToData(newDate));
+    invoke(this.props, 'onDayChange', xdateToData(newDate));
   };
 
   renderReservations() {

--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import invoke from 'lodash/invoke';
+import isFunction from 'lodash/isFunction';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
@@ -230,7 +231,7 @@ class ReservationList extends Component<ReservationListProps, ReservationsListSt
 
   onScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const yOffset = event.nativeEvent.contentOffset.y;
-    _.invoke(this.props, 'onScroll', yOffset);
+    invoke(this.props, 'onScroll', yOffset);
 
     let topRowOffset = 0;
     let topRow;
@@ -248,7 +249,7 @@ class ReservationList extends Component<ReservationListProps, ReservationsListSt
     const dateIsSame = sameDate(day, this.selectedDay);
     if (!dateIsSame && this.scrollOver) {
       this.selectedDay = day.clone();
-      _.invoke(this.props, 'onDayChange', day.clone());
+      invoke(this.props, 'onDayChange', day.clone());
     }
   };
 
@@ -280,8 +281,8 @@ class ReservationList extends Component<ReservationListProps, ReservationsListSt
   render() {
     const {reservations, selectedDay, theme, style} = this.props;
     if (!reservations || !reservations[toMarkingFormat(selectedDay)]) {
-      if (_.isFunction(this.props.renderEmptyData)) {
-        return _.invoke(this.props, 'renderEmptyData');
+      if (isFunction(this.props.renderEmptyData)) {
+        return invoke(this.props, 'renderEmptyData');
       }
 
       return <ActivityIndicator style={this.style.indicator} color={theme?.indicatorColor} />;

--- a/src/agenda/reservation-list/reservation.tsx
+++ b/src/agenda/reservation-list/reservation.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
@@ -68,7 +68,7 @@ class Reservation extends Component<ReservationProps> {
         changed = false;
       } else if (r1.reservation && r2.reservation) {
         if ((!r1.date && !r2.date) || (r1.date && r2.date)) {
-          if (_.isFunction(this.props.rowHasChanged)) {
+          if (isFunction(this.props.rowHasChanged)) {
             changed = this.props.rowHasChanged(r1.reservation, r2.reservation);
           }
         }
@@ -78,7 +78,7 @@ class Reservation extends Component<ReservationProps> {
   }
 
   renderDate(date?: XDate, item?: DayReservations) {
-    if (_.isFunction(this.props.renderDay)) {
+    if (isFunction(this.props.renderDay)) {
       return this.props.renderDay(date ? xdateToData(date) : undefined, item);
     }
 
@@ -107,10 +107,10 @@ class Reservation extends Component<ReservationProps> {
 
     if (reservation) {
       const firstItem = date ? true : false;
-      if (_.isFunction(this.props.renderItem)) {
+      if (isFunction(this.props.renderItem)) {
         content = this.props.renderItem(reservation, firstItem);
       }
-    } else if (_.isFunction(this.props.renderEmptyDate)) {
+    } else if (isFunction(this.props.renderEmptyDate)) {
       content = this.props.renderEmptyDate(date);
     }
 

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import invoke from 'lodash/invoke';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
@@ -264,8 +264,8 @@ class CalendarList extends Component<Props, State> {
       if (!doNotTriggerListeners) {
         const currMont = this.state.currentMonth.clone();
 
-        _.invoke(this.props, 'onMonthChange', xdateToData(currMont));
-        _.invoke(this.props, 'onVisibleMonthsChange', [xdateToData(currMont)]);
+        invoke(this.props, 'onMonthChange', xdateToData(currMont));
+        invoke(this.props, 'onVisibleMonthsChange', [xdateToData(currMont)]);
       }
     });
   }
@@ -300,7 +300,7 @@ class CalendarList extends Component<Props, State> {
       }
     }
 
-    _.invoke(this.props, 'onVisibleMonthsChange', visibleMonths);
+    invoke(this.props, 'onVisibleMonthsChange', visibleMonths);
 
     this.setState({
       // @ts-ignore

--- a/src/calendar/day/basic/index.tsx
+++ b/src/calendar/day/basic/index.tsx
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import invoke from 'lodash/invoke';
+import values from 'lodash/values';
 import PropTypes from 'prop-types';
 
 import React, {Component, Fragment} from 'react';
@@ -42,7 +43,7 @@ export default class BasicDay extends Component<BasicDayProps> {
     /** The marking object */
     marking: PropTypes.any,
     /** Date marking style [simple/period/multi-dot/multi-period]. Default = 'simple' */
-    markingType: PropTypes.oneOf(_.values(Marking.markingTypes)),
+    markingType: PropTypes.oneOf(values(Marking.markingTypes)),
     /** Theme object */
     theme: PropTypes.object,
     /** onPress callback */
@@ -73,11 +74,11 @@ export default class BasicDay extends Component<BasicDayProps> {
   }
 
   onPress = () => {
-    _.invoke(this.props, 'onPress', this.props.date);
+    invoke(this.props, 'onPress', this.props.date);
   };
 
   onLongPress = () => {
-    _.invoke(this.props, 'onLongPress', this.props.date);
+    invoke(this.props, 'onLongPress', this.props.date);
   };
 
   get marking() {

--- a/src/calendar/day/index.tsx
+++ b/src/calendar/day/index.tsx
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import get from 'lodash/get';
+import omit from 'lodash/omit';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 import memoize from 'memoize-one';
@@ -18,7 +19,7 @@ import PeriodDay from './period';
 import {MarkingProps} from './marking';
 
 
-const basicDayPropsTypes = _.omit(BasicDay.propTypes, 'date');
+const basicDayPropsTypes = omit(BasicDay.propTypes, 'date');
 
 export interface DayProps extends Omit<BasicDayProps, 'date'> {
   /** The day to render */
@@ -81,8 +82,8 @@ export default class Day extends Component<DayProps> {
   }
 
   getAccessibilityLabel = memoize((day, marking, isToday) => {
-    const today = _.get(XDate, 'locales[XDate.defaultLocale].today');
-    const formatAccessibilityLabel = _.get(XDate, 'locales[XDate.defaultLocale].formatAccessibilityLabel');
+    const today = get(XDate, 'locales[XDate.defaultLocale].today');
+    const formatAccessibilityLabel = get(XDate, 'locales[XDate.defaultLocale].formatAccessibilityLabel');
     const markingLabel = this.getMarkingLabel(marking);
 
     if (formatAccessibilityLabel) {
@@ -106,7 +107,7 @@ export default class Day extends Component<DayProps> {
     const date = xdateToData(day);
     const isToday = dateutils_isToday(day);
     const Component = this.getDayComponent();
-    const dayProps = _.omit(this.props, 'day');
+    const dayProps = omit(this.props, 'day');
     const accessibilityLabel = this.getAccessibilityLabel(day, marking, isToday);
 
     return (

--- a/src/calendar/day/marking/index.tsx
+++ b/src/calendar/day/marking/index.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import filter from 'lodash/filter';
 
 import React, {Component} from 'react';
 import {View, ViewStyle, TextStyle} from 'react-native';
@@ -93,7 +93,7 @@ export default class Marking extends Component<MarkingProps> {
 
     if (items && Array.isArray(items) && items.length > 0) {
       // Filter out items so that we process only those which have color property
-      const validItems = _.filter(items, function(o: DOT | PERIOD) { return o.color; });
+      const validItems = filter(items, function(o: DOT | PERIOD) { return o.color; });
 
       return validItems.map((item, index) => {
         return type === MarkingTypes.MULTI_DOT ? this.renderDot(index, item) : this.renderPeriod(index, item);

--- a/src/calendar/day/period/index.tsx
+++ b/src/calendar/day/period/index.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 
 import React, {Component} from 'react';
@@ -57,7 +57,7 @@ export default class PeriodDay extends Component<PeriodDayProps> {
 
   shouldComponentUpdate(nextProps: PeriodDayProps) {
     const newMarkingStyle = this.getDrawingStyle(nextProps.marking);
-    if (!_.isEqual(this.markingStyle, newMarkingStyle)) {
+    if (!isEqual(this.markingStyle, newMarkingStyle)) {
       this.markingStyle = newMarkingStyle;
       return true;
     }

--- a/src/calendar/header/index.tsx
+++ b/src/calendar/header/index.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import includes from 'lodash/includes';
 import PropTypes from 'prop-types';
 import memoize from 'memoize-one';
 import XDate from 'xdate';
@@ -154,7 +154,7 @@ class CalendarHeader extends Component<Props> {
     return weekDaysNames.map((day: string, idx: number) => {
       const dayStyle = [this.style.dayHeader];
 
-      if (_.includes(disabledDaysIndexes, idx)) {
+      if (includes(disabledDaysIndexes, idx)) {
         dayStyle.push(this.style.disabledDayHeader);
       }
 

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import invoke from 'lodash/invoke';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 import memoize from 'memoize-one';
@@ -150,8 +150,8 @@ class Calendar extends Component<CalendarProps, CalendarState> {
     this.setState({currentMonth: day.clone()}, () => {
       if (!doNotTriggerListeners) {
         const currMont = this.state.currentMonth.clone();
-        _.invoke(this.props, 'onMonthChange', xdateToData(currMont));
-        _.invoke(this.props, 'onVisibleMonthsChange', [xdateToData(currMont)]);
+        invoke(this.props, 'onMonthChange', xdateToData(currMont));
+        invoke(this.props, 'onVisibleMonthsChange', [xdateToData(currMont)]);
       }
     });
   };

--- a/src/component-updater.js
+++ b/src/component-updater.js
@@ -1,8 +1,12 @@
-const _ = require('lodash');
+const get = require('lodash/get');
+const omit = require('lodash/omit');
+const pickBy = require('lodash/pickBy');
+const isEqual = require('lodash/isEqual');
+const includes = require('lodash/includes');
 
 function shouldUpdate(a, b, paths) {
   for (let i = 0; i < paths.length; i++) {
-    const equals = _.isEqual(_.get(a, paths[i]), _.get(b, paths[i]));
+    const equals = isEqual(get(a, paths[i]), get(b, paths[i]));
     if (!equals) {
       return true;
     }
@@ -14,10 +18,10 @@ function extractComponentProps(component, props, ignoreProps) {
   const componentPropTypes = component.propTypes;
   if (componentPropTypes) {
     const keys = Object.keys(componentPropTypes);
-    const componentProps = _.chain(props)
-      .pickBy((_value, key) => _.includes(keys, key))
-      .omit(ignoreProps)
-      .value();
+    const componentProps = omit(
+      pickBy(props, (_value, key) => includes(keys, key)),
+      ignoreProps
+    );
     return componentProps;
   }
   return {};

--- a/src/expandableCalendar/Context/Presenter.ts
+++ b/src/expandableCalendar/Context/Presenter.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import invoke from 'lodash/invoke';
 import XDate from 'xdate';
 
 // @ts-expect-error
@@ -55,10 +55,10 @@ class Presenter {
 
     updateState(buttonIcon);
 
-    _.invoke(props, 'onDateChanged', date, updateSource);
+    invoke(props, 'onDateChanged', date, updateSource);
 
     if (!isSameMonth) {
-      _.invoke(props, 'onMonthChange', xdateToData(new XDate(date)), updateSource);
+      invoke(props, 'onMonthChange', xdateToData(new XDate(date)), updateSource);
     }
   };
 

--- a/src/expandableCalendar/WeekCalendar/presenter.ts
+++ b/src/expandableCalendar/WeekCalendar/presenter.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import invoke from 'lodash/invoke';
 import XDate from 'xdate';
 
 import React from 'react';
@@ -33,7 +33,7 @@ class Presenter {
 
   // Events
   onDayPress = (context: any, value: DateData) => {
-    _.invoke(context, 'setDate', value.dateString, updateSources.DAY_PRESS);
+    invoke(context, 'setDate', value.dateString, updateSources.DAY_PRESS);
   };
 
   onScroll = ({context, updateState, x, page, items, width}: any) => {
@@ -46,7 +46,7 @@ class Presenter {
     const newPage = this._getNewPage(x, width);
 
     if (this._shouldUpdateState(page, newPage)) {
-      _.invoke(context, 'setDate', items[newPage], updateSources.WEEK_SCROLL);
+      invoke(context, 'setDate', items[newPage], updateSources.WEEK_SCROLL);
       const data = this._getItemsForPage(page, items);
       updateState(data, newPage);
     }

--- a/src/expandableCalendar/agendaList.tsx
+++ b/src/expandableCalendar/agendaList.tsx
@@ -1,4 +1,8 @@
-import _ from 'lodash';
+import get from 'lodash/get';
+import map from 'lodash/map';
+import omit from 'lodash/omit';
+import invoke from 'lodash/invoke';
+import isFunction from 'lodash/isFunction';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
@@ -71,7 +75,7 @@ class AgendaList extends Component<Props> {
   };
 
   style = styleConstructor(this.props.theme);
-  _topSection = _.get(this.props, 'sections[0].title');
+  _topSection = get(this.props, 'sections[0].title');
   didScroll = false;
   sectionScroll = false;
   viewabilityConfig = {
@@ -107,7 +111,7 @@ class AgendaList extends Component<Props> {
 
   getSectionIndex(date: Date) {
     let i;
-    _.map(this.props.sections, (section, index) => {
+    map(this.props.sections, (section, index) => {
       // NOTE: sections titles should match current date format!!!
       if (section.title === date) {
         i = index;
@@ -162,12 +166,12 @@ class AgendaList extends Component<Props> {
 
   onViewableItemsChanged = ((info: {viewableItems: Array<ViewToken>; changed: Array<ViewToken>}) => {
     if (info?.viewableItems && !this.sectionScroll) {
-      const topSection = _.get(info?.viewableItems[0], 'section.title');
+      const topSection = get(info?.viewableItems[0], 'section.title');
       if (topSection && topSection !== this._topSection) {
         this._topSection = topSection;
         if (this.didScroll && !this.props.avoidDateUpdates) {
           // to avoid setDate() on first load (while setting the initial context.date value)
-          _.invoke(this.props.context, 'setDate', this._topSection, updateSources.LIST_DRAG);
+          invoke(this.props.context, 'setDate', this._topSection, updateSources.LIST_DRAG);
         }
       }
     }
@@ -177,19 +181,19 @@ class AgendaList extends Component<Props> {
     if (!this.didScroll) {
       this.didScroll = true;
     }
-    _.invoke(this.props, 'onScroll', event);
+    invoke(this.props, 'onScroll', event);
   };
 
   onMomentumScrollBegin = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    _.invoke(this.props.context, 'setDisabled', true);
-    _.invoke(this.props, 'onMomentumScrollBegin', event);
+    invoke(this.props.context, 'setDisabled', true);
+    invoke(this.props, 'onMomentumScrollBegin', event);
   };
 
   onMomentumScrollEnd = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     // when list momentum ends AND when scrollToSection scroll ends
     this.sectionScroll = false;
-    _.invoke(this.props.context, 'setDisabled', false);
-    _.invoke(this.props, 'onMomentumScrollEnd', event);
+    invoke(this.props.context, 'setDisabled', false);
+    invoke(this.props, 'onMomentumScrollEnd', event);
   };
 
   onScrollToIndexFailed = (info: {
@@ -225,11 +229,11 @@ class AgendaList extends Component<Props> {
 
   keyExtractor = (item: any, index: number) => {
     const {keyExtractor} = this.props;
-    return _.isFunction(keyExtractor) ? keyExtractor(item, index) : String(index);
+    return isFunction(keyExtractor) ? keyExtractor(item, index) : String(index);
   };
 
   render() {
-    const props = _.omit(this.props, 'context');
+    const props = omit(this.props, 'context');
 
     return (
       <SectionList

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -1,4 +1,7 @@
-import _ from 'lodash';
+import first from 'lodash/first';
+import invoke from 'lodash/invoke';
+import values from 'lodash/values';
+import isFunction from 'lodash/isFunction';
 import PropTypes from 'prop-types';
 import memoize from 'memoize-one';
 import XDate from 'xdate';
@@ -83,7 +86,7 @@ class ExpandableCalendar extends Component<Props, State> {
   static propTypes = {
     ...CalendarList.propTypes,
     /** the initial position of the calendar ('open' or 'closed') */
-    initialPosition: PropTypes.oneOf(_.values(Positions)),
+    initialPosition: PropTypes.oneOf(values(Positions)),
     /** callback that fires when the calendar is opened or closed */
     onCalendarToggled: PropTypes.func,
     /** an option to disable the pan gesture and disable the opening and closing of the calendar (initialPosition will persist)*/
@@ -246,7 +249,7 @@ class ExpandableCalendar extends Component<Props, State> {
         const firstDayOfWeek = (next ? 7 : -7) - dayOfTheWeek + firstDay;
         d.addDays(firstDayOfWeek);
       }
-      _.invoke(this.props.context, 'setDate', toMarkingFormat(d), updateSources.PAGE_SCROLL);
+      invoke(this.props.context, 'setDate', toMarkingFormat(d), updateSources.PAGE_SCROLL);
     }
   }
 
@@ -356,7 +359,7 @@ class ExpandableCalendar extends Component<Props, State> {
         useNativeDriver: false
       }).start(this.onAnimatedFinished);
 
-      _.invoke(this.props, 'onCalendarToggled', isOpen);
+      invoke(this.props, 'onCalendarToggled', isOpen);
 
       this.setPosition();
       this.closeHeader(isOpen);
@@ -398,18 +401,18 @@ class ExpandableCalendar extends Component<Props, State> {
   /** Events */
 
   onPressArrowLeft = () => {
-    _.invoke(this.props, 'onPressArrowLeft');
+    invoke(this.props, 'onPressArrowLeft');
     this.scrollPage(false);
   };
 
   onPressArrowRight = () => {
-    _.invoke(this.props, 'onPressArrowRight');
+    invoke(this.props, 'onPressArrowRight');
     this.scrollPage(true);
   };
 
   onDayPress = (value: DateData) => {
     // {year: 2019, month: 4, day: 22, timestamp: 1555977600000, dateString: "2019-04-23"}
-    _.invoke(this.props.context, 'setDate', value.dateString, updateSources.DAY_PRESS);
+    invoke(this.props.context, 'setDate', value.dateString, updateSources.DAY_PRESS);
 
     setTimeout(() => {
       // to allows setDate to be completed
@@ -424,14 +427,14 @@ class ExpandableCalendar extends Component<Props, State> {
   };
 
   onVisibleMonthsChange = (value: DateData[]) => {
-    if (this.visibleMonth !== _.first(value)?.month) {
-      this.visibleMonth = _.first(value)?.month; // equivalent to this.getMonth(value[0].dateString)
+    if (this.visibleMonth !== first(value)?.month) {
+      this.visibleMonth = first(value)?.month; // equivalent to this.getMonth(value[0].dateString)
 
       // for horizontal scroll
       const {date, updateSource} = this.props.context;
 
       if (this.visibleMonth !== this.getMonth(date) && updateSource !== updateSources.DAY_PRESS) {
-        const next = this.isLaterDate(_.first(value), date);
+        const next = this.isLaterDate(first(value), date);
         this.scrollPage(next);
       }
 
@@ -529,7 +532,7 @@ class ExpandableCalendar extends Component<Props, State> {
   renderArrow = (direction: Direction) => {
     const {renderArrow, rightArrowImageSource = RIGHT_ARROW, leftArrowImageSource = LEFT_ARROW, testID} = this.props;
 
-    if (_.isFunction(renderArrow)) {
+    if (isFunction(renderArrow)) {
       return renderArrow(direction);
     }
 

--- a/src/timeline/Timeline.tsx
+++ b/src/timeline/Timeline.tsx
@@ -1,5 +1,7 @@
 // @flow
-import _ from 'lodash';
+import min from 'lodash/min';
+import map from 'lodash/map';
+import invoke from 'lodash/invoke';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
@@ -85,7 +87,7 @@ export default class Timeline extends Component<TimelineProps, State> {
 
     const width = dimensionWidth - LEFT_MARGIN;
     const packedEvents = populateEvents(props.events, width, start);
-    let initPosition = _.min(_.map(packedEvents, 'top')) - this.calendarHeight / (end - start);
+    let initPosition = min(map(packedEvents, 'top')) - this.calendarHeight / (end - start);
     const verifiedInitPosition = initPosition < 0 ? 0 : initPosition;
 
     this.state = {
@@ -161,7 +163,7 @@ export default class Timeline extends Component<TimelineProps, State> {
     if (this.props.eventTapped) { //TODO: remove after deprecation
       this.props.eventTapped(event);
     } else {
-      _.invoke(this.props, 'onEventPress', event);
+      invoke(this.props, 'onEventPress', event);
     }
   }
 


### PR DESCRIPTION
webpack can not remove unuse methods in lodash, because we use `require('lodash')` to import it
so change to `require('lodash/methodX')`