### PR TITLE
fix CalendarListItem height

### DIFF
--- a/src/calendar-list/item.tsx
+++ b/src/calendar-list/item.tsx
@@ -87,7 +87,7 @@ class CalendarListItem extends Component<CalendarListItemProps, CalendarListItem
   };
 
   getCalendarStyle = memoize((width, height, style) => {
-    return [{width, height}, this.style.calendar, style];
+    return [{width, minHeight: height}, this.style.calendar, style];
   });
 
   render() {


### PR DESCRIPTION
The marking of the last line in a calendar list item with 6 lines of dates is cut. 

![Screen Shot 2021-08-29 at 15 01 54](https://user-images.githubusercontent.com/66782556/131249658-850a1b10-588f-4df1-8920-5ece564089b2.png)
