### PR TITLE
Toggle week scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # React Native Calendars 🗓️ 📆
-
 [![Version](https://img.shields.io/npm/v/react-native-calendars.svg)](https://www.npmjs.com/package/react-native-calendars)
 [![Build Status](https://travis-ci.org/wix/react-native-calendars.svg?branch=master)](https://travis-ci.org/wix/react-native-calendars)
 
@@ -55,24 +54,11 @@ Calendars can be localized by adding custom locales to `LocaleConfig` object:
 import {LocaleConfig} from 'react-native-calendars';
 
 LocaleConfig.locales['fr'] = {
-  monthNames: [
-    'Janvier',
-    'Février',
-    'Mars',
-    'Avril',
-    'Mai',
-    'Juin',
-    'Juillet',
-    'Août',
-    'Septembre',
-    'Octobre',
-    'Novembre',
-    'Décembre'
-  ],
-  monthNamesShort: ['Janv.', 'Févr.', 'Mars', 'Avril', 'Mai', 'Juin', 'Juil.', 'Août', 'Sept.', 'Oct.', 'Nov.', 'Déc.'],
-  dayNames: ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi'],
-  dayNamesShort: ['Dim.', 'Lun.', 'Mar.', 'Mer.', 'Jeu.', 'Ven.', 'Sam.'],
-  today: "Aujourd'hui"
+  monthNames: ['Janvier','Février','Mars','Avril','Mai','Juin','Juillet','Août','Septembre','Octobre','Novembre','Décembre'],
+  monthNamesShort: ['Janv.','Févr.','Mars','Avril','Mai','Juin','Juil.','Août','Sept.','Oct.','Nov.','Déc.'],
+  dayNames: ['Dimanche','Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi'],
+  dayNamesShort: ['Dim.','Lun.','Mar.','Mer.','Jeu.','Ven.','Sam.'],
+  today: 'Aujourd\'hui'
 };
 LocaleConfig.defaultLocale = 'fr';
 ```
@@ -94,23 +80,17 @@ LocaleConfig.defaultLocale = 'fr';
   // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
   maxDate={'2012-05-30'}
   // Handler which gets executed on day press. Default = undefined
-  onDayPress={day => {
-    console.log('selected day', day);
-  }}
+  onDayPress={(day) => {console.log('selected day', day)}}
   // Handler which gets executed on day long press. Default = undefined
-  onDayLongPress={day => {
-    console.log('selected day', day);
-  }}
+  onDayLongPress={(day) => {console.log('selected day', day)}}
   // Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting
   monthFormat={'yyyy MM'}
   // Handler which gets executed when visible month changes in calendar. Default = undefined
-  onMonthChange={month => {
-    console.log('month changed', month);
-  }}
+  onMonthChange={(month) => {console.log('month changed', month)}}
   // Hide month navigation arrows. Default = false
   hideArrows={true}
   // Replace default arrows with custom ones (direction can be 'left' or 'right')
-  renderArrow={direction => <Arrow />}
+  renderArrow={(direction) => (<Arrow/>)}
   // Do not show days of other months in month page. Default = false
   hideExtraDays={true}
   // If hideArrows = false and hideExtraDays = false do not switch month when tapping on greyed out
@@ -133,9 +113,7 @@ LocaleConfig.defaultLocale = 'fr';
   // Disable all touch events for disabled days. can be override with disableTouchEvent in markedDates
   disableAllTouchEventsForDisabledDays={true}
   // Replace default month and year title with custom one. the function receive a date as parameter
-  renderHeader={date => {
-    /*Return JSX*/
-  }}
+  renderHeader={(date) => {/*Return JSX*/}}
   // Enable the option to swipe between months. Default = false
   enableSwipeMonths={true}
 />
@@ -187,7 +165,7 @@ const workout = {key: 'workout', color: 'green'};
     '2017-10-25': {dots: [vacation, massage, workout], selected: true, selectedColor: 'red'},
     '2017-10-26': {dots: [massage, workout], disabled: true}
   }}
-/>;
+/>
 ```
 
 Period marking
@@ -224,7 +202,7 @@ Multi-period marking
 
 ```javascript
 <Calendar
-  markingType="multi-period"
+  markingType='multi-period'
   markedDates={{
     '2017-12-14': {
       periods: [
@@ -282,7 +260,6 @@ Custom marking allows you to customize each marker with custom styles.
 ```
 
 **NEW!** While we still don't support multi marking type, we add the possibility to combine between `period` and `simple`.
-
 ```javascript
 <Calendar
   markingType={'period'}
@@ -297,7 +274,6 @@ Custom marking allows you to customize each marker with custom styles.
   }}
 />
 ```
-
 <kbd>
   <img height=350 src="https://github.com/wix-private/wix-react-native-calendar/blob/master/demo/multi-marking.png?raw=true">
 </kbd>
@@ -353,9 +329,7 @@ The loading indicator next to the month name will be displayed if `<Calendar/>` 
   }}
 />
 ```
-
 #### Customize days titles with disabled styling
-
 ```javascript
 <Calendar
   theme={{
@@ -425,7 +399,9 @@ If you need custom functionality not supported by current day component implemen
   dayComponent={({date, state}) => {
     return (
       <View>
-        <Text style={{textAlign: 'center', color: state === 'disabled' ? 'gray' : 'black'}}>{date.day}</Text>
+        <Text style={{textAlign: 'center', color: state === 'disabled' ? 'gray' : 'black'}}>
+          {date.day}
+        </Text>
       </View>
     );
   }}
@@ -434,9 +410,9 @@ If you need custom functionality not supported by current day component implemen
 
 The `dayComponent` prop has to receive a RN component or a function that receive props. The `dayComponent` will receive such props:
 
-- state - disabled if the day should be disabled (this is decided by base calendar component).
-- marking - `markedDates` value for this day.
-- date - the date object representing this day.
+* state - disabled if the day should be disabled (this is decided by base calendar component).
+* marking - `markedDates` value for this day.
+* date - the date object representing this day.
 
 **Tip**: Don't forget to implement `shouldComponentUpdate()` for your custom day component to make the calendar perform better
 
@@ -490,7 +466,6 @@ You can also make the `CalendarList` scroll horizontally. To do that you need to
 ```
 
 ### Agenda
-
 <kbd>
   <img src="https://github.com/wix-private/wix-react-native-calendar/blob/master/demo/agenda.gif?raw=true">
 </kbd>
@@ -510,21 +485,13 @@ An advanced `Agenda` component that can display interactive listings for calenda
     '2012-05-25': [{name: 'item 3 - any js object'}, {name: 'any js object'}]
   }}
   // Callback that gets called when items for a certain month should be loaded (month became visible)
-  loadItemsForMonth={month => {
-    console.log('trigger items loading');
-  }}
+  loadItemsForMonth={(month) => {console.log('trigger items loading')}}
   // Callback that fires when the calendar is opened or closed
-  onCalendarToggled={calendarOpened => {
-    console.log(calendarOpened);
-  }}
+  onCalendarToggled={(calendarOpened) => {console.log(calendarOpened)}}
   // Callback that gets called on day press
-  onDayPress={day => {
-    console.log('day pressed');
-  }}
+  onDayPress={(day) => {console.log('day pressed')}}
   // Callback that gets called when day changes while scrolling agenda list
-  onDayChange={day => {
-    console.log('day changed');
-  }}
+  onDayChange={(day) => {console.log('day changed')}}
   // Initially selected day
   selected={'2012-05-16'}
   // Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined
@@ -536,29 +503,17 @@ An advanced `Agenda` component that can display interactive listings for calenda
   // Max amount of months allowed to scroll to the future. Default = 50
   futureScrollRange={50}
   // Specify how each item should be rendered in agenda
-  renderItem={(item, firstItemInDay) => {
-    return <View />;
-  }}
+  renderItem={(item, firstItemInDay) => {return (<View />);}}
   // Specify how each date should be rendered. day can be undefined if the item is not first in that day
-  renderDay={(day, item) => {
-    return <View />;
-  }}
+  renderDay={(day, item) => {return (<View />);}}
   // Specify how empty date content with no items should be rendered
-  renderEmptyDate={() => {
-    return <View />;
-  }}
+  renderEmptyDate={() => {return (<View />);}}
   // Specify how agenda knob should look like
-  renderKnob={() => {
-    return <View />;
-  }}
+  renderKnob={() => {return (<View />);}}
   // Specify what should be rendered instead of ActivityIndicator
-  renderEmptyData={() => {
-    return <View />;
-  }}
+  renderEmptyData = {() => {return (<View />);}}
   // Specify your item comparison function for increased performance
-  rowHasChanged={(r1, r2) => {
-    return r1.text !== r2.text;
-  }}
+  rowHasChanged={(r1, r2) => {return r1.text !== r2.text}}
   // Hide knob button. Default = false
   hideKnob={true}
   // When `true` and `hideKnob` prop is `false`, the knob will always be visible and the user will be able to drag the knob up and close the calendar. Default = false
@@ -594,8 +549,8 @@ An advanced `Agenda` component that can display interactive listings for calenda
 
 ## Authors
 
-- [Tautvilas Mecinskas](https://github.com/tautvilas/) - Initial code - [@tautvilas](https://twitter.com/Tautvilas)
-- Katrin Zotchev - Initial design - [@katrin_zot](https://twitter.com/katrin_zot)
+* [Tautvilas Mecinskas](https://github.com/tautvilas/) - Initial code - [@tautvilas](https://twitter.com/Tautvilas)
+* Katrin Zotchev - Initial design - [@katrin_zot](https://twitter.com/katrin_zot)
 
 See also the list of [contributors](https://github.com/wix/react-native-calendar-components/contributors) who participated in this project.
 
@@ -603,6 +558,6 @@ See also the list of [contributors](https://github.com/wix/react-native-calendar
 
 Pull requests are most welcome!
 Please `npm run test` and `npm run lint` before push.
-Don't forget to add a **title** and a **description** that explain the issue you're trying to solve and your suggested solution.
+Don't forget to add a **title** and a **description** that explain the issue you're trying to solve and your suggested solution. 
 Screenshots and gifs are VERY helpful.
 Please do NOT format the files as we are trying to keep a unified syntax and the reviewing process fast and simple.

--- a/README.md
+++ b/README.md
@@ -138,8 +138,6 @@ LocaleConfig.defaultLocale = 'fr';
   }}
   // Enable the option to swipe between months. Default = false
   enableSwipeMonths={true}
-  // Toggles the agenda moving automatically between weeks
-  scrollBetweenWeeks={true}
 />
 ```
 
@@ -589,6 +587,8 @@ An advanced `Agenda` component that can display interactive listings for calenda
   }}
   // Agenda container style
   style={{}}
+  // Toggles the agenda moving automatically between weeks
+  scrollBetweenWeeks={true}
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ LocaleConfig.defaultLocale = 'fr';
   }}
   // Enable the option to swipe between months. Default = false
   enableSwipeMonths={true}
+  // Toggles the agenda moving automatically between weeks
+  scrollBetweenWeeks={true}
 />
 ```
 
@@ -587,8 +589,6 @@ An advanced `Agenda` component that can display interactive listings for calenda
   }}
   // Agenda container style
   style={{}}
-  // Toggles the agenda moving automatically between weeks
-  scrollBetweenWeeks={true}
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # React Native Calendars 🗓️ 📆
+
 [![Version](https://img.shields.io/npm/v/react-native-calendars.svg)](https://www.npmjs.com/package/react-native-calendars)
 [![Build Status](https://travis-ci.org/wix/react-native-calendars.svg?branch=master)](https://travis-ci.org/wix/react-native-calendars)
 
@@ -54,11 +55,24 @@ Calendars can be localized by adding custom locales to `LocaleConfig` object:
 import {LocaleConfig} from 'react-native-calendars';
 
 LocaleConfig.locales['fr'] = {
-  monthNames: ['Janvier','Février','Mars','Avril','Mai','Juin','Juillet','Août','Septembre','Octobre','Novembre','Décembre'],
-  monthNamesShort: ['Janv.','Févr.','Mars','Avril','Mai','Juin','Juil.','Août','Sept.','Oct.','Nov.','Déc.'],
-  dayNames: ['Dimanche','Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi'],
-  dayNamesShort: ['Dim.','Lun.','Mar.','Mer.','Jeu.','Ven.','Sam.'],
-  today: 'Aujourd\'hui'
+  monthNames: [
+    'Janvier',
+    'Février',
+    'Mars',
+    'Avril',
+    'Mai',
+    'Juin',
+    'Juillet',
+    'Août',
+    'Septembre',
+    'Octobre',
+    'Novembre',
+    'Décembre'
+  ],
+  monthNamesShort: ['Janv.', 'Févr.', 'Mars', 'Avril', 'Mai', 'Juin', 'Juil.', 'Août', 'Sept.', 'Oct.', 'Nov.', 'Déc.'],
+  dayNames: ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi'],
+  dayNamesShort: ['Dim.', 'Lun.', 'Mar.', 'Mer.', 'Jeu.', 'Ven.', 'Sam.'],
+  today: "Aujourd'hui"
 };
 LocaleConfig.defaultLocale = 'fr';
 ```
@@ -80,17 +94,23 @@ LocaleConfig.defaultLocale = 'fr';
   // Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined
   maxDate={'2012-05-30'}
   // Handler which gets executed on day press. Default = undefined
-  onDayPress={(day) => {console.log('selected day', day)}}
+  onDayPress={day => {
+    console.log('selected day', day);
+  }}
   // Handler which gets executed on day long press. Default = undefined
-  onDayLongPress={(day) => {console.log('selected day', day)}}
+  onDayLongPress={day => {
+    console.log('selected day', day);
+  }}
   // Month format in calendar title. Formatting values: http://arshaw.com/xdate/#Formatting
   monthFormat={'yyyy MM'}
   // Handler which gets executed when visible month changes in calendar. Default = undefined
-  onMonthChange={(month) => {console.log('month changed', month)}}
+  onMonthChange={month => {
+    console.log('month changed', month);
+  }}
   // Hide month navigation arrows. Default = false
   hideArrows={true}
   // Replace default arrows with custom ones (direction can be 'left' or 'right')
-  renderArrow={(direction) => (<Arrow/>)}
+  renderArrow={direction => <Arrow />}
   // Do not show days of other months in month page. Default = false
   hideExtraDays={true}
   // If hideArrows = false and hideExtraDays = false do not switch month when tapping on greyed out
@@ -113,7 +133,9 @@ LocaleConfig.defaultLocale = 'fr';
   // Disable all touch events for disabled days. can be override with disableTouchEvent in markedDates
   disableAllTouchEventsForDisabledDays={true}
   // Replace default month and year title with custom one. the function receive a date as parameter
-  renderHeader={(date) => {/*Return JSX*/}}
+  renderHeader={date => {
+    /*Return JSX*/
+  }}
   // Enable the option to swipe between months. Default = false
   enableSwipeMonths={true}
 />
@@ -165,7 +187,7 @@ const workout = {key: 'workout', color: 'green'};
     '2017-10-25': {dots: [vacation, massage, workout], selected: true, selectedColor: 'red'},
     '2017-10-26': {dots: [massage, workout], disabled: true}
   }}
-/>
+/>;
 ```
 
 Period marking
@@ -202,7 +224,7 @@ Multi-period marking
 
 ```javascript
 <Calendar
-  markingType='multi-period'
+  markingType="multi-period"
   markedDates={{
     '2017-12-14': {
       periods: [
@@ -260,6 +282,7 @@ Custom marking allows you to customize each marker with custom styles.
 ```
 
 **NEW!** While we still don't support multi marking type, we add the possibility to combine between `period` and `simple`.
+
 ```javascript
 <Calendar
   markingType={'period'}
@@ -274,6 +297,7 @@ Custom marking allows you to customize each marker with custom styles.
   }}
 />
 ```
+
 <kbd>
   <img height=350 src="https://github.com/wix-private/wix-react-native-calendar/blob/master/demo/multi-marking.png?raw=true">
 </kbd>
@@ -329,7 +353,9 @@ The loading indicator next to the month name will be displayed if `<Calendar/>` 
   }}
 />
 ```
+
 #### Customize days titles with disabled styling
+
 ```javascript
 <Calendar
   theme={{
@@ -399,9 +425,7 @@ If you need custom functionality not supported by current day component implemen
   dayComponent={({date, state}) => {
     return (
       <View>
-        <Text style={{textAlign: 'center', color: state === 'disabled' ? 'gray' : 'black'}}>
-          {date.day}
-        </Text>
+        <Text style={{textAlign: 'center', color: state === 'disabled' ? 'gray' : 'black'}}>{date.day}</Text>
       </View>
     );
   }}
@@ -410,9 +434,9 @@ If you need custom functionality not supported by current day component implemen
 
 The `dayComponent` prop has to receive a RN component or a function that receive props. The `dayComponent` will receive such props:
 
-* state - disabled if the day should be disabled (this is decided by base calendar component).
-* marking - `markedDates` value for this day.
-* date - the date object representing this day.
+- state - disabled if the day should be disabled (this is decided by base calendar component).
+- marking - `markedDates` value for this day.
+- date - the date object representing this day.
 
 **Tip**: Don't forget to implement `shouldComponentUpdate()` for your custom day component to make the calendar perform better
 
@@ -466,6 +490,7 @@ You can also make the `CalendarList` scroll horizontally. To do that you need to
 ```
 
 ### Agenda
+
 <kbd>
   <img src="https://github.com/wix-private/wix-react-native-calendar/blob/master/demo/agenda.gif?raw=true">
 </kbd>
@@ -485,13 +510,21 @@ An advanced `Agenda` component that can display interactive listings for calenda
     '2012-05-25': [{name: 'item 3 - any js object'}, {name: 'any js object'}]
   }}
   // Callback that gets called when items for a certain month should be loaded (month became visible)
-  loadItemsForMonth={(month) => {console.log('trigger items loading')}}
+  loadItemsForMonth={month => {
+    console.log('trigger items loading');
+  }}
   // Callback that fires when the calendar is opened or closed
-  onCalendarToggled={(calendarOpened) => {console.log(calendarOpened)}}
+  onCalendarToggled={calendarOpened => {
+    console.log(calendarOpened);
+  }}
   // Callback that gets called on day press
-  onDayPress={(day) => {console.log('day pressed')}}
+  onDayPress={day => {
+    console.log('day pressed');
+  }}
   // Callback that gets called when day changes while scrolling agenda list
-  onDayChange={(day) => {console.log('day changed')}}
+  onDayChange={day => {
+    console.log('day changed');
+  }}
   // Initially selected day
   selected={'2012-05-16'}
   // Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined
@@ -503,17 +536,29 @@ An advanced `Agenda` component that can display interactive listings for calenda
   // Max amount of months allowed to scroll to the future. Default = 50
   futureScrollRange={50}
   // Specify how each item should be rendered in agenda
-  renderItem={(item, firstItemInDay) => {return (<View />);}}
+  renderItem={(item, firstItemInDay) => {
+    return <View />;
+  }}
   // Specify how each date should be rendered. day can be undefined if the item is not first in that day
-  renderDay={(day, item) => {return (<View />);}}
+  renderDay={(day, item) => {
+    return <View />;
+  }}
   // Specify how empty date content with no items should be rendered
-  renderEmptyDate={() => {return (<View />);}}
+  renderEmptyDate={() => {
+    return <View />;
+  }}
   // Specify how agenda knob should look like
-  renderKnob={() => {return (<View />);}}
+  renderKnob={() => {
+    return <View />;
+  }}
   // Specify what should be rendered instead of ActivityIndicator
-  renderEmptyData = {() => {return (<View />);}}
+  renderEmptyData={() => {
+    return <View />;
+  }}
   // Specify your item comparison function for increased performance
-  rowHasChanged={(r1, r2) => {return r1.text !== r2.text}}
+  rowHasChanged={(r1, r2) => {
+    return r1.text !== r2.text;
+  }}
   // Hide knob button. Default = false
   hideKnob={true}
   // When `true` and `hideKnob` prop is `false`, the knob will always be visible and the user will be able to drag the knob up and close the calendar. Default = false
@@ -542,13 +587,15 @@ An advanced `Agenda` component that can display interactive listings for calenda
   }}
   // Agenda container style
   style={{}}
+  // Toggles the agenda moving automatically between weeks
+  scrollBetweenWeeks={true}
 />
 ```
 
 ## Authors
 
-* [Tautvilas Mecinskas](https://github.com/tautvilas/) - Initial code - [@tautvilas](https://twitter.com/Tautvilas)
-* Katrin Zotchev - Initial design - [@katrin_zot](https://twitter.com/katrin_zot)
+- [Tautvilas Mecinskas](https://github.com/tautvilas/) - Initial code - [@tautvilas](https://twitter.com/Tautvilas)
+- Katrin Zotchev - Initial design - [@katrin_zot](https://twitter.com/katrin_zot)
 
 See also the list of [contributors](https://github.com/wix/react-native-calendar-components/contributors) who participated in this project.
 
@@ -556,6 +603,6 @@ See also the list of [contributors](https://github.com/wix/react-native-calendar
 
 Pull requests are most welcome!
 Please `npm run test` and `npm run lint` before push.
-Don't forget to add a **title** and a **description** that explain the issue you're trying to solve and your suggested solution. 
+Don't forget to add a **title** and a **description** that explain the issue you're trying to solve and your suggested solution.
 Screenshots and gifs are VERY helpful.
 Please do NOT format the files as we are trying to keep a unified syntax and the reviewing process fast and simple.

--- a/example/src/screens/agenda.tsx
+++ b/example/src/screens/agenda.tsx
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import {Alert, StyleSheet, Text, View, TouchableOpacity} from 'react-native';
-//import {Agenda} from 'react-native-calendars';
-import {Agenda} from "../../../src/index";
+// @ts-expect-error
+import {Agenda} from 'react-native-calendars';
 
 
 const testIDs = require('../testIDs');

--- a/example/src/screens/agenda.tsx
+++ b/example/src/screens/agenda.tsx
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import {Alert, StyleSheet, Text, View, TouchableOpacity} from 'react-native';
-// @ts-expect-error
-import {Agenda} from 'react-native-calendars';
+//import {Agenda} from 'react-native-calendars';
+import {Agenda} from "../../../src/index";
 
 
 const testIDs = require('../testIDs');
@@ -22,6 +22,7 @@ export default class AgendaScreen extends Component {
         renderEmptyDate={this.renderEmptyDate.bind(this)}
         rowHasChanged={this.rowHasChanged.bind(this)}
         showClosingKnob={true}
+        // scrollBetweenWeeks={false}
         // markingType={'period'}
         // markedDates={{
         //    '2017-05-08': {textColor: '#43515c'},

--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -123,7 +123,7 @@ class ReservationList extends Component<ReservationListProps, ReservationsListSt
     this.heights = [];
     this.selectedDay = props.selectedDay;
     this.scrollOver = true;
-    this.scrollBetweenWeeks = props.scrollBetweenWeeks ? props.scrollBetweenWeeks : true;
+    this.scrollBetweenWeeks = props.scrollBetweenWeeks === false ? false : true;
   }
 
   componentDidMount() {

--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -123,7 +123,7 @@ class ReservationList extends Component<ReservationListProps, ReservationsListSt
     this.heights = [];
     this.selectedDay = props.selectedDay;
     this.scrollOver = true;
-    this.scrollBetweenWeeks = Boolean(props.scrollBetweenWeeks);
+    this.scrollBetweenWeeks = props.scrollBetweenWeeks ? props.scrollBetweenWeeks : true;
   }
 
   componentDidMount() {

--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -264,7 +264,7 @@ class ReservationList extends Component<ReservationListProps, ReservationsListSt
 
     const day = row.day;
     const dateIsSame = sameDate(day, this.selectedDay);
-    if (!dateIsSame && this.scrollOver && this.scrollBetweenWeeks) {
+    if (!dateIsSame && this.scrollOver) {
       this.selectedDay = day.clone();
       _.invoke(this.props, 'onDayChange', day.clone());
     }


### PR DESCRIPTION
This adds the scrollBetweenWeeks prop on the reservations component which gives the ability to disable the agenda moving automatically between weeks. Defaults to true to be enabled.