### PR TITLE
Add missing steps to 'try it out' section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ You can run example module by performing these steps:
 
 ```
 $ git clone git@github.com:wix/react-native-calendars.git
+$ cd react-native-calendars
 $ npm install
+$ cd ios && pod install && cd ..
 $ react-native run-ios
 ```
 


### PR DESCRIPTION
The original one didn't include installing pods & entering the cloned repo