### PR TITLE
RenderItem props not delivered in weekCalendar

### DIFF
--- a/src/expandableCalendar/WeekCalendar/index.tsx
+++ b/src/expandableCalendar/WeekCalendar/index.tsx
@@ -221,7 +221,7 @@ class WeekCalendar extends Component<Props, State> {
           showsHorizontalScrollIndicator={false}
           pagingEnabled
           scrollEnabled
-          renderItem={this.renderItem}
+          renderItem={this.renderItem.bind(this)}
           keyExtractor={this.keyExtractor}
           initialScrollIndex={NUMBER_OF_PAGES}
           getItemLayout={this.getItemLayout}


### PR DESCRIPTION
Initially, When switching from a monthly calendar to a weekly calendar, correct issues that cannot be re-rended because marked dates are not properly delivered.

### ScreenShot
- monthly calendar
<img width="293" alt="1" src="https://user-images.githubusercontent.com/44993222/135704707-69f515f4-ac47-427a-b2dd-ea385e37c037.png">

- The weekly calendar of the existing code
<img width="291" alt="2" src="https://user-images.githubusercontent.com/44993222/135704730-be68ca82-ef97-4360-a387-c3899f16d2e3.png">

- The weekly calendar of the New code
<img width="289" alt="3" src="https://user-images.githubusercontent.com/44993222/135704735-2c27f269-a3dd-4478-b171-528d860eb070.png">


