### PR TITLE
Fix import path of calendar provider

### DIFF
--- a/src/expandableCalendar/Context/Provider.tsx
+++ b/src/expandableCalendar/Context/Provider.tsx
@@ -8,7 +8,7 @@ import {StyleSheet, Animated, TouchableOpacity, View, StyleProp, ViewStyle} from
 import {toMarkingFormat} from '../../interface';
 import {Theme, UpdateSource, DateData} from '../../types';
 import styleConstructor from '../style';
-import CalendarContext from '.';
+import CalendarContext from './index';
 import Presenter from './Presenter';
 
 


### PR DESCRIPTION
This small change fixes a broken import.

Bug was found whilst mimicking this example

https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendar.tsx

![Simulator Screen Shot - iPhone 13 mini - 2021-10-06 at 08 47 49](https://user-images.githubusercontent.com/189383/136161749-e13a2b3a-d0f4-4451-babc-299224caab27.png)


