### PR TITLE
Add style props to Agenda to change knob's style

### DIFF
--- a/example/src/screens/agenda.tsx
+++ b/example/src/screens/agenda.tsx
@@ -20,6 +20,14 @@ export default class AgendaScreen extends Component {
         renderEmptyDate={this.renderEmptyDate.bind(this)}
         rowHasChanged={this.rowHasChanged.bind(this)}
         showClosingKnob={true}
+        // knobStyle={styles.wideKnobStyle}
+        // renderKnob={() => {
+        //   return (
+        //     <View>
+        //       <Text>This is a manual knob</Text>
+        //     </View>
+        //   );
+        // }}
         // markingType={'period'}
         // markedDates={{
         //    '2017-05-08': {textColor: '#43515c'},
@@ -107,5 +115,8 @@ const styles = StyleSheet.create({
     height: 15,
     flex: 1,
     paddingTop: 30
+  },
+  wideKnobStyle: {
+    width: '100%'
   }
 });

--- a/src/agenda/index.tsx
+++ b/src/agenda/index.tsx
@@ -23,8 +23,7 @@ import {VelocityTracker} from '../input';
 import {DateData} from '../types';
 import styleConstructor from './style';
 import CalendarList, {CalendarListProps} from '../calendar-list';
-import ReservationList, {ReservationListProps}  from './reservation-list';
-
+import ReservationList, {ReservationListProps} from './reservation-list';
 
 const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
@@ -39,8 +38,9 @@ export type ReservationsType = {
   [date: string]: ReservationItemType[];
 };
 
-export type AgendaProps = CalendarListProps & ReservationListProps & {
-  /** the list of items that have to be displayed in agenda. If you want to render item as empty date
+export type AgendaProps = CalendarListProps &
+  ReservationListProps & {
+    /** the list of items that have to be displayed in agenda. If you want to render item as empty date
    the value of date key has to be an empty array []. If there exists no value for date key it is
    considered that the date in question is not yet loaded */
   items: ReservationsType;
@@ -54,6 +54,8 @@ export type AgendaProps = CalendarListProps & ReservationListProps & {
   onDayChange?: (data: any) => void;
   /** specify how agenda knob should look like */
   renderKnob?: () => JSX.Element;
+  /** specify style of agenda knob, if you want to expand the zone of knob, you can change it here */
+  knobStyle?: ViewStyle;
   /** initially selected day */
   selected: boolean; //TODO: Should be renamed 'selectedDay'
   /** Hide knob button. Default = false */
@@ -100,6 +102,8 @@ export default class Agenda extends Component<AgendaProps, AgendaState> {
     onDayChange: PropTypes.func,
     /** specify how agenda knob should look like */
     renderKnob: PropTypes.func,
+    /** specify style of agenda knob, if you want to expand the zone of knob, you can change it here */
+    knobStyle: PropTypes.object,
     /** initially selected day */
     selected: PropTypes.any, //TODO: Should be renamed 'selectedDay'
     /** Hide knob button. Default = false */
@@ -389,12 +393,13 @@ export default class Agenda extends Component<AgendaProps, AgendaState> {
     let knob: JSX.Element | null = <View style={this.style.knobContainer} />;
 
     if (!hideKnob) {
-      const knobView = renderKnob ? renderKnob() : <View style={this.style.knob}/>;
-      knob = !this.state.calendarScrollable || showClosingKnob ? (
-        <View style={this.style.knobContainer}>
-          <View ref={this.knob}>{knobView}</View>
-        </View>
-      ) : null;
+      const knobView = renderKnob ? renderKnob() : <View style={this.style.knob} />;
+      knob =
+        !this.state.calendarScrollable || showClosingKnob ? (
+          <View style={this.style.knobContainer}>
+            <View ref={this.knob}>{knobView}</View>
+          </View>
+        ) : null;
     }
     return knob;
   }
@@ -465,8 +470,7 @@ export default class Agenda extends Component<AgendaProps, AgendaState> {
     const scrollPadPosition = (shouldAllowDragging ? HEADER_HEIGHT : openCalendarScrollPadPosition) - KNOB_HEIGHT;
     const scrollPadStyle = {
       height: KNOB_HEIGHT,
-      top: scrollPadPosition,
-      left: (this.viewWidth - 80) / 2
+      top: scrollPadPosition
     };
 
     return (
@@ -484,7 +488,7 @@ export default class Agenda extends Component<AgendaProps, AgendaState> {
         </Animated.View>
         <Animated.ScrollView
           ref={this.scrollPad}
-          style={[this.style.scrollPadStyle, scrollPadStyle]}
+          style={[this.style.scrollPadStyle, scrollPadStyle, this.props.knobStyle]}
           overScrollMode="never"
           showsHorizontalScrollIndicator={false}
           showsVerticalScrollIndicator={false}

--- a/src/agenda/style.ts
+++ b/src/agenda/style.ts
@@ -49,7 +49,8 @@ export default function styleConstructor(theme: Theme = {}) {
     },
     scrollPadStyle: {
       position: 'absolute',
-      width: 80
+      width: 80,
+      alignSelf: 'center'
     },
     // @ts-expect-error
     ...(theme['stylesheet.agenda.main'] || {})


### PR DESCRIPTION
### Description
This PR addresses: https://github.com/wix/react-native-calendars/issues/1653
I added a new props `knobStyle` to let make the knob's style changeable, but if the maintainer thinks just making the knob's width wider is enough, I can also open the PR for it and close this one.

### Changes
 - Add `knobStyle` props to let users to change knob's style
 - Update Agenda's example

### Gif
![2021-10-13 19 23 38](https://user-images.githubusercontent.com/44686790/137240931-118e319b-acb0-4cdd-b5c6-fe4b2f2bca2e.gif)