### PR TITLE
Fix: Agenda style Typo (animatedContiner -> animatedContainer)

### DIFF
--- a/src/agenda/style.ts
+++ b/src/agenda/style.ts
@@ -12,7 +12,7 @@ export default function styleConstructor(theme: Theme = {}) {
       flex: 1,
       overflow: 'hidden'
     },
-    animatedContiner: {
+    animatedContainer: {
       flex: 1
     },
     knob,


### PR DESCRIPTION
Fixed typo in styles which means an animated view doesn't get `flex: 1` as it should.