### PR TITLE
Add closeOnDayPress prop to ExpandableCalendar

### DIFF
--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -60,6 +60,8 @@ export interface Props extends CalendarListProps {
   openThreshold?: number;
   /** a threshold for closing the calendar with the pan gesture */
   closeThreshold?: number;
+  /** Whether to close the calendar on day press. Default = true */
+  closeOnDayPress?: boolean;
   context?: any;
 }
 export type ExpandableCalendarProps = Props;
@@ -102,7 +104,9 @@ class ExpandableCalendar extends Component<Props, State> {
     /** a threshold for opening the calendar with the pan gesture */
     openThreshold: PropTypes.number,
     /** a threshold for closing the calendar with the pan gesture */
-    closeThreshold: PropTypes.number
+    closeThreshold: PropTypes.number,
+    /** Whether to close the calendar on day press. Default = true */
+    closeOnDayPress: PropTypes.bool
   };
 
   static defaultProps = {
@@ -113,7 +117,8 @@ class ExpandableCalendar extends Component<Props, State> {
     rightArrowImageSource: RIGHT_ARROW,
     allowShadow: true,
     openThreshold: PAN_GESTURE_THRESHOLD,
-    closeThreshold: PAN_GESTURE_THRESHOLD
+    closeThreshold: PAN_GESTURE_THRESHOLD,
+    closeOnDayPress: true
   };
 
   static positions = Positions;
@@ -414,12 +419,14 @@ class ExpandableCalendar extends Component<Props, State> {
     // {year: 2019, month: 4, day: 22, timestamp: 1555977600000, dateString: "2019-04-23"}
     invoke(this.props.context, 'setDate', value.dateString, updateSources.DAY_PRESS);
 
-    setTimeout(() => {
-      // to allows setDate to be completed
-      if (this.state.position === Positions.OPEN) {
-        this.bounceToPosition(this.closedHeight);
-      }
-    }, 0);
+    if (this.props.closeOnDayPress) {
+      setTimeout(() => {
+        // to allows setDate to be completed
+        if (this.state.position === Positions.OPEN) {
+          this.bounceToPosition(this.closedHeight);
+        }
+      }, 0);
+    }
 
     if (this.props.onDayPress) {
       this.props.onDayPress(value);


### PR DESCRIPTION
Currently, if `ExpandableCalendar` is open, it will always close when a day is pressed, and there is no way to override this behavior. This PR adds a new prop `closeOnDayPress` to `ExpandableCalendar`, which when `false` will not close an open calendar when a day is pressed. This property defaults to `true` to maintain backward compatibility.