### PR TITLE
Fix contentRef in CalendarConsumer

### DIFF
--- a/src/expandableCalendar/asCalendarConsumer.tsx
+++ b/src/expandableCalendar/asCalendarConsumer.tsx
@@ -16,7 +16,7 @@ function asCalendarConsumer(WrappedComponent: React.ComponentType<any>): React.C
     render() {
       return (
         <CalendarContext.Consumer>
-          {context => <WrappedComponent ref={this.contentRef} context={context} {...this.props} />}
+          {context => <WrappedComponent ref={this.saveRef} context={context} {...this.props} />}
         </CalendarContext.Consumer>
       );
     }


### PR DESCRIPTION
The conversion of `ExpandableCalendar` to TypeScript in #1598 introduced a breaking change to the behavior of `contentRef` in `CalendarConsumer`. Before, `contentRef` held a reference to the wrapped component. Now, `contentRef` is always `undefined`. This PR returns to the previous behavior.

Fixes #1634 