### PR TITLE
Fix eslint config and fix lint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
     it: true,
     describe: true
   },
-  extends: ['eslint:recommended'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaFeatures: {
@@ -26,6 +26,9 @@ module.exports = {
     'object-curly-spacing': ['error', 'never'],
     semi: ['error', 'always'],
     'react/jsx-uses-react': 2,
-    'react/jsx-uses-vars': 2
+    'react/jsx-uses-vars': 2,
+    '@typescript-eslint/no-use-before-define': 0,
+    '@typescript-eslint/no-var-requires': 0,
+    '@typescript-eslint/explicit-function-return-type': 0
   }
 };

--- a/example/src/screens/menu.js
+++ b/example/src/screens/menu.js
@@ -2,8 +2,8 @@ import React, {Component} from 'react';
 import {Platform, StyleSheet, View, ScrollView, TouchableOpacity, Text, Image} from 'react-native';
 import {Navigation} from 'react-native-navigation';
 
-const appIcon = require('../img/app-icon-120x120.png');
-const testIDs = require('../testIDs');
+import appIcon from '../img/app-icon-120x120.png';
+import testIDs from '../testIDs';
 
 export default class MenuScreen extends Component {
   render() {

--- a/src/calendar/index.spec.js
+++ b/src/calendar/index.spec.js
@@ -19,7 +19,7 @@ describe('Calendar', () => {
 
   describe('Month days', () => {
     it('should render current month days including extra days from other months by default', () => {
-      let expectedDays = [];
+      const expectedDays = [];
       expectedDays.push(...getDaysArray(29, 31)); // March
       expectedDays.push(...getDaysArray(1, 30)); // April
       expectedDays.push(...getDaysArray(1, 2)); // May
@@ -213,7 +213,7 @@ describe('Calendar', () => {
     });
 
     it('should not have loading indicator with `displayLoadingIndicator` prop when `markedDates` collection has a value for every day of the month', () => {
-      let date = currentDate;
+      const date = currentDate;
       const markedDates = {};
       for (let i = 0; i < 30; i++) {
         const string = date.toISOString().split('T')[0];

--- a/src/componentUpdater.spec.js
+++ b/src/componentUpdater.spec.js
@@ -1,4 +1,4 @@
-const {shouldUpdate} = require('./componentUpdater');
+import {shouldUpdate} from './componentUpdater';
 
 describe('component updater', () => {
   it('should return true if two different objects are provided with same path', async () => {

--- a/src/dateutils.spec.js
+++ b/src/dateutils.spec.js
@@ -1,5 +1,5 @@
-const XDate = require('xdate');
-const dateutils = require('./dateutils');
+import XDate from 'xdate';
+import * as dateutils from './dateutils';
 
 describe('dateutils', function () {
   describe('sameMonth()', function () {

--- a/src/expandableCalendar/Context/Presenter.spec.js
+++ b/src/expandableCalendar/Context/Presenter.spec.js
@@ -1,4 +1,4 @@
-const {default: Presenter} = require('./Presenter');
+import Presenter from './Presenter';
 import XDate from 'xdate';
 import {UpdateSources} from '../commons';
 import {toMarkingFormat} from '../../interface';

--- a/src/expandableCalendar/WeekCalendar/presenter.spec.js
+++ b/src/expandableCalendar/WeekCalendar/presenter.spec.js
@@ -1,5 +1,5 @@
-const {UpdateSources} = require('../commons');
-const {default: Presenter} = require('./presenter');
+import {UpdateSources} from '../commons';
+import Presenter from './presenter';
 
 describe('WeekCalendar presenter tests', () => {
   const twoDaysSameWeek = {

--- a/src/interface.spec.js
+++ b/src/interface.spec.js
@@ -1,5 +1,5 @@
-const iface = require('./interface');
-const XDate = require('xdate');
+import * as iface from './interface';
+import XDate from 'xdate';
 
 describe('calendar interface', () => {
   describe('input', () => {


### PR DESCRIPTION
- Fix eslint configuration to use `typescript-eslint/recommended` - this fix the issue where eslint consider typings as unused vars
- Fix all new errors resulted from adding the new `typescript-eslint/recommended` plugin