### PR TITLE
Using React Fragment to avoid style issue

### DIFF
--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -309,7 +309,7 @@ class Calendar extends Component<CalendarProps, CalendarState> {
 
   render() {
     const {enableSwipeMonths, style} = this.props;
-    const GestureComponent = enableSwipeMonths ? GestureRecognizer : View;
+    const GestureComponent = enableSwipeMonths ? GestureRecognizer : React.Fragment;
     const gestureProps = enableSwipeMonths ? this.swipeProps : undefined;
 
     return (


### PR DESCRIPTION
Here's one case for me:
I add styles for container view, but with a View for GestureRecognizer, my style will mess up, if we use Fragment, there will be no side effect on container.