### PR TITLE
Fix overriding hideExtraDays on ExpandableCalendar

### DIFF
--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -570,6 +570,7 @@ class ExpandableCalendar extends Component<Props, State> {
             <CalendarList
               testID="calendar"
               horizontal={horizontal}
+              hideExtraDays={!horizontal}
               {...others}
               theme={themeObject}
               ref={this.calendar}
@@ -581,7 +582,6 @@ class ExpandableCalendar extends Component<Props, State> {
               hideArrows={this.shouldHideArrows()}
               onPressArrowLeft={this.onPressArrowLeft}
               onPressArrowRight={this.onPressArrowRight}
-              hideExtraDays={!horizontal}
               renderArrow={this.renderArrow}
               staticHeader
             />


### PR DESCRIPTION
Currently, `hideExtraDays` on `ExpandableCalendar` does not change the display of extra days on the calendar, even though `hideExtraDays` is a property of `ExpandableCalendar` inherited from `Calendar`. `hideExtraDays` is always set to `false` for horizontal scroll and `true` for vertical scroll. This fixes `ExpandableCalendar` to respect `hideExtraDays` if it is explicitly set, and defaults to the currently behavior if it is not.