### PR TITLE
fix: day accessibility label localization

### DIFF
--- a/src/calendar/day/index.tsx
+++ b/src/calendar/day/index.tsx
@@ -77,15 +77,13 @@ export default class Day extends Component<DayProps> {
   }
 
   getAccessibilityLabel = memoize((day, marking, isToday) => {
+    // @ts-expect-error
     const today = XDate.locales[XDate.defaultLocale].today || 'today';
-    const formatAccessibilityLabel = XDate.locales[XDate.defaultLocale].formatAccessibilityLabel;
+    // @ts-expect-error
+    const formatAccessibilityLabel = XDate.locales[XDate.defaultLocale].formatAccessibilityLabel || 'dddd d MMMM yyyy';
     const markingLabel = this.getMarkingLabel(marking);
 
-    if (formatAccessibilityLabel) {
-      return `${isToday ? today : ''} ${day.toString(formatAccessibilityLabel)} ${markingLabel}`;
-    }
-
-    return `${isToday ? today : ''} ${day.toString('dddd d MMMM yyyy')} ${markingLabel}`;
+    return `${isToday ? today : ''} ${day.toString(formatAccessibilityLabel)} ${markingLabel}`;
   });
 
   getDayComponent() {

--- a/src/calendar/day/index.tsx
+++ b/src/calendar/day/index.tsx
@@ -1,4 +1,3 @@
-import get from 'lodash/get';
 import omit from 'lodash/omit';
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
@@ -78,15 +77,15 @@ export default class Day extends Component<DayProps> {
   }
 
   getAccessibilityLabel = memoize((day, marking, isToday) => {
-    const today = get(XDate, 'locales[XDate.defaultLocale].today');
-    const formatAccessibilityLabel = get(XDate, 'locales[XDate.defaultLocale].formatAccessibilityLabel');
+    const today = XDate.locales[XDate.defaultLocale].today || 'today';
+    const formatAccessibilityLabel = XDate.locales[XDate.defaultLocale].formatAccessibilityLabel;
     const markingLabel = this.getMarkingLabel(marking);
 
     if (formatAccessibilityLabel) {
       return `${isToday ? today : ''} ${day.toString(formatAccessibilityLabel)} ${markingLabel}`;
     }
 
-    return `${isToday ? 'today' : ''} ${day.toString('dddd d MMMM yyyy')} ${markingLabel}`;
+    return `${isToday ? today : ''} ${day.toString('dddd d MMMM yyyy')} ${markingLabel}`;
   });
 
   getDayComponent() {


### PR DESCRIPTION
Lodash get can't resolve XDate.locales[XDate.defaultLocale] because it can't retrieve the value of XDate.defaultLocale since it's used as a string and not as a value in the path parameter of the _.get method. .

This PR implements a fix to get the values natively with JS instead of using lodash. 

It also fixes the case that when the prop `formatAccessibilityLabel` is not defined, the hardcoded string 'today' is used instead of using the XDate translated value.