### PR TITLE
Agenda renders only for the first item of the day

### DIFF
--- a/src/agenda/reservation-list/reservation.tsx
+++ b/src/agenda/reservation-list/reservation.tsx
@@ -75,8 +75,8 @@ class Reservation extends Component<ReservationProps> {
   }
 
   renderDate(date?: XDate, item?: DayReservations) {
-    if (isFunction(this.props.renderDay) && date) {
-      return this.props.renderDay(date, item);
+    if (isFunction(this.props.renderDay)) {
+      return this.props.renderDay(date ? xdateToData(date) : undefined, item);
     }
 
     const today = date && isToday(date) ? this.style.today : undefined;

--- a/src/agenda/reservation-list/reservation.tsx
+++ b/src/agenda/reservation-list/reservation.tsx
@@ -19,8 +19,8 @@ export interface ReservationProps {
   theme: Theme;
   /** specify your item comparison function for increased performance */
   rowHasChanged?: (a: any, b: any) => boolean;
-  /** specify how each date should be rendered. day can be undefined if the item is not first in that day */
-  renderDay?: (date: XDate, item?: DayReservations) => React.Component;
+  /** specify how each date should be rendered. date can be undefined if the item is not first in that day */
+  renderDay?: (date?: XDate, item?: DayReservations) => React.Component;
   /** specify how each item should be rendered in agenda */
   renderItem?: (reservation: any, isFirst: boolean) => React.Component;
   /** specify how empty date content with no items should be rendered */

--- a/src/agenda/reservation-list/reservation.tsx
+++ b/src/agenda/reservation-list/reservation.tsx
@@ -5,7 +5,6 @@ import XDate from 'xdate';
 import React, {Component} from 'react';
 import {View, Text} from 'react-native';
 
-import {xdateToData} from '../../interface';
 import {isToday} from '../../dateutils';
 // @ts-expect-error
 import {RESERVATION_DATE} from '../../testIDs';
@@ -77,7 +76,7 @@ class Reservation extends Component<ReservationProps> {
 
   renderDate(date?: XDate, item?: DayReservations) {
     if (isFunction(this.props.renderDay)) {
-      return this.props.renderDay(date ? xdateToData(date) : undefined, item);
+      return this.props.renderDay(date, item);
     }
 
     const today = date && isToday(date) ? this.style.today : undefined;

--- a/src/agenda/reservation-list/reservation.tsx
+++ b/src/agenda/reservation-list/reservation.tsx
@@ -5,6 +5,7 @@ import XDate from 'xdate';
 import React, {Component} from 'react';
 import {View, Text} from 'react-native';
 
+import {xdateToData} from '../../interface';
 import {isToday} from '../../dateutils';
 // @ts-expect-error
 import {RESERVATION_DATE} from '../../testIDs';


### PR DESCRIPTION
The doc states :
`// Specify how each date should be rendered. day can be undefined if the item is not first in that day`
However, the tag 1.1269.0  has broken the behaviour and `Agenda.renderDate` is called only for the first item of the day now.