### PR TITLE
Change release process to publish snapshot versions for master commits

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,6 +21,6 @@ steps:
       npm install
       npm run test
       npm run build:ts
-      if [[ $(echo $BUILDKITE_MESSAGE | tr '[:upper:]' '[:lower:]') =~ release ]];then
+      if [[ $BUILDKITE_PULL_REQUEST == 'false' ]];then
         npm run release
       fi

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -6,11 +6,14 @@ const exec = require('shell-utils').exec;
 const cp = require('child_process');
 
 let IS_SNAPSHOT;
-if (process.env.BUILDKITE_MESSAGE.match(/^release$/i)){
+const isReleaseBuild = process.env.BUILDKITE_MESSAGE.match(/^release$/i);
+const isPRBuild = process.env.BUILDKITE_PULL_REQUEST === 'true';
+
+if (isReleaseBuild) {
   IS_SNAPSHOT = cp.execSync(`buildkite-agent meta-data get is-snapshot`).toString();
 }
 const ONLY_ON_BRANCH = 'release';
-const isSnapshotBuild = IS_SNAPSHOT === 'true';
+const isSnapshotBuild = !isPRBuild || IS_SNAPSHOT === 'true';
 const VERSION_TAG = isSnapshotBuild ? 'snapshot' : 'latest';
 const VERSION_INC = 'minor';
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -13,7 +13,7 @@ if (isReleaseBuild) {
   IS_SNAPSHOT = cp.execSync(`buildkite-agent meta-data get is-snapshot`).toString();
 }
 const ONLY_ON_BRANCH = 'release';
-const isSnapshotBuild = !isPRBuild || IS_SNAPSHOT === 'true';
+const isSnapshotBuild = (!isPRBuild && !isReleaseBuild) || IS_SNAPSHOT === 'true';
 const VERSION_TAG = isSnapshotBuild ? 'snapshot' : 'latest';
 const VERSION_INC = 'minor';
 


### PR DESCRIPTION
@Inbal-Tish 
I changed the script and the pipeline so we'll have `snapshot` version for each master build, exactly like we have in public uilib. 
Please take a look. 