### PR TITLE
Fix all components display names

### DIFF
--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -57,7 +57,7 @@ interface ReservationsListState {
 }
 
 class ReservationList extends Component<ReservationListProps, ReservationsListState> {
-  static displayName = 'IGNORE';
+  static displayName = 'ReservationList';
 
   static propTypes = {
     ...Reservation.propTypes,

--- a/src/agenda/reservation-list/reservation.tsx
+++ b/src/agenda/reservation-list/reservation.tsx
@@ -28,7 +28,7 @@ export interface ReservationProps {
 }
 
 class Reservation extends Component<ReservationProps> {
-  static displayName = 'IGNORE';
+  static displayName = 'Reservation';
 
   static propTypes = {
     item: PropTypes.any,

--- a/src/calendar-list/item.tsx
+++ b/src/calendar-list/item.tsx
@@ -10,6 +10,7 @@ import {extractComponentProps} from '../componentUpdater';
 import {formatNumbers} from '../dateutils';
 import Calendar, {CalendarProps} from '../calendar';
 import styleConstructor from './style';
+import {getCalendarDateString} from '../services';
 
 export type CalendarListItemProps = CalendarProps & {
   item: any;
@@ -26,7 +27,7 @@ type CalendarListItemState = {
 };
 
 class CalendarListItem extends Component<CalendarListItemProps, CalendarListItemState> {
-  static displayName = 'IGNORE';
+  static displayName = 'CalendarListItem';
 
   static propTypes = {
     ...Calendar.propTypes,
@@ -113,7 +114,7 @@ class CalendarListItem extends Component<CalendarListItemProps, CalendarListItem
         <Calendar
           {...calendarProps}
           testID={testID}
-          current={item}
+          current={getCalendarDateString(item.toString())}
           style={calStyle}
           headerStyle={horizontal ? headerStyle : undefined}
           disableMonthChange

--- a/src/calendar/day/basic/index.tsx
+++ b/src/calendar/day/basic/index.tsx
@@ -34,7 +34,7 @@ export interface BasicDayProps {
 }
 
 export default class BasicDay extends Component<BasicDayProps> {
-  static displayName = 'IGNORE';
+  static displayName = 'BasicDay';
 
   static propTypes = {
     state: PropTypes.oneOf(['selected', 'disabled', 'inactive', 'today', '']),

--- a/src/calendar/day/index.tsx
+++ b/src/calendar/day/index.tsx
@@ -25,7 +25,7 @@ export interface DayProps extends Omit<BasicDayProps, 'date'> {
 }
 
 export default class Day extends Component<DayProps> {
-  static displayName = 'IGNORE';
+  static displayName = 'Day';
 
   static propTypes = {
     ...basicDayPropsTypes,

--- a/src/calendar/day/marking/index.tsx
+++ b/src/calendar/day/marking/index.tsx
@@ -61,7 +61,7 @@ export interface MarkingProps extends DotProps {
 }
 
 export default class Marking extends Component<MarkingProps> {
-  static displayName = 'IGNORE';
+  static displayName = 'Marking';
 
   static markings = Markings;
   

--- a/src/calendar/day/period/index.tsx
+++ b/src/calendar/day/period/index.tsx
@@ -24,7 +24,7 @@ interface PeriodDayProps {
 }
 
 export default class PeriodDay extends Component<PeriodDayProps> {
-  static displayName = 'IGNORE';
+  static displayName = 'PeriodDay';
 
   static propTypes = {
     state: PropTypes.oneOf(['selected', 'disabled', 'inactive', 'today', '']),

--- a/src/calendar/header/index.tsx
+++ b/src/calendar/header/index.tsx
@@ -66,7 +66,7 @@ interface Props {
 export type CalendarHeaderProps = Props;
 
 class CalendarHeader extends Component<Props> {
-  static displayName = 'IGNORE';
+  static displayName = 'CalendarHeader';
 
   static propTypes = {
     theme: PropTypes.object,

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -7,7 +7,19 @@ import memoize from 'memoize-one';
 import XDate from 'xdate';
 
 import React, {Component} from 'react';
-import {AccessibilityInfo, PanResponder, Animated, View, ViewStyle, Text, Image, ImageSourcePropType, PanResponderInstance, GestureResponderEvent, PanResponderGestureState} from 'react-native';
+import {
+  AccessibilityInfo,
+  PanResponder,
+  Animated,
+  View,
+  ViewStyle,
+  Text,
+  Image,
+  ImageSourcePropType,
+  PanResponderInstance,
+  GestureResponderEvent,
+  PanResponderGestureState
+} from 'react-native';
 
 // @ts-expect-error
 import {CALENDAR_KNOB} from '../testIDs';
@@ -20,7 +32,6 @@ import Calendar from '../calendar';
 import asCalendarConsumer from './asCalendarConsumer';
 import WeekCalendar from './WeekCalendar';
 import Week from './week';
-
 
 const commons = require('./commons');
 const updateSources = commons.UpdateSources;
@@ -37,7 +48,6 @@ const DAY_NAMES_PADDING = 24;
 const PAN_GESTURE_THRESHOLD = 30;
 const LEFT_ARROW = require('../calendar/img/previous.png');
 const RIGHT_ARROW = require('../calendar/img/next.png');
-
 
 export interface Props extends CalendarListProps {
   /** the initial position of the calendar ('open' or 'closed') */
@@ -131,7 +141,7 @@ class ExpandableCalendar extends Component<Props, State> {
   _height: number;
   _wrapperStyles: {
     style: ViewStyle;
-  }
+  };
   _headerStyles: {
     style: ViewStyle;
   };
@@ -140,7 +150,7 @@ class ExpandableCalendar extends Component<Props, State> {
   };
   visibleMonth: number;
   visibleYear: number | undefined;
-  initialDate: XDate;
+  initialDate: string;
   headerStyleOverride: Theme;
   header: React.RefObject<any> = React.createRef();
   wrapper: React.RefObject<any> = React.createRef();
@@ -149,7 +159,7 @@ class ExpandableCalendar extends Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    
+
     this.closedHeight = CLOSED_HEIGHT + (props.hideKnob ? 0 : KNOB_CONTAINER_HEIGHT);
     this.numberOfWeeks = this.getNumberOfWeeksInMonth(new XDate(this.props.context.date));
     this.openHeight = this.getOpenHeight();
@@ -162,7 +172,7 @@ class ExpandableCalendar extends Component<Props, State> {
 
     this.visibleMonth = this.getMonth(this.props.context.date);
     this.visibleYear = this.getYear(this.props.context.date);
-    this.initialDate = new XDate(props.context.date); // should be set only once!!!
+    this.initialDate = props.context.date;
     this.headerStyleOverride = {
       stylesheet: {
         calendar: {
@@ -218,7 +228,7 @@ class ExpandableCalendar extends Component<Props, State> {
 
   updateNativeStyles() {
     this.wrapper?.current?.setNativeProps(this._wrapperStyles);
-    
+
     if (!this.props.horizontal) {
       this.header?.current?.setNativeProps(this._headerStyles);
     } else {
@@ -508,7 +518,7 @@ class ExpandableCalendar extends Component<Props, State> {
     const {disableWeekScroll} = this.props;
     const WeekComponent = disableWeekScroll ? Week : WeekCalendar;
     const weekCalendarProps = disableWeekScroll ? undefined : {allowShadow: false};
-    
+
     return (
       <Animated.View
         ref={this.weekCalendar}
@@ -579,7 +589,6 @@ class ExpandableCalendar extends Component<Props, State> {
               {...others}
               theme={themeObject}
               ref={this.calendar}
-              // @ts-expect-error should be converted to string
               current={this.initialDate}
               onDayPress={this.onDayPress}
               onVisibleMonthsChange={this.onVisibleMonthsChange}

--- a/src/expandableCalendar/week.tsx
+++ b/src/expandableCalendar/week.tsx
@@ -20,7 +20,7 @@ export type WeekProps = Props;
 
 
 class Week extends PureComponent<Props> {
-  static displayName = 'IGNORE';
+  static displayName = 'Week';
 
   static propTypes = {
     ...Calendar.propTypes,


### PR DESCRIPTION
All of the internal components' display names were set to `IGNORE`
I assume it's because of private uilib docs. 

Anyway, apparently this affected the call stack of errors, so when there was an error coming from a component with IGNORE display name, it was mention as `IGNORE` and that makes it difficult to investigate issues. 

I also fixed the followings
- There was a type error coming from ExpandableCalender related to the `current` prop. You can see it in the packager when you open the relevant example screen.
I fixed the type of the value we pass to current in ExpandableCalendar
- Also in CalendarList component, I converted the date item we have there back to string before we pass it to the Calendar component

