### PR TITLE
Publish git tags only for official releae versions

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -101,8 +101,10 @@ function tagAndPublish(newVersion) {
   console.log(`trying to publish ${newVersion}...`);
   exec.execSync(`npm --no-git-tag-version --allow-same-version version ${newVersion}`);
   exec.execSyncRead(`npm publish --tag ${VERSION_TAG}`);
-  exec.execSync(`git tag -a ${newVersion} -m "${newVersion}"`);
-  exec.execSyncSilent(`git push deploy ${newVersion} || true`);
+  if (isReleaseBuild && !IS_SNAPSHOT) {
+    exec.execSync(`git tag -a ${newVersion} -m "${newVersion}"`);
+    exec.execSyncSilent(`git push deploy ${newVersion} || true`);
+  }
 }
 
 run();


### PR DESCRIPTION
Currently every published version (snapshot or official release) is tagged in git in [here](https://github.com/wix/react-native-calendars/tags)
This will fix it and tag only the official release versions. 

From now own, let's use these release tags for release notes instead of changelog file we have today

I added an example for the latest release
https://github.com/wix/react-native-calendars/releases/tag/1.1272.0