### PR TITLE
Modify style of agenda calendar's scrollView

### DIFF
--- a/src/agenda/index.tsx
+++ b/src/agenda/index.tsx
@@ -466,7 +466,6 @@ export default class Agenda extends Component<AgendaProps, State> {
     const scrollPadStyle = {
       height: KNOB_HEIGHT,
       top: scrollPadPosition,
-      left: (this.viewWidth - 80) / 2
     };
 
     return (

--- a/src/agenda/style.ts
+++ b/src/agenda/style.ts
@@ -49,7 +49,8 @@ export default function styleConstructor(theme: Theme = {}) {
     },
     scrollPadStyle: {
       position: 'absolute',
-      width: 80
+      width: '100%',
+      alignSelf: 'center'
     },
     // @ts-expect-error
     ...(theme['stylesheet.agenda.main'] || {})


### PR DESCRIPTION
### Description
This PR addresses: #1653
Make touchable area of agenda calendar's knob full-width. Confirmed all other calendars(Expandable, Timeline calendar) had the full-width knob by default. So this PR makes the Agenda calendar's knob's behavior aligned to the others.   

### Changes
Modify Agenda component's style in `Animated.ScrollView`.

### Gif
<image src="https://user-images.githubusercontent.com/44686790/147300120-95fb982b-6cc3-4369-ac8f-654999238f88.gif" width ="250" height="550">

<image src="https://user-images.githubusercontent.com/44686790/147300132-f826f432-0038-4bbb-8d26-b3da86308fab.gif" width ="250" height="550">




