### PR TITLE
Convert HorizontalList to InfiniteList

### DIFF
--- a/src/infinite-list/index.tsx
+++ b/src/infinite-list/index.tsx
@@ -3,31 +3,24 @@ import React, {forwardRef, useCallback, useMemo, useRef} from 'react';
 import {DataProvider, LayoutProvider, RecyclerListView, RecyclerListViewProps} from 'recyclerlistview';
 import constants from '../commons/constants';
 
-const layoutProvider = new LayoutProvider(
-  () => 'page',
-  (_type, dim) => {
-    dim.width = constants.screenWidth;
-    dim.height = constants.screenHeight;
-  }
-);
+const dataProviderMaker = (items: string[]) => new DataProvider((item1, item2) => item1 !== item2).cloneWithRows(items);
 
-const dataProviderMaker = (items: string[]) =>
-  new DataProvider((item1, item2) => item1.value !== item2.value || item1.label !== item2.label).cloneWithRows(items);
-
-export interface HorizontalListProps
+export interface InfiniteListProps
   extends Omit<RecyclerListViewProps, 'dataProvider' | 'layoutProvider' | 'rowRenderer'> {
   data: any[];
   renderItem: RecyclerListViewProps['rowRenderer'];
   pageWidth?: number;
+  pageHeight?: number;
   onPageChange?: (pageIndex: number, prevPageIndex: number) => void;
   initialPageIndex?: number;
 }
 
-const HorizontalList = (props: HorizontalListProps, ref: any) => {
+const InfiniteList = (props: InfiniteListProps, ref: any) => {
   const {
     renderItem,
     data,
     pageWidth = constants.screenWidth,
+    pageHeight = constants.screenHeight, 
     onPageChange,
     initialPageIndex = 0,
     extendedState,
@@ -36,6 +29,16 @@ const HorizontalList = (props: HorizontalListProps, ref: any) => {
   const dataProvider = useMemo(() => {
     return dataProviderMaker(data);
   }, [data]);
+
+  const layoutProvider = useRef(
+    new LayoutProvider(
+      () => 'page',
+      (_type, dim) => {
+        dim.width = pageWidth;
+        dim.height = pageHeight;
+      }
+    )
+  );
 
   const pageIndex = useRef<number>();
 
@@ -61,7 +64,7 @@ const HorizontalList = (props: HorizontalListProps, ref: any) => {
       isHorizontal
       rowRenderer={renderItem}
       dataProvider={dataProvider}
-      layoutProvider={layoutProvider}
+      layoutProvider={layoutProvider.current}
       extendedState={extendedState}
       initialRenderIndex={initialPageIndex}
       renderAheadOffset={5 * pageWidth}
@@ -75,4 +78,4 @@ const HorizontalList = (props: HorizontalListProps, ref: any) => {
   );
 };
 
-export default forwardRef(HorizontalList);
+export default forwardRef(InfiniteList);

--- a/src/infinite-list/index.tsx
+++ b/src/infinite-list/index.tsx
@@ -17,7 +17,7 @@ export interface InfiniteListProps
   onPageChange?: (pageIndex: number, prevPageIndex: number) => void;
   onReachEdge?: (pageIndex: number) => void;
   onReachNearEdge?: (pageIndex: number) => void;
-  nearEdgeThreshold?: number;
+  onReachNearEdgeThreshold?: number;
   initialPageIndex?: number;
   scrollViewProps?: ScrollViewProps;
 }
@@ -31,7 +31,7 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
     onPageChange,
     onReachEdge,
     onReachNearEdge,
-    nearEdgeThreshold,
+    onReachNearEdgeThreshold,
     initialPageIndex = 0,
     extendedState,
     scrollViewProps
@@ -67,7 +67,7 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
 
           if (newPageIndex === 0 || newPageIndex === data.length - 1) {
             isOnEdge.current = true;
-          } else if (nearEdgeThreshold && !inRange(newPageIndex, nearEdgeThreshold, data.length - nearEdgeThreshold)) {
+          } else if (onReachNearEdgeThreshold && !inRange(newPageIndex, onReachNearEdgeThreshold, data.length - onReachNearEdgeThreshold)) {
             isNearEdge.current = true;
           }
         }

--- a/src/timeline-list/index.tsx
+++ b/src/timeline-list/index.tsx
@@ -7,7 +7,7 @@ import Context from '../expandableCalendar/Context';
 import {UpdateSources} from '../expandableCalendar/commons';
 import Timeline, {TimelineProps} from '../timeline/Timeline';
 import InfiniteList from '../infinite-list';
-import useTimelinePages, {INITIAL_PAGE} from './useTimelinePages';
+import useTimelinePages, {INITIAL_PAGE, NEAR_EDGE_THRESHOLD} from './useTimelinePages';
 
 export interface TimelineListProps {
   events: {[date: string]: TimelineProps['events']};
@@ -65,14 +65,14 @@ const TimelineList = (props: TimelineListProps) => {
       const newDate = pagesRef.current[pageIndex];
       if (newDate !== prevDate.current) {
         setDate(newDate, UpdateSources.LIST_DRAG);
-
-        if (isNearEdges(pageIndex)) {
-          shouldResetPages.current = isNearEdges(pageIndex);
-        }
       }
     }, 0),
     []
   );
+
+  const onReachNearEdge = useCallback(() => {
+    shouldResetPages.current = true;
+  }, []);
 
   const onTimelineOffsetChange = useCallback(offset => {
     setTimelineOffset(offset);
@@ -109,6 +109,8 @@ const TimelineList = (props: TimelineListProps) => {
       data={pages}
       renderItem={renderPage}
       onPageChange={onPageChange}
+      onReachNearEdge={onReachNearEdge}
+      nearEdgeThreshold={NEAR_EDGE_THRESHOLD}
       onScroll={onScroll}
       extendedState={{todayEvents: events[date], pages}}
       initialPageIndex={INITIAL_PAGE}

--- a/src/timeline-list/index.tsx
+++ b/src/timeline-list/index.tsx
@@ -1,6 +1,5 @@
 import React, {useCallback, useContext, useEffect, useRef, useState} from 'react';
 // import {Text} from 'react-native';
-import identity from 'lodash/identity';
 import throttle from 'lodash/throttle';
 
 import Context from '../expandableCalendar/Context';
@@ -29,7 +28,6 @@ const TimelineList = (props: TimelineListProps) => {
     scrollToPageDebounce,
     shouldResetPages,
     isOutOfRange,
-    isNearEdges
   } = useTimelinePages({date, listRef});
 
   useEffect(() => {
@@ -115,7 +113,6 @@ const TimelineList = (props: TimelineListProps) => {
       extendedState={{todayEvents: events[date], pages}}
       initialPageIndex={INITIAL_PAGE}
       scrollViewProps={{
-        keyExtractor: identity,
         onMomentumScrollEnd
       }}
     />

--- a/src/timeline-list/index.tsx
+++ b/src/timeline-list/index.tsx
@@ -6,7 +6,7 @@ import throttle from 'lodash/throttle';
 import Context from '../expandableCalendar/Context';
 import {UpdateSources} from '../expandableCalendar/commons';
 import Timeline, {TimelineProps} from '../timeline/Timeline';
-import HorizontalList from './HorizontalList';
+import InfiniteList from '../infinite-list';
 import useTimelinePages, {INITIAL_PAGE} from './useTimelinePages';
 
 export interface TimelineListProps {
@@ -104,7 +104,7 @@ const TimelineList = (props: TimelineListProps) => {
   );
 
   return (
-    <HorizontalList
+    <InfiniteList
       ref={listRef}
       data={pages}
       renderItem={renderPage}

--- a/src/timeline-list/index.tsx
+++ b/src/timeline-list/index.tsx
@@ -108,7 +108,7 @@ const TimelineList = (props: TimelineListProps) => {
       renderItem={renderPage}
       onPageChange={onPageChange}
       onReachNearEdge={onReachNearEdge}
-      nearEdgeThreshold={NEAR_EDGE_THRESHOLD}
+      onReachNearEdgeThreshold={NEAR_EDGE_THRESHOLD}
       onScroll={onScroll}
       extendedState={{todayEvents: events[date], pages}}
       initialPageIndex={INITIAL_PAGE}

--- a/src/timeline-list/useTimelinePages.ts
+++ b/src/timeline-list/useTimelinePages.ts
@@ -7,7 +7,7 @@ import debounce from 'lodash/debounce';
 import constants from '../commons/constants';
 import {generateDay} from '../dateutils';
 
-const PAGES_COUNT = 30;
+const PAGES_COUNT = 100;
 export const NEAR_EDGE_THRESHOLD = 10;
 export const INITIAL_PAGE = Math.floor(PAGES_COUNT / 2);
 

--- a/src/timeline-list/useTimelinePages.ts
+++ b/src/timeline-list/useTimelinePages.ts
@@ -7,8 +7,8 @@ import debounce from 'lodash/debounce';
 import constants from '../commons/constants';
 import {generateDay} from '../dateutils';
 
-const PAGES_COUNT = 100;
-const NEAR_EDGE_THRESHOLD = 10;
+const PAGES_COUNT = 30;
+export const NEAR_EDGE_THRESHOLD = 10;
 export const INITIAL_PAGE = Math.floor(PAGES_COUNT / 2);
 
 


### PR DESCRIPTION
- I renamed HorizontalList to InfiniteList and moved it out of timeline-list folder so it'll be a common component for all other components to use. 
- I made the component more dynamic so it can now accept pageWidth and pageHeight for different types of pages
- I added APIs for onReachEdge and onReachNearEdge since it's a logic that is needed in all cases (instead of each component to calculate that)
