### PR TITLE
fix type import error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,5 +18,5 @@ export {default as Timeline} from './timeline/Timeline';
 export type {TimelineProps, TimelineEventProps, TimelinePackedEventProps} from './timeline/Timeline';
 export {default as TimelineList} from './timeline-list';
 export {default as CalendarUtils} from './services';
-export {DateData, AgendaEntry, AgendaSchedule} from './types';
+export type {DateData, AgendaEntry, AgendaSchedule} from './types';
 export {default as LocaleConfig} from 'xdate';


### PR DESCRIPTION
follow up #1745 and fix the remaining type import error reported in [comment](https://github.com/wix/react-native-calendars/issues/1686#issuecomment-1013966402)