### PR TITLE
Remove comments from old PropTypes

### DIFF
--- a/src/agenda/index.tsx
+++ b/src/agenda/index.tsx
@@ -32,10 +32,6 @@ const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
 
 export type AgendaProps = CalendarListProps & ReservationListProps & {
-  /** the list of items that have to be displayed in agenda. If you want to render item as empty date
-   the value of date key has to be an empty array []. If there exists no value for date key it is
-   considered that the date in question is not yet loaded */
-  items?: AgendaSchedule;
   /** callback that gets called when items for a certain month should be loaded (month became visible) */
   loadItemsForMonth?: (data: DateData) => void;
   /** callback that fires when the calendar is opened or closed */
@@ -45,10 +41,10 @@ export type AgendaProps = CalendarListProps & ReservationListProps & {
   /** specify how agenda knob should look like */
   renderKnob?: () => JSX.Element;
   /** initially selected day */
-  selected?: string; //TODO: Should be renamed 'selectedDay'
+  selected?: string; //TODO: Should be renamed 'selectedDay' and inherited from ReservationList
   /** Hide knob button. Default = false */
   hideKnob?: boolean;
-  /** When `true` and `hideKnob` prop is `false`, the knob will always be visible and the user will be able to drag the knob up and close the calendar. Default = false */
+  /** Whether the knob should always be visible (when hideKnob = false) */
   showClosingKnob?: boolean;
 }
 
@@ -74,25 +70,14 @@ export default class Agenda extends Component<AgendaProps, State> {
   static propTypes = {
     ...CalendarList.propTypes,
     ...ReservationList.propTypes,
-    /** agenda container style */
     style: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.number]),
-    /** the list of items that have to be displayed in agenda. If you want to render item as empty date
-     the value of date key has to be an empty array []. If there exists no value for date key it is
-     considered that the date in question is not yet loaded */
     items: PropTypes.object,
-    /** callback that gets called when items for a certain month should be loaded (month became visible) */
     loadItemsForMonth: PropTypes.func,
-    /** callback that fires when the calendar is opened or closed */
     onCalendarToggled: PropTypes.func,
-    /** callback that gets called when day changes while scrolling agenda list */
     onDayChange: PropTypes.func,
-    /** specify how agenda knob should look like */
     renderKnob: PropTypes.func,
-    /** initially selected day */
-    selected: PropTypes.any, //TODO: Should be renamed 'selectedDay'
-    /** Hide knob button. Default = false */
+    selected: PropTypes.any, //TODO: Should be renamed 'selectedDay' and inherited from ReservationList
     hideKnob: PropTypes.bool,
-    /** When `true` and `hideKnob` prop is `false`, the knob will always be visible and the user will be able to drag the knob up and close the calendar. Default = false */
     showClosingKnob: PropTypes.bool
   };
 

--- a/src/agenda/index.tsx
+++ b/src/agenda/index.tsx
@@ -23,7 +23,6 @@ import {VelocityTracker} from '../velocityTracker';
 import {DateData} from '../types';
 import {getCalendarDateString} from '../services';
 import styleConstructor from './style';
-import {AgendaSchedule} from '../types';
 import CalendarList, {CalendarListProps} from '../calendar-list';
 import ReservationList, {ReservationListProps}  from './reservation-list';
 

--- a/src/agenda/index.tsx
+++ b/src/agenda/index.tsx
@@ -131,7 +131,7 @@ export default class Agenda extends Component<AgendaProps, State> {
   }
 
   componentDidUpdate(prevProps: AgendaProps) {
-    if (this.props.selected && !sameDate(parseDate(this.props.selected), parseDate(prevProps.selected))) {
+    if (!sameDate(parseDate(this.props.selected), parseDate(prevProps.selected))) {
       this.setState({selectedDay: parseDate(this.props.selected)});
     } else if (!prevProps.items) {
       this.loadReservations(this.props);

--- a/src/agenda/index.tsx
+++ b/src/agenda/index.tsx
@@ -20,7 +20,7 @@ import {weekDayNames, sameDate, sameMonth} from '../dateutils';
 // @ts-expect-error
 import {AGENDA_CALENDAR_KNOB} from '../testIDs';
 import {VelocityTracker} from '../velocityTracker';
-import {DateData} from '../types';
+import {DateData, AgendaSchedule} from '../types';
 import {getCalendarDateString} from '../services';
 import styleConstructor from './style';
 import CalendarList, {CalendarListProps} from '../calendar-list';
@@ -31,6 +31,10 @@ const HEADER_HEIGHT = 104;
 const KNOB_HEIGHT = 24;
 
 export type AgendaProps = CalendarListProps & ReservationListProps & {
+  /** the list of items that have to be displayed in agenda. If you want to render item as empty date
+  the value of date key kas to be an empty array []. If there exists no value for date key it is
+  considered that the date in question is not yet loaded */
+  items?: AgendaSchedule;
   /** callback that gets called when items for a certain month should be loaded (month became visible) */
   loadItemsForMonth?: (data: DateData) => void;
   /** callback that fires when the calendar is opened or closed */
@@ -69,8 +73,8 @@ export default class Agenda extends Component<AgendaProps, State> {
   static propTypes = {
     ...CalendarList.propTypes,
     ...ReservationList.propTypes,
-    style: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.number]),
     items: PropTypes.object,
+    style: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.number]),
     loadItemsForMonth: PropTypes.func,
     onCalendarToggled: PropTypes.func,
     onDayChange: PropTypes.func,

--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -28,7 +28,7 @@ export type ReservationListProps = ReservationProps & {
   renderEmptyData?: () => JSX.Element;
   style?: StyleProp<ViewStyle>;
 
-  /** onScroll ListView event */
+  /** onScroll FlatList event */
   onScroll?: (yOffset: number) => void;
   /** Called when the user begins dragging the agenda list **/
   onScrollBeginDrag?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
@@ -60,34 +60,21 @@ class ReservationList extends Component<ReservationListProps, State> {
 
   static propTypes = {
     ...Reservation.propTypes,
-    /** the list of items that have to be displayed in agenda. If you want to render item as empty date
-    the value of date key kas to be an empty array []. If there exists no value for date key it is
-    considered that the date in question is not yet loaded */
     items: PropTypes.object,
     selectedDay: PropTypes.instanceOf(XDate),
     topDay: PropTypes.instanceOf(XDate),
-    /** Show items only for the selected date. Default = false */
-    showOnlySelectedDayItems: PropTypes.bool,
-    /** callback that gets called when day changes while scrolling agenda list */
     onDayChange: PropTypes.func,
-    /** specify what should be rendered instead of ActivityIndicator */
+    
+    showOnlySelectedDayItems: PropTypes.bool,
     renderEmptyData: PropTypes.func,
 
-    /** onScroll ListView event */
     onScroll: PropTypes.func,
-    /** Called when the user begins dragging the agenda list **/
     onScrollBeginDrag: PropTypes.func,
-    /** Called when the user stops dragging the agenda list **/
     onScrollEndDrag: PropTypes.func,
-    /** Called when the momentum scroll starts for the agenda list **/
     onMomentumScrollBegin: PropTypes.func,
-    /** Called when the momentum scroll stops for the agenda list **/
     onMomentumScrollEnd: PropTypes.func,
-    /** A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView */
     refreshControl: PropTypes.element,
-    /** Set this true while waiting for new data from a refresh */
     refreshing: PropTypes.bool,
-    /** If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the refreshing prop correctly */
     onRefresh: PropTypes.func
   };
   

--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -128,7 +128,7 @@ class ReservationList extends Component<ReservationListProps, State> {
     const {selectedDay} = props;
     const reservations = this.getReservations(props);
     
-    if (this.list && selectedDay && this.selectedDay && !sameDate(selectedDay, this.selectedDay)) {
+    if (this.list && !sameDate(selectedDay, this.selectedDay)) {
       let scrollPosition = 0;
       for (let i = 0; i < reservations.scrollPosition; i++) {
         scrollPosition += this.heights[i] || 0;
@@ -228,8 +228,7 @@ class ReservationList extends Component<ReservationListProps, State> {
 
     const day = row.date;
     if (day) {
-      const dateIsSame = this.selectedDay && sameDate(day, this.selectedDay);
-      if (!dateIsSame && this.scrollOver) {
+      if (!sameDate(day, this.selectedDay) && this.scrollOver) {
         this.selectedDay = day.clone();
         this.props.onDayChange?.(day.clone());
       }

--- a/src/agenda/reservation-list/reservation.tsx
+++ b/src/agenda/reservation-list/reservation.tsx
@@ -6,6 +6,7 @@ import React, {Component} from 'react';
 import {View, Text} from 'react-native';
 
 import {isToday} from '../../dateutils';
+import {getDefaultLocale} from '../../services';
 // @ts-expect-error
 import {RESERVATION_DATE} from '../../testIDs';
 import styleConstructor from './style';
@@ -79,7 +80,7 @@ class Reservation extends Component<ReservationProps> {
     }
 
     const today = date && isToday(date) ? this.style.today : undefined;
-    const dayNames = XDate.locales[XDate.defaultLocale].dayNamesShort;
+    const dayNames = getDefaultLocale().dayNamesShort;
 
     if (date) {
       return (

--- a/src/agenda/reservation-list/reservation.tsx
+++ b/src/agenda/reservation-list/reservation.tsx
@@ -33,15 +33,10 @@ class Reservation extends Component<ReservationProps> {
   static propTypes = {
     date: PropTypes.any,
     item: PropTypes.any,
-    /** Specify theme properties to override specific styles for item's parts. Default = {} */
     theme: PropTypes.object,
-    /** specify your item comparison function for increased performance */
     rowHasChanged: PropTypes.func,
-    /** specify how each date should be rendered. day can be undefined if the item is not first in that day */
     renderDay: PropTypes.func,
-    /** specify how each item should be rendered in agenda */
     renderItem: PropTypes.func,
-    /** specify how empty date content with no items should be rendered */
     renderEmptyDate: PropTypes.func
   };
 

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -81,37 +81,21 @@ class CalendarList extends Component<CalendarListProps, State> {
 
   static propTypes = {
     ...Calendar.propTypes,
-    /** Max amount of months allowed to scroll to the past. Default = 50 */
     pastScrollRange: PropTypes.number,
-    /** Max amount of months allowed to scroll to the future. Default = 50 */
     futureScrollRange: PropTypes.number,
-    /** Used when calendar scroll is horizontal, default is device width, pagination should be disabled */
     calendarWidth: PropTypes.number,
-    /** Dynamic calendar height */
     calendarHeight: PropTypes.number,
-    /** Style for the List item (the calendar) */
     calendarStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
-    /** Whether to use static header that will not scroll with the list (horizontal only) */
     staticHeader: PropTypes.bool,
-    /** Enable or disable vertical / horizontal scroll indicator. Default = false */
     showScrollIndicator: PropTypes.bool,
-    /** Whether to animate the auto month scroll */
     animateScroll: PropTypes.bool,
-    /** Enable or disable scrolling of calendar list */
     scrollEnabled: PropTypes.bool,
-    /** When true, the calendar list scrolls to top when the status bar is tapped. Default = true */
     scrollsToTop: PropTypes.bool,
-    /** Enable or disable paging on scroll */
     pagingEnabled: PropTypes.bool,
-    /** Whether the scroll is horizontal */
     horizontal: PropTypes.bool,
-    /** Should Keyboard persist taps */
     keyboardShouldPersistTaps: PropTypes.oneOf(['never', 'always', 'handled']),
-    /** A custom key extractor for the generated calendar months */
     keyExtractor: PropTypes.func,
-    /** How far from the end to trigger the onEndReached callback */
     onEndReachedThreshold: PropTypes.number,
-    /** Called once when the scroll position gets within onEndReachedThreshold */
     onEndReached: PropTypes.func
   };
 

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -6,7 +6,7 @@ import {FlatList, Platform, Dimensions, View, ViewStyle, LayoutChangeEvent, Flat
 
 import {extractComponentProps} from '../componentUpdater';
 import {xdateToData, parseDate} from '../interface';
-import {page, sameDate} from '../dateutils';
+import {page, sameDate, sameMonth} from '../dateutils';
 // @ts-expect-error
 import {STATIC_HEADER} from '../testIDs';
 import styleConstructor from './style';
@@ -234,7 +234,7 @@ class CalendarList extends Component<CalendarListProps, State> {
   };
 
   updateMonth(day: XDate) {
-    if (day.toString('yyyy MM') === this.state.currentMonth.toString('yyyy MM')) {
+    if (sameMonth(day, this.state.currentMonth)) {
       return;
     }
 

--- a/src/calendar-list/item.tsx
+++ b/src/calendar-list/item.tsx
@@ -7,7 +7,7 @@ import {Text, View} from 'react-native';
 
 import {Theme} from '../types';
 import {extractComponentProps} from '../componentUpdater';
-import {formatNumbers} from '../dateutils';
+import {formatNumbers, sameMonth} from '../dateutils';
 import Calendar, {CalendarProps} from '../calendar';
 import styleConstructor from './style';
 import {getCalendarDateString} from '../services';
@@ -54,7 +54,7 @@ class CalendarListItem extends Component<CalendarListItemProps, CalendarListItem
     const r1 = this.props.item;
     const r2 = nextProps.item;
 
-    return r1.toString('yyyy MM') !== r2.toString('yyyy MM') || !!(r2.propBump && r2.propBump !== r1.propBump);
+    return !sameMonth(r1, r2) || !!(r2.propBump && r2.propBump !== r1.propBump);
   }
 
   onPressArrowLeft = (_: any, month: any) => {

--- a/src/calendar/day/basic/index.tsx
+++ b/src/calendar/day/basic/index.tsx
@@ -23,10 +23,12 @@ export interface BasicDayProps {
   onLongPress?: (date?: DateData) => void;
   /** The date to return from press callbacks */
   date?: DateData;
+
   /** Disable all touch events for disabled days. can be override with disableTouchEvent in markedDates*/
   disableAllTouchEventsForDisabledDays?: boolean;
   /** Disable all touch events for inactive days. can be override with disableTouchEvent in markedDates*/
   disableAllTouchEventsForInactiveDays?: boolean;
+  
   /** Test ID*/
   testID?: string;
   /** Accessibility label */
@@ -38,21 +40,13 @@ export default class BasicDay extends Component<BasicDayProps> {
 
   static propTypes = {
     state: PropTypes.oneOf(['selected', 'disabled', 'inactive', 'today', '']),
-    /** The marking object */
     marking: PropTypes.any,
-    /** Date marking style [simple/period/multi-dot/multi-period]. Default = 'simple' */
     markingType: PropTypes.oneOf(values(Marking.markings)),
-    /** Theme object */
     theme: PropTypes.object,
-    /** onPress callback */
     onPress: PropTypes.func,
-    /** onLongPress callback */
     onLongPress: PropTypes.func,
-    /** The date to return from press callbacks */
     date: PropTypes.object,
-    /** Disable all touch events for disabled days. Can be override with disableTouchEvent in markedDates*/
     disableAllTouchEventsForDisabledDays: PropTypes.bool,
-    /** Disable all touch events for inactive days. can be override with disableTouchEvent in markedDates*/
     disableAllTouchEventsForInactiveDays: PropTypes.bool
 
   };

--- a/src/calendar/day/index.tsx
+++ b/src/calendar/day/index.tsx
@@ -8,6 +8,7 @@ import React, {Component} from 'react';
 import {shouldUpdate} from '../../componentUpdater';
 import {formatNumbers, isToday} from '../../dateutils';
 import {xdateToData} from '../../interface';
+import {getDefaultLocale} from '../../services';
 // @ts-expect-error
 import {SELECT_DATE_SLOT} from '../../testIDs';
 import BasicDay, {BasicDayProps} from './basic';
@@ -76,10 +77,8 @@ export default class Day extends Component<DayProps> {
   }
 
   getAccessibilityLabel = memoize((day, marking, isToday) => {
-    // @ts-expect-error
-    const today = XDate.locales[XDate.defaultLocale].today || 'today';
-    // @ts-expect-error
-    const formatAccessibilityLabel = XDate.locales[XDate.defaultLocale].formatAccessibilityLabel || 'dddd d MMMM yyyy';
+    const today = getDefaultLocale().today || 'today';
+    const formatAccessibilityLabel = getDefaultLocale().formatAccessibilityLabel || 'dddd d MMMM yyyy';
     const markingLabel = this.getMarkingLabel(marking);
 
     return `${isToday ? today : ''} ${day.toString(formatAccessibilityLabel)} ${markingLabel}`;
@@ -109,7 +108,7 @@ export default class Day extends Component<DayProps> {
         testID={`${SELECT_DATE_SLOT}-${date?.dateString}`}
         accessibilityLabel={accessibilityLabel}
       >
-        {formatNumbers(date ? day?.getDate() : day)}
+        {formatNumbers(day?.getDate())}
       </Component>
     );
   }

--- a/src/calendar/day/index.tsx
+++ b/src/calendar/day/index.tsx
@@ -29,9 +29,7 @@ export default class Day extends Component<DayProps> {
 
   static propTypes = {
     ...basicDayPropsTypes,
-    /** The day to render */
     day: PropTypes.object,
-    /** Provide custom day rendering component */
     dayComponent: PropTypes.any
   };
 

--- a/src/calendar/header/index.tsx
+++ b/src/calendar/header/index.tsx
@@ -17,7 +17,7 @@ import {
   ColorValue
 } from 'react-native';
 import {shouldUpdate} from '../../componentUpdater';
-import {formatNumbers, weekDayNames} from '../../dateutils';
+import {formatNumbers, weekDayNames, sameMonth} from '../../dateutils';
 import {
   CHANGE_MONTH_LEFT_ARROW,
   CHANGE_MONTH_RIGHT_ARROW,
@@ -111,7 +111,7 @@ class CalendarHeader extends Component<CalendarHeaderProps> {
   }
 
   shouldComponentUpdate(nextProps: CalendarHeaderProps) {
-    if (nextProps.month?.toString('yyyy MM') !== this.props.month?.toString('yyyy MM')) {
+    if (!sameMonth(nextProps.month, this.props.month)) {
       return true;
     }
     return shouldUpdate(this.props, nextProps, [

--- a/src/calendar/header/index.tsx
+++ b/src/calendar/header/index.tsx
@@ -30,12 +30,17 @@ import styleConstructor from './style';
 import {Theme, Direction} from '../../types';
 
 export interface CalendarHeaderProps {
-  theme?: Theme;
-  firstDay?: number;
-  displayLoadingIndicator?: boolean;
-  showWeekNumbers?: boolean;
   month?: XDate;
   addMonth?: (num: number) => void;
+
+  /** Specify theme properties to override specific styles for calendar parts */
+  theme?: Theme;
+  /** If firstDay=1 week starts from Monday. Note that dayNames and dayNamesShort should still start from Sunday */
+  firstDay?: number;
+  /** Display loading indicator. Default = false */
+  displayLoadingIndicator?: boolean;
+  /** Show week numbers. Default = false */
+  showWeekNumbers?: boolean;
   /** Month format in the title. Formatting values: http://arshaw.com/xdate/#Formatting */
   monthFormat?: string;
   /**  Hide day names */
@@ -45,9 +50,9 @@ export interface CalendarHeaderProps {
   /** Replace default arrows with custom ones (direction can be 'left' or 'right') */
   renderArrow?: (direction: Direction) => ReactNode;
   /** Handler which gets executed when press arrow icon left. It receive a callback can go back month */
-  onPressArrowLeft?: (method: () => void, month?: XDate) => void;
+  onPressArrowLeft?: (method: () => void, month?: XDate) => void; //TODO: replace with string
   /** Handler which gets executed when press arrow icon right. It receive a callback can go next month */
-  onPressArrowRight?: (method: () => void, month?: XDate) => void;
+  onPressArrowRight?: (method: () => void, month?: XDate) => void; //TODO: replace with string
   /** Disable left arrow */
   disableArrowLeft?: boolean;
   /** Disable right arrow */
@@ -55,9 +60,10 @@ export interface CalendarHeaderProps {
   /** Apply custom disable color to selected day indexes */
   disabledDaysIndexes?: number[];
   /** Replace default title with custom one. the function receive a date as parameter */
-  renderHeader?: (date?: XDate) => ReactNode;
+  renderHeader?: (date?: XDate) => ReactNode; //TODO: replace with string
   /** Replace default title with custom element */
   customHeaderTitle?: JSX.Element;
+  
   /** Provide aria-level for calendar heading for proper accessibility when used with web (react-native-web) */
   webAriaLevel?: number;
   testID?: string;
@@ -70,35 +76,25 @@ class CalendarHeader extends Component<CalendarHeaderProps> {
   static displayName = 'CalendarHeader';
 
   static propTypes = {
+    month: PropTypes.instanceOf(XDate),
+    addMonth: PropTypes.func,
+
     theme: PropTypes.object,
     firstDay: PropTypes.number,
     displayLoadingIndicator: PropTypes.bool,
     showWeekNumbers: PropTypes.bool,
-    month: PropTypes.instanceOf(XDate),
-    addMonth: PropTypes.func,
-    /** Month format in the title. Formatting values: http://arshaw.com/xdate/#Formatting */
     monthFormat: PropTypes.string,
-    /**  Hide day names. Default = false */
     hideDayNames: PropTypes.bool,
-    /** Hide month navigation arrows. Default = false */
     hideArrows: PropTypes.bool,
-    /** Replace default arrows with custom ones (direction can be 'left' or 'right') */
     renderArrow: PropTypes.func,
-    /** Handler which gets executed when press arrow icon left. It receive a callback can go back month */
     onPressArrowLeft: PropTypes.func,
-    /** Handler which gets executed when press arrow icon right. It receive a callback can go next month */
     onPressArrowRight: PropTypes.func,
-    /** Disable left arrow. Default = false */
     disableArrowLeft: PropTypes.bool,
-    /** Disable right arrow. Default = false */
     disableArrowRight: PropTypes.bool,
-    /** Apply custom disable color to selected day indexes */
     disabledDaysIndexes: PropTypes.arrayOf(PropTypes.number),
-    /** Replace default title with custom one. the function receive a date as parameter */
     renderHeader: PropTypes.any,
-    /** Replace default title with custom element */
     customHeaderTitle: PropTypes.any,
-    /** Provide aria-level for calendar heading for proper accessibility when used with web (react-native-web) */
+    
     webAriaLevel: PropTypes.number
   };
 

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -125,7 +125,7 @@ class Calendar extends Component<CalendarProps, State> {
   };
 
   updateMonth = (day: any) => {
-    if (day.toString('yyyy MM') === this.state.currentMonth.toString('yyyy MM')) {
+    if (sameMonth(day, this.state.currentMonth)) {
       return;
     }
     this.setState({currentMonth: day.clone()}, () => {

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -26,8 +26,6 @@ type MarkedDatesType = {
 };
 
 export interface CalendarProps extends CalendarHeaderProps, DayProps {
-  /** Specify theme properties to override specific styles for calendar parts */
-  theme?: Theme;
   /** Specify style for calendar container element */
   style?: StyleProp<ViewStyle>;
   /** Initially visible month */
@@ -38,14 +36,8 @@ export interface CalendarProps extends CalendarHeaderProps, DayProps {
   minDate?: string;
   /** Maximum date that can be selected, dates after maxDate will be grayed out */
   maxDate?: string;
-  /** If firstDay=1 week starts from Monday. Note that dayNames and dayNamesShort should still start from Sunday */
-  firstDay?: number;
   /** Collection of dates that have to be marked */
   markedDates?: MarkedDatesType;
-  /** Display loading indicator */
-  displayLoadingIndicator?: boolean;
-  /** Show week numbers */
-  showWeekNumbers?: boolean;
   /** Do not show days of other months in month page */
   hideExtraDays?: boolean;
   /** Always show six weeks on each month (only when hideExtraDays = false) */
@@ -87,49 +79,23 @@ class Calendar extends Component<CalendarProps, State> {
   static propTypes = {
     ...CalendarHeader.propTypes,
     ...Day.propTypes,
-    /** Specify theme properties to override specific styles for calendar parts. Default = {} */
-    theme: PropTypes.object,
-    /** Specify style for calendar container element. Default = {} */
     style: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.number]),
-    /** Initially visible month in 'yyyy-MM-dd' format. Default = now */
     current: PropTypes.string,
-    /** Initially visible month. If changed will initialize the calendar to this value */
     initialDate: PropTypes.string,
-    /** Minimum date that can be selected, dates before minDate will be grayed out. Default = undefined */
     minDate: PropTypes.string,
-    /** Maximum date that can be selected, dates after maxDate will be grayed out. Default = undefined */
     maxDate: PropTypes.string,
-    /** If firstDay=1 week starts from Monday. Note that dayNames and dayNamesShort should still start from Sunday. */
-    firstDay: PropTypes.number,
-    /** Collection of dates that have to be marked. Default = {} */
     markedDates: PropTypes.object,
-    /** Display loading indicator. Default = false */
-    displayLoadingIndicator: PropTypes.bool,
-    /** Show week numbers. Default = false */
-    showWeekNumbers: PropTypes.bool,
-    /** Do not show days of other months in month page. Default = false */
     hideExtraDays: PropTypes.bool,
-    /** Always show six weeks on each month (only when hideExtraDays = false). Default = false */
     showSixWeeks: PropTypes.bool,
-    /** Handler which gets executed on day press. Default = undefined */
     onDayPress: PropTypes.func,
-    /** Handler which gets executed on day long press. Default = undefined */
     onDayLongPress: PropTypes.func,
-    /** Handler which gets executed when month changes in calendar. Default = undefined */
     onMonthChange: PropTypes.func,
-    /** Handler which gets executed when visible month changes in calendar. Default = undefined */
     onVisibleMonthsChange: PropTypes.func,
-    /** Disables changing month when click on days of other months (when hideExtraDays is false). Default = false */
     disableMonthChange: PropTypes.bool,
-    /** Enable the option to swipe between months. Default: false */
     enableSwipeMonths: PropTypes.bool,
-    /** Disable days by default. Default = false */
     disabledByDefault: PropTypes.bool,
-    /** Style passed to the header */
     headerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
-    /** Allow rendering a totally custom header */
     customHeader: PropTypes.any,
-    /** Allow selection of dates before minDate or after maxDate */
     allowSelectionOutOfRange: PropTypes.bool
   };
   static defaultProps = {

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -13,7 +13,7 @@ import {getState} from '../day-state-manager';
 import {extractComponentProps} from '../componentUpdater';
 // @ts-expect-error
 import {WEEK_NUMBER} from '../testIDs';
-import {DateData} from '../types';
+import {DateData, Theme} from '../types';
 import styleConstructor from './style';
 import CalendarHeader, {CalendarHeaderProps} from './header';
 import Day, {DayProps} from './day/index';
@@ -26,6 +26,14 @@ type MarkedDatesType = {
 };
 
 export interface CalendarProps extends CalendarHeaderProps, DayProps {
+  /** Specify theme properties to override specific styles for calendar parts */
+  theme?: Theme;
+  /** If firstDay=1 week starts from Monday. Note that dayNames and dayNamesShort should still start from Sunday */
+  firstDay?: number;
+  /** Display loading indicator */
+  displayLoadingIndicator?: boolean;
+  /** Show week numbers */
+  showWeekNumbers?: boolean;
   /** Specify style for calendar container element */
   style?: StyleProp<ViewStyle>;
   /** Initially visible month */
@@ -79,6 +87,10 @@ class Calendar extends Component<CalendarProps, State> {
   static propTypes = {
     ...CalendarHeader.propTypes,
     ...Day.propTypes,
+    theme: PropTypes.object,
+    firstDay: PropTypes.number,
+    displayLoadingIndicator: PropTypes.bool,
+    showWeekNumbers: PropTypes.bool,
     style: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.number]),
     current: PropTypes.string,
     initialDate: PropTypes.string,

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -13,7 +13,7 @@ import {getState} from '../day-state-manager';
 import {extractComponentProps} from '../componentUpdater';
 // @ts-expect-error
 import {WEEK_NUMBER} from '../testIDs';
-import {Theme, DateData} from '../types';
+import {DateData} from '../types';
 import styleConstructor from './style';
 import CalendarHeader, {CalendarHeaderProps} from './header';
 import Day, {DayProps} from './day/index';

--- a/src/dateutils.spec.js
+++ b/src/dateutils.spec.js
@@ -1,5 +1,5 @@
 import XDate from 'xdate';
-import {sameMonth, sameWeek, isLTE, isGTE, month, page, generateDay} from './dateutils';
+import {sameMonth, sameWeek, isLTE, isGTE, month, page, generateDay, isPastDate} from './dateutils';
 
 describe('dateutils', function () {
   describe('sameMonth()', function () {
@@ -52,6 +52,21 @@ describe('dateutils', function () {
       expect(sameWeek(a, b, 1)).toBe(true);
 
       expect(sameWeek(a, b, 2)).toBe(false);
+    });
+  });
+
+  describe('isPastDate', () => {
+    it('Expect to get true while passing a past date', () => {
+      const pastDate = '2021-04-04';
+      const futureDate = '2050-04-04';
+      const today1 = XDate();
+      const today2 = new Date();
+
+      expect(isPastDate(futureDate)).toBe(false);
+      expect(isPastDate(pastDate)).toBe(true);
+
+      expect(isPastDate(today1)).toBe(false);
+      expect(isPastDate(today2)).toBe(false);
     });
   });
 

--- a/src/dateutils.ts
+++ b/src/dateutils.ts
@@ -1,14 +1,27 @@
 const XDate = require('xdate');
 const {parseDate, toMarkingFormat} = require('./interface');
+const {getDefaultLocale} = require('./services');
 
 const latinNumbersPattern = /[0-9]/g;
 
-export function sameMonth(a: XDate, b: XDate) {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+function isValidXDate(date: any) {
+  return date && (date instanceof XDate);
 }
 
-export function sameDate(a: XDate, b: XDate) {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+export function sameMonth(a?: XDate, b?: XDate) {
+  if (!isValidXDate(a) || !isValidXDate(b)) {
+    return false;
+  } else {
+    return a?.getFullYear() === b?.getFullYear() && a?.getMonth() === b?.getMonth();
+  }
+}
+
+export function sameDate(a?: XDate, b?: XDate) {
+  if (!isValidXDate(a) || !isValidXDate(b)) {
+    return false;
+  } else {
+    return a?.getFullYear() === b?.getFullYear() && a?.getMonth() === b?.getMonth() && a?.getDate() === b?.getDate();
+  } 
 }
 
 export function sameWeek(a: XDate, b: XDate, firstDayOfWeek: number) {
@@ -16,7 +29,27 @@ export function sameWeek(a: XDate, b: XDate, firstDayOfWeek: number) {
   return weekDates?.includes(b);
 }
 
-export function isToday(date: XDate) {
+export function isPastDate(date: string) {
+  const today = new XDate();
+  const d = new XDate(date);
+
+  if (today.getFullYear() > d.getFullYear()) {
+    return true;
+  }
+  if (today.getFullYear() === d.getFullYear()) {
+    if (today.getMonth() > d.getMonth()) {
+      return true;
+    }
+    if (today.getMonth() === d.getMonth()) {
+      if (today.getDate() > d.getDate()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function isToday(date?: XDate) {
   return sameDate(date, XDate.today());
 }
 
@@ -29,12 +62,12 @@ export function isLTE(a: XDate, b: XDate) {
 }
 
 export function formatNumbers(date: any) {
-  const numbers = XDate.locales[XDate.defaultLocale].numbers;
+  const numbers = getDefaultLocale().numbers;
   return numbers ? date.toString().replace(latinNumbersPattern, (char: any) => numbers[+char]) : date;
 }
 
-export function fromTo(a: XDate, b: XDate) {
-  const days = [];
+export function fromTo(a: XDate, b: XDate): XDate[] {
+  const days: XDate[] = [];
   let from = +a;
   const to = +b;
 
@@ -47,7 +80,7 @@ export function fromTo(a: XDate, b: XDate) {
 export function month(date: XDate) {
   const year = date.getFullYear(),
     month = date.getMonth();
-  const days = new Date(year, month + 1, 0).getDate();
+  const days = new XDate(year, month + 1, 0).getDate();
 
   const firstDay = new XDate(year, month, 1, 0, 0, 0, true);
   const lastDay = new XDate(year, month, days, 0, 0, 0, true);
@@ -56,7 +89,7 @@ export function month(date: XDate) {
 }
 
 export function weekDayNames(firstDayOfWeek = 0) {
-  let weekDaysNames = XDate.locales[XDate.defaultLocale].dayNamesShort;
+  let weekDaysNames = getDefaultLocale().dayNamesShort;
   const dayShift = firstDayOfWeek % 7;
   if (dayShift) {
     weekDaysNames = weekDaysNames.slice(dayShift).concat(weekDaysNames.slice(0, dayShift));
@@ -66,8 +99,8 @@ export function weekDayNames(firstDayOfWeek = 0) {
 
 export function page(date: XDate, firstDayOfWeek = 0, showSixWeeks = false) {
   const days = month(date);
-  let before = [],
-    after = [];
+  let before: XDate[] = [];
+  let after: XDate[] = [];
 
   const fdow = (7 + firstDayOfWeek) % 7 || 7;
   const ldow = (fdow + 6) % 7;

--- a/src/expandableCalendar/Context/Presenter.spec.js
+++ b/src/expandableCalendar/Context/Presenter.spec.js
@@ -10,22 +10,8 @@ describe('Context provider tests', () => {
 
   const pastDate = '2021-04-04';
   const futureDate = '2050-04-04';
-  const today1 = XDate();
-  const today2 = new Date();
   const todayDate = toMarkingFormat(XDate());
   const updateSources = UpdateSources.CALENDAR_INIT;
-
-  describe('isPastDate function tests', () => {
-    it('Expect to get true while passing a past date', () => {
-      const {_isPastDate} = makeUUT();
-
-      expect(_isPastDate(futureDate)).toBe(false);
-      expect(_isPastDate(pastDate)).toBe(true);
-
-      expect(_isPastDate(today1)).toBe(false);
-      expect(_isPastDate(today2)).toBe(false);
-    });
-  });
 
   describe('Button Icon test', () => {
     it('Expect to get down button on past date', () => {

--- a/src/expandableCalendar/Context/Presenter.ts
+++ b/src/expandableCalendar/Context/Presenter.ts
@@ -1,7 +1,8 @@
 import XDate from 'xdate';
 
-import {sameMonth, isToday} from '../../dateutils';
+import {sameMonth, isToday, isPastDate} from '../../dateutils';
 import {xdateToData, toMarkingFormat} from '../../interface';
+import {getDefaultLocale} from '../../services';
 import {UpdateSources} from '../commons';
 import {CalendarContextProviderProps} from './Provider';
 
@@ -9,26 +10,6 @@ const commons = require('../commons');
 const TOP_POSITION = 65;
 
 class Presenter {
-  _isPastDate(date: string) {
-    const today = new XDate();
-    const d = new XDate(date);
-
-    if (today.getFullYear() > d.getFullYear()) {
-      return true;
-    }
-    if (today.getFullYear() === d.getFullYear()) {
-      if (today.getMonth() > d.getMonth()) {
-        return true;
-      }
-      if (today.getMonth() === d.getMonth()) {
-        if (today.getDate() > d.getDate()) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
   _getIconDown = () => {
     return require('../../img/down.png');
   };
@@ -41,7 +22,7 @@ class Presenter {
     if (!showTodayButton) {
       return undefined;
     }
-    const icon = this._isPastDate(date) ? this._getIconDown() : this._getIconUp();
+    const icon = isPastDate(date) ? this._getIconDown() : this._getIconUp();
     return icon;
   };
 
@@ -52,14 +33,13 @@ class Presenter {
     updateState: (buttonIcon: number) => void,
     updateSource: UpdateSources
   ) => {
-    const isSameMonth = sameMonth(new XDate(date), new XDate(newDate));
     const buttonIcon = this.getButtonIcon(date, props.showTodayButton);
 
     updateState(buttonIcon);
 
     props.onDateChanged?.(date, updateSource);
 
-    if (!isSameMonth) {
+    if (!sameMonth(new XDate(date), new XDate(newDate))) {
       props.onMonthChange?.(xdateToData(new XDate(date)), updateSource);
     }
   };
@@ -107,8 +87,7 @@ class Presenter {
   };
 
   getTodayFormatted = () => {
-    // @ts-expect-error
-    const todayString = XDate.locales[XDate.defaultLocale].today || commons.todayString;
+    const todayString = getDefaultLocale().today || commons.todayString;
     const today = todayString.charAt(0).toUpperCase() + todayString.slice(1);
     return today;
   };

--- a/src/expandableCalendar/Context/Provider.tsx
+++ b/src/expandableCalendar/Context/Provider.tsx
@@ -14,6 +14,10 @@ import {UpdateSources} from '../commons';
 const TOP_POSITION = 65;
 
 interface Props {
+  /** Specify theme properties to override specific styles for calendar parts */
+  theme?: Theme;
+  /** Specify style for calendar container element */
+  style?: StyleProp<ViewStyle>;
   /** Initial date in 'yyyy-MM-dd' format. Default = now */
   date: string;
   /** Callback for date change event */
@@ -28,8 +32,6 @@ interface Props {
   todayButtonStyle?: ViewStyle;
   /** The opacity for the disabled today button (0-1) */
   disabledOpacity?: number;
-  style?: StyleProp<ViewStyle>;
-  theme?: Theme;
 }
 export type CalendarContextProviderProps = Props;
 
@@ -41,19 +43,12 @@ class CalendarProvider extends Component<Props> {
   static displayName = 'CalendarProvider';
 
   static propTypes = {
-    /** Initial date in 'yyyy-MM-dd' format. Default = now */
     date: PropTypes.any.isRequired,
-    /** Callback for date change event */
     onDateChanged: PropTypes.func,
-    /** Callback for month change event */
     onMonthChange: PropTypes.func,
-    /** Whether to show the today button */
     showTodayButton: PropTypes.bool,
-    /** Today button's top position */
     todayBottomMargin: PropTypes.number,
-    /** Today button's style */
     todayButtonStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
-    /** The opacity for the disabled today button (0-1) */
     disabledOpacity: PropTypes.number
   };
 

--- a/src/expandableCalendar/WeekCalendar/index.tsx
+++ b/src/expandableCalendar/WeekCalendar/index.tsx
@@ -26,6 +26,7 @@ export interface WeekCalendarProps extends CalendarListProps {
   allowShadow?: boolean;
   /** whether to hide the names of the week days */
   hideDayNames?: boolean;
+
   context?: any;
 }
 
@@ -43,11 +44,8 @@ class WeekCalendar extends Component<WeekCalendarProps, State> {
 
   static propTypes = {
     ...CalendarList.propTypes,
-    /** the current date */
     current: PropTypes.any,
-    /** whether to have shadow/elevation for the calendar */
     allowShadow: PropTypes.bool,
-    /** whether to hide the names of the week days */
     hideDayNames: PropTypes.bool
   };
 

--- a/src/expandableCalendar/agendaList.tsx
+++ b/src/expandableCalendar/agendaList.tsx
@@ -31,6 +31,8 @@ const commons = require('./commons');
 const updateSources = commons.UpdateSources;
 
 export interface AgendaListProps extends SectionListProps<any, DefaultSectionT> {
+  /** Specify theme properties to override specific styles for calendar parts */
+  theme?: Theme;
   /** day format in section title. Formatting values: http://arshaw.com/xdate/#Formatting */
   dayFormat?: string;
   /** a function to custom format the section header's title */
@@ -48,7 +50,7 @@ export interface AgendaListProps extends SectionListProps<any, DefaultSectionT> 
   viewOffset?: number;
   /** enable scrolling the agenda list to the next date with content when pressing a day without content */
   scrollToNextEvent?: boolean;
-  theme?: Theme;
+  
   context?: any;
 }
 
@@ -63,18 +65,11 @@ class AgendaList extends Component<AgendaListProps> {
 
   static propTypes = {
     // ...SectionList.propTypes,
-    /** day format in section title. Formatting values: http://arshaw.com/xdate/#Formatting */
     dayFormat: PropTypes.string,
-    /** a function to custom format the section header's title */
     dayFormatter: PropTypes.func,
-    /** whether to use moment.js for date string formatting
-     * (remember to pass 'dayFormat' with appropriate format, like 'dddd, MMM D') */
     useMoment: PropTypes.bool,
-    /** whether to mark today's title with the "Today, ..." string. Default = true */
     markToday: PropTypes.bool,
-    /** style passed to the section view */
     sectionStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
-    /** whether to block the date change in calendar (and calendar context provider) when agenda scrolls */
     avoidDateUpdates: PropTypes.bool
   };
 

--- a/src/expandableCalendar/agendaList.tsx
+++ b/src/expandableCalendar/agendaList.tsx
@@ -23,6 +23,7 @@ import {
 import {isToday, isGTE, sameDate} from '../dateutils';
 import {getMoment} from '../momentResolver';
 import {parseDate} from '../interface';
+import {getDefaultLocale} from '../services';
 import {Theme} from '../types';
 import styleConstructor from './style';
 import asCalendarConsumer from './asCalendarConsumer';
@@ -155,8 +156,7 @@ class AgendaList extends Component<AgendaListProps> {
     }
 
     if (markToday) {
-      // @ts-expect-error
-      const todayString = XDate.locales[XDate.defaultLocale].today || commons.todayString;
+      const todayString = getDefaultLocale().today || commons.todayString;
       const today = isToday(new XDate(title));
       sectionTitle = today ? `${todayString}, ${sectionTitle}` : sectionTitle;
     }

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -149,7 +149,7 @@ class ExpandableCalendar extends Component<ExpandableCalendarProps, State> {
     super(props);
 
     this.closedHeight = CLOSED_HEIGHT + (props.hideKnob ? 0 : KNOB_CONTAINER_HEIGHT);
-    this.numberOfWeeks = this.getNumberOfWeeksInMonth(new XDate(this.props.context.date));
+    this.numberOfWeeks = this.getNumberOfWeeksInMonth(this.props.context.date);
     this.openHeight = this.getOpenHeight();
 
     const startHeight = props.initialPosition === Positions.CLOSED ? this.closedHeight : this.openHeight;
@@ -274,8 +274,8 @@ class ExpandableCalendar extends Component<ExpandableCalendarProps, State> {
     return d.getMonth() + 1;
   }
 
-  getNumberOfWeeksInMonth(month: XDate) {
-    const days = page(month, this.props.firstDay);
+  getNumberOfWeeksInMonth(month: string) {
+    const days = page(parseDate(month), this.props.firstDay);
     return days.length / 7;
   }
 
@@ -449,7 +449,7 @@ class ExpandableCalendar extends Component<ExpandableCalendarProps, State> {
         // updating openHeight
         setTimeout(() => {
           // to wait for setDate() call in horizontal scroll (this.scrollPage())
-          const numberOfWeeks = this.getNumberOfWeeksInMonth(parseDate(this.props.context.date));
+          const numberOfWeeks = this.getNumberOfWeeksInMonth(this.props.context.date);
           if (numberOfWeeks !== this.numberOfWeeks) {
             this.numberOfWeeks = numberOfWeeks;
             this.openHeight = this.getOpenHeight();

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -71,6 +71,7 @@ export interface ExpandableCalendarProps extends CalendarListProps {
   closeThreshold?: number;
   /** Whether to close the calendar on day press. Default = true */
   closeOnDayPress?: boolean;
+  
   context?: any;
 }
 
@@ -93,27 +94,16 @@ class ExpandableCalendar extends Component<ExpandableCalendarProps, State> {
 
   static propTypes = {
     ...CalendarList.propTypes,
-    /** the initial position of the calendar ('open' or 'closed') */
     initialPosition: PropTypes.oneOf(values(Positions)),
-    /** callback that fires when the calendar is opened or closed */
     onCalendarToggled: PropTypes.func,
-    /** an option to disable the pan gesture and disable the opening and closing of the calendar (initialPosition will persist)*/
     disablePan: PropTypes.bool,
-    /** whether to hide the knob  */
     hideKnob: PropTypes.bool,
-    /** source for the left arrow image */
     leftArrowImageSource: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.func]),
-    /** source for the right arrow image */
     rightArrowImageSource: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.func]),
-    /** whether to have shadow/elevation for the calendar */
     allowShadow: PropTypes.bool,
-    /** whether to disable the week scroll in closed position */
     disableWeekScroll: PropTypes.bool,
-    /** a threshold for opening the calendar with the pan gesture */
     openThreshold: PropTypes.number,
-    /** a threshold for closing the calendar with the pan gesture */
     closeThreshold: PropTypes.number,
-    /** Whether to close the calendar on day press. Default = true */
     closeOnDayPress: PropTypes.bool
   };
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -18,7 +18,7 @@ export function xdateToData(d: XDate) {
   };
 }
 
-export function parseDate(d: any) {
+export function parseDate(d?: any) {
   if (!d) {
     return;
   } else if (d.timestamp) {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -16,6 +16,11 @@ export function getCalendarDateString(date?: Date | string | number) {
   }
 }
 
+export function getDefaultLocale(): any {
+  return XDate.locales[XDate.defaultLocale];
+}
+
 export default {
-  getCalendarDateString
+  getCalendarDateString,
+  getDefaultLocale
 };


### PR DESCRIPTION
1) Remove comments from old propTypes for cleaner code.
2) Use 'sameMonth' instead of string compare.
3) Use 'getDefaultLocal'.
4) Move 'isPastDate' to dateutils.
5) Optional params in 'sameDate', 'sameMonth' and 'parseDate'.