### PR TITLE
CalendarListItem inside TouchableOpacity

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "memoize-one": "^5.2.1",
     "prop-types": "^15.5.10",
     "react-native-swipe-gestures": "^1.0.5",
+    "react-native-gesture-handler": "~2.1.0",
     "recyclerlistview": "^3.0.5",
     "xdate": "^0.8.0"
   },

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
 import React, {Component} from 'react';
-import {FlatList, TouchableOpacity, Platform, Dimensions, View, ViewStyle, LayoutChangeEvent, FlatListProps} from 'react-native';
+import { TouchableOpacity, Platform, Dimensions, View, ViewStyle, LayoutChangeEvent, FlatListProps} from 'react-native';
+import { FlatList } from 'react-native-gesture-handler';
 
 import {extractComponentProps} from '../componentUpdater';
 import {xdateToData, parseDate} from '../interface';

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
 import React, {Component} from 'react';
-import {FlatList, Platform, Dimensions, View, ViewStyle, LayoutChangeEvent, FlatListProps} from 'react-native';
+import {FlatList, TouchableOpacity, Platform, Dimensions, View, ViewStyle, LayoutChangeEvent, FlatListProps} from 'react-native';
 
 import {extractComponentProps} from '../componentUpdater';
 import {xdateToData, parseDate} from '../interface';
@@ -291,15 +291,17 @@ class CalendarList extends Component<CalendarListProps, State> {
     const {calendarStyle, horizontal, calendarWidth, testID, ...others} = this.props;
 
     return (
-      <CalendarListItem
-        {...others}
-        item={item}
-        testID={`${testID}_${item}`}
-        style={calendarStyle}
-        horizontal={horizontal}
-        calendarWidth={horizontal ? calendarWidth : undefined}
-        scrollToMonth={this.scrollToMonth}
-      />
+      <TouchableOpacity activeOpacity={1}>
+        <CalendarListItem
+          {...others}
+          item={item}
+          testID={`${testID}_${item}`}
+          style={calendarStyle}
+          horizontal={horizontal}
+          calendarWidth={horizontal ? calendarWidth : undefined}
+          scrollToMonth={this.scrollToMonth}
+        />
+      </TouchableOpacity>
     );
   };
 


### PR DESCRIPTION
CalendarListItem inside TouchableOpacity to prevent unreliable/janky scrolling when CalendarList is inside a scrollView or a swipeable modal.

This makes it way smoother for my use case.

Alternatively, would be great to have a prop that allowed to opt in for this.