### PR TITLE
Agenda Fixes: Generic Items, Key Extractor

### DIFF
--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -3,21 +3,30 @@ import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
 import React, {Component} from 'react';
-import {ActivityIndicator, View, FlatList, StyleProp, ViewStyle, TextStyle, NativeSyntheticEvent, NativeScrollEvent, LayoutChangeEvent} from 'react-native';
+import {
+  ActivityIndicator,
+  View,
+  FlatList,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
+  LayoutChangeEvent
+} from 'react-native';
 
 import {extractComponentProps} from '../../componentUpdater';
 import {sameDate} from '../../dateutils';
 import {toMarkingFormat} from '../../interface';
 import styleConstructor from './style';
 import Reservation, {ReservationProps} from './reservation';
-import {AgendaEntry, AgendaSchedule} from '../../types';
+import {AgendaSchedule} from '../../types';
 
-
-export type ReservationListProps = ReservationProps & {
+export type ReservationListProps<T> = ReservationProps<T> & {
   /** the list of items that have to be displayed in agenda. If you want to render item as empty date
   the value of date key kas to be an empty array []. If there exists no value for date key it is
   considered that the date in question is not yet loaded */
-  items?: AgendaSchedule;
+  items?: AgendaSchedule<T>;
   selectedDay?: XDate;
   topDay?: XDate;
   /** Show items only for the selected date. Default = false */
@@ -44,18 +53,20 @@ export type ReservationListProps = ReservationProps & {
   refreshing?: boolean;
   /** If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the refreshing prop correctly */
   onRefresh?: () => void;
+  /** Extractor for underlying FlatList. Ensure that this is unique per item, or else scrolling may have duplicated and / or missing items.  */
+  keyExtractor?: () => string;
 };
 
-interface DayAgenda {
-  reservation?: AgendaEntry;
+interface DayAgenda<T> {
+  reservation?: T;
   date?: XDate;
 }
 
-interface State {
-  reservations: DayAgenda[];
+interface State<T> {
+  reservations: DayAgenda<T>[];
 }
 
-class ReservationList extends Component<ReservationListProps, State> {
+class ReservationList<T = any> extends Component<ReservationListProps<T>, State<T>> {
   static displayName = 'ReservationList';
 
   static propTypes = {
@@ -64,7 +75,7 @@ class ReservationList extends Component<ReservationListProps, State> {
     selectedDay: PropTypes.instanceOf(XDate),
     topDay: PropTypes.instanceOf(XDate),
     onDayChange: PropTypes.func,
-    
+
     showOnlySelectedDayItems: PropTypes.bool,
     renderEmptyData: PropTypes.func,
 
@@ -77,10 +88,11 @@ class ReservationList extends Component<ReservationListProps, State> {
     refreshing: PropTypes.bool,
     onRefresh: PropTypes.func
   };
-  
+
   static defaultProps = {
     refreshing: false,
-    selectedDay: new XDate(true)
+    selectedDay: new XDate(true),
+    keyExtractor: (_item: unknown, index: number) => String(index)
   };
 
   private style: {[key: string]: ViewStyle | TextStyle};
@@ -89,8 +101,7 @@ class ReservationList extends Component<ReservationListProps, State> {
   private scrollOver: boolean;
   private list: React.RefObject<FlatList> = React.createRef();
 
-
-  constructor(props: ReservationListProps) {
+  constructor(props: ReservationListProps<T>) {
     super(props);
 
     this.style = styleConstructor(props.theme);
@@ -108,26 +119,24 @@ class ReservationList extends Component<ReservationListProps, State> {
     this.updateDataSource(this.getReservations(this.props).reservations);
   }
 
-  componentDidUpdate(prevProps: ReservationListProps) {
+  componentDidUpdate(prevProps: ReservationListProps<T>) {
     if (this.props.topDay && prevProps.topDay && prevProps !== this.props) {
       if (!sameDate(prevProps.topDay, this.props.topDay)) {
-        this.setState({reservations: []},
-          () => this.updateReservations(this.props)
-        );
+        this.setState({reservations: []}, () => this.updateReservations(this.props));
       } else {
         this.updateReservations(this.props);
       }
     }
   }
 
-  updateDataSource(reservations: DayAgenda[]) {
+  updateDataSource(reservations: DayAgenda<T>[]) {
     this.setState({reservations});
   }
 
-  updateReservations(props: ReservationListProps) {
+  updateReservations(props: ReservationListProps<T>) {
     const {selectedDay} = props;
     const reservations = this.getReservations(props);
-    
+
     if (this.list && !sameDate(selectedDay, this.selectedDay)) {
       let scrollPosition = 0;
       for (let i = 0; i < reservations.scrollPosition; i++) {
@@ -141,12 +150,12 @@ class ReservationList extends Component<ReservationListProps, State> {
     this.updateDataSource(reservations.reservations);
   }
 
-  getReservationsForDay(iterator: XDate, props: ReservationListProps) {
+  getReservationsForDay(iterator: XDate, props: ReservationListProps<T>) {
     const day = iterator.clone();
     const res = props.items?.[toMarkingFormat(day)];
-    
+
     if (res && res.length) {
-      return res.map((reservation: AgendaEntry, i: number) => {
+      return res.map((reservation: T, i: number) => {
         return {
           reservation,
           date: i ? undefined : day
@@ -163,14 +172,14 @@ class ReservationList extends Component<ReservationListProps, State> {
     }
   }
 
-  getReservations(props: ReservationListProps) {
+  getReservations(props: ReservationListProps<T>) {
     const {selectedDay, showOnlySelectedDayItems} = props;
-    
+
     if (!props.items || !selectedDay) {
       return {reservations: [], scrollPosition: 0};
     }
 
-    let reservations: DayAgenda[] = [];
+    let reservations: DayAgenda<T>[] = [];
     if (this.state.reservations && this.state.reservations.length) {
       const iterator = this.state.reservations[0].date?.clone();
       if (iterator) {
@@ -248,26 +257,24 @@ class ReservationList extends Component<ReservationListProps, State> {
     return false;
   };
 
-  renderRow = ({item, index}: {item: DayAgenda; index: number}) => {
+  renderRow = ({item, index}: {item: DayAgenda<T>; index: number}) => {
     const reservationProps = extractComponentProps(Reservation, this.props);
 
     return (
       <View onLayout={this.onRowLayoutChange.bind(this, index)}>
-        <Reservation {...reservationProps} item={item.reservation} date={item.date}/>
+        <Reservation {...reservationProps} item={item.reservation} date={item.date} />
       </View>
     );
   };
 
-  keyExtractor = (_item: DayAgenda, index: number) => String(index);
-
   render() {
     const {items, selectedDay, theme, style} = this.props;
-    
-    if (!items || selectedDay && !items[toMarkingFormat(selectedDay)]) {
+
+    if (!items || (selectedDay && !items[toMarkingFormat(selectedDay)])) {
       if (isFunction(this.props.renderEmptyData)) {
         return this.props.renderEmptyData?.();
       }
-      return <ActivityIndicator style={this.style.indicator} color={theme?.indicatorColor}/>;
+      return <ActivityIndicator style={this.style.indicator} color={theme?.indicatorColor} />;
     }
 
     return (
@@ -277,7 +284,7 @@ class ReservationList extends Component<ReservationListProps, State> {
         contentContainerStyle={this.style.content}
         data={this.state.reservations}
         renderItem={this.renderRow}
-        keyExtractor={this.keyExtractor}
+        keyExtractor={this.props.keyExtractor}
         showsVerticalScrollIndicator={false}
         scrollEventThrottle={200}
         onMoveShouldSetResponderCapture={this.onMoveShouldSetResponderCapture}

--- a/src/agenda/reservation-list/reservation.tsx
+++ b/src/agenda/reservation-list/reservation.tsx
@@ -10,25 +10,24 @@ import {getDefaultLocale} from '../../services';
 // @ts-expect-error
 import {RESERVATION_DATE} from '../../testIDs';
 import styleConstructor from './style';
-import {Theme, AgendaEntry} from '../../types';
+import {Theme} from '../../types';
 
-
-export interface ReservationProps {
+export interface ReservationProps<T> {
   date?: XDate;
-  item?: AgendaEntry;
+  item?: T;
   /** Specify theme properties to override specific styles for item's parts. Default = {} */
   theme?: Theme;
   /** specify your item comparison function for increased performance */
-  rowHasChanged?: (a: AgendaEntry, b: AgendaEntry) => boolean;
+  rowHasChanged?: (a: T, b: T) => boolean;
   /** specify how each date should be rendered. date can be undefined if the item is not first in that day */
-  renderDay?: (date?: XDate, item?: AgendaEntry) => React.Component | JSX.Element;
+  renderDay?: (date?: XDate, item?: T) => React.Component | JSX.Element;
   /** specify how each item should be rendered in agenda */
-  renderItem?: (reservation: AgendaEntry, isFirst: boolean) => React.Component | JSX.Element;
+  renderItem?: (reservation: T, isFirst: boolean) => React.Component | JSX.Element;
   /** specify how empty date content with no items should be rendered */
   renderEmptyDate?: (date?: XDate) => React.Component | JSX.Element;
 }
 
-class Reservation extends Component<ReservationProps> {
+class Reservation<T = any> extends Component<ReservationProps<T>> {
   static displayName = 'Reservation';
 
   static propTypes = {
@@ -43,18 +42,18 @@ class Reservation extends Component<ReservationProps> {
 
   style;
 
-  constructor(props: ReservationProps) {
+  constructor(props: ReservationProps<T>) {
     super(props);
 
     this.style = styleConstructor(props.theme);
   }
 
-  shouldComponentUpdate(nextProps: ReservationProps) {
+  shouldComponentUpdate(nextProps: ReservationProps<T>) {
     const d1 = this.props.date;
     const d2 = nextProps.date;
     const r1 = this.props.item;
     const r2 = nextProps.item;
-    
+
     let changed = true;
     if (!d1 && !d2) {
       changed = false;
@@ -74,7 +73,7 @@ class Reservation extends Component<ReservationProps> {
     return changed;
   }
 
-  renderDate(date?: XDate, item?: AgendaEntry) {
+  renderDate(date?: XDate, item?: T) {
     if (isFunction(this.props.renderDay)) {
       return this.props.renderDay(date, item);
     }
@@ -94,13 +93,13 @@ class Reservation extends Component<ReservationProps> {
         </View>
       );
     } else {
-      return <View style={this.style.day}/>;
+      return <View style={this.style.day} />;
     }
   }
 
   render() {
     const {item, date} = this.props;
-    
+
     let content;
     if (item) {
       const firstItem = date ? true : false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,12 +91,6 @@ export interface Theme {
   };
 }
 
-export type AgendaEntry = {
-  name: string;
-  height: number;
-  day: string;
-}
-
-export type AgendaSchedule = {
-  [date: string]: AgendaEntry[];
-}
+export type AgendaSchedule<T> = {
+  [date: string]: T[];
+};


### PR DESCRIPTION
Hello! First, thanks for this library. This is an awesome set of tools.

This PR attempts to solve two issues with the current `Agenda`:
1. The component is not generic. Specifically, `AgendaEntry` is not generic, nor the functions that use it, such as `renderItem`
2. The Agenda has a bug with using indexes as the keys. This is causing rendering issues because data is falsely considered to be stable across renders. The result is that, while updating the `data` list of the underlying `FlatList` (either through calendar navigation, or `items` updating. Anything that touches `state.reservations`), items are duplicated and / or not shown. (this is documented at https://github.com/wix/react-native-calendars/issues/1791#issue-1138143626)

This is a backwards compatible solution to both of these. The types of the functions will now be inferred from the data type, and the key extractor can now be specified. (FWIW, I'm pretty sure the default prop of the index -> string extractor isn't needed. This is the default the flatlist would use anyways, and is bug prone. However, I've left it to keep this PR backwards compatible).

This should also:
close #1792 -- this attempts to add a fix to issue (2) above.
close #1683 -- this attempts to add a fix to issue (1) above.
close #1791

#1777 doesn't have much info, but it looks like this will solve that too.

Please let me know if this needs any updates, or any other suggestions. 