### PR TITLE
fix custom day component logic

### DIFF
--- a/example/src/screens/calendars.tsx
+++ b/example/src/screens/calendars.tsx
@@ -348,7 +348,7 @@ const CalendarsScreen = () => {
             return (
               <View>
                 <Text style={[styles.customDay, state === 'disabled' ? styles.disabledText : styles.defaultText]}>
-                  {date?.day}
+                  {date}
                 </Text>
               </View>
             );

--- a/src/calendar/day/index.tsx
+++ b/src/calendar/day/index.tsx
@@ -57,7 +57,7 @@ const Day = React.memo((props: DayProps) => {
     return `${_isToday ? today : ''} ${_date?.toString(formatAccessibilityLabel)} ${markingAccessibilityLabel}`;
   }, [_date, marking, _isToday]);
   
-  const Component = dayComponent || markingType === 'period' ? PeriodDay : BasicDay;
+  const Component = dayComponent || (markingType === 'period' ? PeriodDay : BasicDay);
 
   return (
     <Component

--- a/src/calendar/day/index.tsx
+++ b/src/calendar/day/index.tsx
@@ -6,14 +6,13 @@ import {formatNumbers, isToday} from '../../dateutils';
 import {getDefaultLocale} from '../../services';
 // @ts-expect-error
 import {SELECT_DATE_SLOT} from '../../testIDs';
-import {DateData} from '../../types';
 import BasicDay, {BasicDayProps} from './basic';
 import PeriodDay from './period';
 
 
 export interface DayProps extends BasicDayProps {
   /** Provide custom day rendering component */
-  dayComponent?: React.ComponentType<DayProps & {date?: DateData}>;
+  dayComponent?: React.ComponentType<DayProps & {date?: string}>;
 }
 
 const Day = React.memo((props: DayProps) => {


### PR DESCRIPTION
This PR fixes the logic related to operator precedence for the `dayComponent` component.

Closes #1823