### PR TITLE
types export fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export {default as asCalendarConsumer} from './expandableCalendar/asCalendarCons
 export {default as Timeline} from './timeline/Timeline';
 export type {TimelineProps, TimelineEventProps, TimelinePackedEventProps} from './timeline/Timeline';
 export {default as TimelineList} from './timeline-list';
-export {TimelineListProps, TimelineListRenderItemInfo} from './timeline-list';
+export type {TimelineListProps, TimelineListRenderItemInfo} from './timeline-list';
 export {default as CalendarUtils} from './services';
 export type {DateData, AgendaEntry, AgendaSchedule} from './types';
 export {default as LocaleConfig} from 'xdate';


### PR DESCRIPTION
Just adding the `type` after the `export` makes it compliant for  webpack's `ts-loader`.