### PR TITLE
componentUpdater.ts uses propTypesMap instead of Component.propTypes

### DIFF
--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -14,6 +14,7 @@ import Calendar, {CalendarProps} from '../calendar';
 import CalendarListItem from './item';
 import CalendarHeader from '../calendar/header/index';
 import constants from '../commons/constants';
+import propTypesMap from '../propTypesMap';
 
 
 const CALENDAR_WIDTH = constants.screenWidth;
@@ -69,6 +70,26 @@ type State = {
   currentMonth: XDate;
 };
 
+export const propTypes = {
+	...Calendar.propTypes,
+	pastScrollRange: PropTypes.number,
+	futureScrollRange: PropTypes.number,
+	calendarWidth: PropTypes.number,
+	calendarHeight: PropTypes.number,
+	calendarStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
+	staticHeader: PropTypes.bool,
+	showScrollIndicator: PropTypes.bool,
+	animateScroll: PropTypes.bool,
+	scrollEnabled: PropTypes.bool,
+	scrollsToTop: PropTypes.bool,
+	pagingEnabled: PropTypes.bool,
+	horizontal: PropTypes.bool,
+	keyboardShouldPersistTaps: PropTypes.oneOf(['never', 'always', 'handled']),
+	keyExtractor: PropTypes.func,
+	onEndReachedThreshold: PropTypes.number,
+	onEndReached: PropTypes.func
+};
+
 /**
  * @description: Calendar List component for both vertical and horizontal calendars
  * @extends: Calendar
@@ -79,25 +100,7 @@ type State = {
 class CalendarList extends Component<CalendarListProps, State> {
   static displayName = 'CalendarList';
 
-  static propTypes = {
-    ...Calendar.propTypes,
-    pastScrollRange: PropTypes.number,
-    futureScrollRange: PropTypes.number,
-    calendarWidth: PropTypes.number,
-    calendarHeight: PropTypes.number,
-    calendarStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
-    staticHeader: PropTypes.bool,
-    showScrollIndicator: PropTypes.bool,
-    animateScroll: PropTypes.bool,
-    scrollEnabled: PropTypes.bool,
-    scrollsToTop: PropTypes.bool,
-    pagingEnabled: PropTypes.bool,
-    horizontal: PropTypes.bool,
-    keyboardShouldPersistTaps: PropTypes.oneOf(['never', 'always', 'handled']),
-    keyExtractor: PropTypes.func,
-    onEndReachedThreshold: PropTypes.number,
-    onEndReached: PropTypes.func
-  };
+  static propTypes = propTypes;
 
   static defaultProps = {
     calendarWidth: CALENDAR_WIDTH,
@@ -360,3 +363,5 @@ class CalendarList extends Component<CalendarListProps, State> {
 }
 
 export default CalendarList;
+
+propTypesMap.set(CalendarList, propTypes);

--- a/src/calendar-list/item.tsx
+++ b/src/calendar-list/item.tsx
@@ -11,6 +11,7 @@ import {formatNumbers, sameMonth} from '../dateutils';
 import Calendar, {CalendarProps} from '../calendar';
 import styleConstructor from './style';
 import {getCalendarDateString} from '../services';
+import propTypesMap from '../propTypesMap';
 
 export type CalendarListItemProps = CalendarProps & {
   item: any;
@@ -26,16 +27,18 @@ type CalendarListItemState = {
   hideExtraDays: boolean;
 };
 
+export const propTypes = {
+	...Calendar.propTypes,
+	item: PropTypes.any,
+	calendarWidth: PropTypes.number,
+	calendarHeight: PropTypes.number,
+	horizontal: PropTypes.bool
+};
+
 class CalendarListItem extends Component<CalendarListItemProps, CalendarListItemState> {
   static displayName = 'CalendarListItem';
 
-  static propTypes = {
-    ...Calendar.propTypes,
-    item: PropTypes.any,
-    calendarWidth: PropTypes.number,
-    calendarHeight: PropTypes.number,
-    horizontal: PropTypes.bool
-  };
+  static propTypes = propTypes;
 
   static defaultProps = {
     hideArrows: true,
@@ -138,3 +141,5 @@ class CalendarListItem extends Component<CalendarListItemProps, CalendarListItem
 }
 
 export default CalendarListItem;
+
+propTypesMap.set(CalendarListItem, propTypes);

--- a/src/calendar/day/basic/index.tsx
+++ b/src/calendar/day/basic/index.tsx
@@ -8,6 +8,7 @@ import {xdateToData} from '../../../interface';
 import {Theme, DayState, MarkingTypes, DateData} from '../../../types';
 import styleConstructor from './style';
 import Marking, {MarkingProps} from '../marking';
+import propTypesMap from '../../../propTypesMap';
 
 
 export interface BasicDayProps extends ViewProps {
@@ -203,7 +204,8 @@ const BasicDay = (props: BasicDayProps) => {
 
 export default BasicDay;
 BasicDay.displayName = 'BasicDay';
-BasicDay.propTypes = {
+
+export const propTypes = {
   state: PropTypes.oneOf(['selected', 'disabled', 'inactive', 'today', '']),
   marking: PropTypes.any,
   markingType: PropTypes.oneOf(values(Marking.markings)),
@@ -214,3 +216,6 @@ BasicDay.propTypes = {
   disableAllTouchEventsForDisabledDays: PropTypes.bool,
   disableAllTouchEventsForInactiveDays: PropTypes.bool
 };
+
+propTypesMap.set(BasicDay, propTypes);
+BasicDay.propTypes = propTypes;

--- a/src/calendar/day/dot/index.tsx
+++ b/src/calendar/day/dot/index.tsx
@@ -3,6 +3,7 @@ import React, {useRef} from 'react';
 import {View} from 'react-native';
 import styleConstructor from './style';
 import {Theme} from '../../../types';
+import propTypesMap from '../../../propTypesMap';
 
 export interface DotProps {
   theme?: Theme;
@@ -47,7 +48,7 @@ const Dot = ({theme, marked, disabled, inactive, color, today, selected}: DotPro
 
 export default Dot;
 
-Dot.propTypes = {
+export const propTypes = {
   theme: PropTypes.object,
   color: PropTypes.string,
   marked: PropTypes.bool,
@@ -56,3 +57,6 @@ Dot.propTypes = {
   inactive: PropTypes.bool,
   today: PropTypes.bool
 };
+
+propTypesMap.set(Dot, propTypes);
+Dot.propTypes = propTypes;

--- a/src/calendar/day/index.tsx
+++ b/src/calendar/day/index.tsx
@@ -10,6 +10,7 @@ import {SELECT_DATE_SLOT} from '../../testIDs';
 import {DateData} from '../../types';
 import BasicDay, {BasicDayProps} from './basic';
 import PeriodDay from './period';
+import propTypesMap from '../../propTypesMap';
 
 
 export interface DayProps extends BasicDayProps {
@@ -77,7 +78,11 @@ const Day = React.memo((props: DayProps) => {
 export default Day;
 
 Day.displayName = 'Day';
-Day.propTypes = {
+
+export const propTypes = {
   ...BasicDay.propTypes,
   dayComponent: PropTypes.any
 };
+
+propTypesMap.set(Day, propTypes);
+Day.propTypes = propTypes;

--- a/src/calendar/day/period/index.tsx
+++ b/src/calendar/day/period/index.tsx
@@ -8,6 +8,7 @@ import {Theme, DayState, DateData} from '../../../types';
 import styleConstructor from './style';
 import Dot from '../dot';
 import {MarkingProps} from '../marking';
+import propTypesMap from '../../../propTypesMap';
 
 
 export interface PeriodDayProps extends ViewProps {
@@ -187,7 +188,8 @@ const PeriodDay = (props: PeriodDayProps) => {
 
 export default PeriodDay;
 PeriodDay.displayName = 'PeriodDay';
-PeriodDay.propTypes = {
+
+export const propTypes = {
   state: PropTypes.oneOf(['selected', 'disabled', 'inactive', 'today', '']),
   marking: PropTypes.any,
   theme: PropTypes.object,
@@ -195,3 +197,6 @@ PeriodDay.propTypes = {
   onLongPress: PropTypes.func,
   date: PropTypes.string
 };
+
+propTypesMap.set(PeriodDay, propTypes);
+PeriodDay.propTypes = propTypes;

--- a/src/calendar/header/index.tsx
+++ b/src/calendar/header/index.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../testIDs';
 import styleConstructor from './style';
 import {Theme, Direction} from '../../types';
+import propTypesMap from '../../propTypesMap';
 
 export interface CalendarHeaderProps {
   month?: XDate;
@@ -276,8 +277,9 @@ const CalendarHeader = forwardRef((props: CalendarHeaderProps, ref) => {
 
 export default CalendarHeader;
 CalendarHeader.displayName = 'CalendarHeader';
-CalendarHeader.propTypes = {
-  month: PropTypes.instanceOf(XDate),
+
+export const propTypes = {
+	month: PropTypes.instanceOf(XDate),
   addMonth: PropTypes.func,
   theme: PropTypes.object,
   firstDay: PropTypes.number,
@@ -296,7 +298,11 @@ CalendarHeader.propTypes = {
   customHeaderTitle: PropTypes.any,
   webAriaLevel: PropTypes.number
 };
+
+propTypesMap.set(CalendarHeader, propTypes);
+CalendarHeader.propTypes = propTypes;
+
 CalendarHeader.defaultProps = {
-  monthFormat: 'MMMM yyyy',
+	monthFormat: 'MMMM yyyy',
   webAriaLevel: 1
 };

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -18,6 +18,7 @@ import CalendarHeader, {CalendarHeaderProps} from './header';
 import Day, {DayProps} from './day/index';
 import BasicDay from './day/basic';
 import {MarkingProps} from './day/marking';
+import propTypesMap from '../propTypesMap';
 
 
 type MarkedDatesType = {
@@ -281,7 +282,8 @@ const Calendar = (props: CalendarProps) => {
 
 export default Calendar;
 Calendar.displayName = 'Calendar';
-Calendar.propTypes = {
+
+export const propTypes = {
   ...CalendarHeader.propTypes,
   ...Day.propTypes,
   theme: PropTypes.object,
@@ -307,6 +309,9 @@ Calendar.propTypes = {
   customHeader: PropTypes.any,
   allowSelectionOutOfRange: PropTypes.bool
 };
+
+propTypesMap.set(Calendar, propTypes);
+Calendar.propTypes = propTypes;
 Calendar.defaultProps = {
   enableSwipeMonths: false
 };

--- a/src/componentUpdater.ts
+++ b/src/componentUpdater.ts
@@ -1,3 +1,5 @@
+import propTypesMap from "./propTypesMap";
+
 const get = require('lodash/get');
 const omit = require('lodash/omit');
 const pickBy = require('lodash/pickBy');
@@ -16,7 +18,7 @@ export function shouldUpdate(props: any, newProps: any, paths: string[]) {
 }
 
 export function extractComponentProps(component: any, props: any, ignoreProps?: string[]) {
-  const componentPropTypes = component.propTypes;
+  const componentPropTypes = propTypesMap.get(component);
   if (componentPropTypes) {
     const keys = Object.keys(componentPropTypes);
     const componentProps = omit(

--- a/src/expandableCalendar/Context/Provider.tsx
+++ b/src/expandableCalendar/Context/Provider.tsx
@@ -10,6 +10,7 @@ import styleConstructor from '../style';
 import CalendarContext from './index';
 import Presenter from './Presenter';
 import {UpdateSources} from '../commons';
+import propTypesMap from '../../propTypesMap';
 
 const TOP_POSITION = 65;
 
@@ -35,6 +36,16 @@ interface Props {
 }
 export type CalendarContextProviderProps = Props;
 
+export const propTypes = {
+	date: PropTypes.any.isRequired,
+	onDateChanged: PropTypes.func,
+	onMonthChange: PropTypes.func,
+	showTodayButton: PropTypes.bool,
+	todayBottomMargin: PropTypes.number,
+	todayButtonStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
+	disabledOpacity: PropTypes.number
+};
+
 /**
  * @description: Calendar context provider component
  * @example: https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendar.js
@@ -42,15 +53,7 @@ export type CalendarContextProviderProps = Props;
 class CalendarProvider extends Component<Props> {
   static displayName = 'CalendarProvider';
 
-  static propTypes = {
-    date: PropTypes.any.isRequired,
-    onDateChanged: PropTypes.func,
-    onMonthChange: PropTypes.func,
-    showTodayButton: PropTypes.bool,
-    todayBottomMargin: PropTypes.number,
-    todayButtonStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
-    disabledOpacity: PropTypes.number
-  };
+  static propTypes = propTypes;
 
   style = styleConstructor(this.props.theme);
   presenter = new Presenter();
@@ -170,6 +173,8 @@ class CalendarProvider extends Component<Props> {
 }
 
 export default CalendarProvider;
+
+propTypesMap.set(CalendarProvider, propTypes);
 
 const styles = StyleSheet.create({
   container: {

--- a/src/expandableCalendar/WeekCalendar/index.tsx
+++ b/src/expandableCalendar/WeekCalendar/index.tsx
@@ -17,6 +17,7 @@ import WeekDaysNames from '../../commons/WeekDaysNames';
 import Week from '../week';
 import Presenter from './presenter';
 import constants from '../../commons/constants';
+import propTypesMap from '../../propTypesMap';
 
 const NUMBER_OF_PAGES = 2; // must be a positive number
 const applyAndroidRtlFix = constants.isAndroid && constants.isRTL;
@@ -34,6 +35,13 @@ interface State {
   items: string[];
 }
 
+export const propTypes = {
+	...CalendarList.propTypes,
+	current: PropTypes.any,
+	allowShadow: PropTypes.bool,
+	hideDayNames: PropTypes.bool
+};
+
 /**
  * @description: Week calendar component
  * @note: Should be wrapped with 'CalendarProvider'
@@ -42,12 +50,7 @@ interface State {
 class WeekCalendar extends Component<WeekCalendarProps, State> {
   static displayName = 'WeekCalendar';
 
-  static propTypes = {
-    ...CalendarList.propTypes,
-    current: PropTypes.any,
-    allowShadow: PropTypes.bool,
-    hideDayNames: PropTypes.bool
-  };
+  static propTypes = propTypes;
 
   static defaultProps = {
     firstDay: 0,
@@ -220,3 +223,5 @@ class WeekCalendar extends Component<WeekCalendarProps, State> {
 }
 
 export default asCalendarConsumer<WeekCalendarProps>(WeekCalendar);
+
+propTypesMap.set(WeekCalendar, propTypes);

--- a/src/expandableCalendar/agendaList.tsx
+++ b/src/expandableCalendar/agendaList.tsx
@@ -28,6 +28,7 @@ import {Theme} from '../types';
 import styleConstructor from './style';
 import asCalendarConsumer from './asCalendarConsumer';
 import constants from '../commons/constants';
+import propTypesMap from '../propTypesMap';
 const commons = require('./commons');
 const updateSources = commons.UpdateSources;
 
@@ -55,6 +56,16 @@ export interface AgendaListProps extends SectionListProps<any, DefaultSectionT> 
   context?: any;
 }
 
+export const propTypes = {
+	// ...SectionList.propTypes,
+	dayFormat: PropTypes.string,
+	dayFormatter: PropTypes.func,
+	useMoment: PropTypes.bool,
+	markToday: PropTypes.bool,
+	sectionStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
+	avoidDateUpdates: PropTypes.bool
+};
+
 /**
  * @description: AgendaList component
  * @note: Should be wrapped with 'CalendarProvider'
@@ -64,15 +75,7 @@ export interface AgendaListProps extends SectionListProps<any, DefaultSectionT> 
 class AgendaList extends Component<AgendaListProps> {
   static displayName = 'AgendaList';
 
-  static propTypes = {
-    // ...SectionList.propTypes,
-    dayFormat: PropTypes.string,
-    dayFormatter: PropTypes.func,
-    useMoment: PropTypes.bool,
-    markToday: PropTypes.bool,
-    sectionStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
-    avoidDateUpdates: PropTypes.bool
-  };
+  static propTypes = propTypes;
 
   static defaultProps = {
     dayFormat: 'dddd, MMM d',
@@ -276,3 +279,5 @@ class AgendaList extends Component<AgendaListProps> {
 }
 
 export default asCalendarConsumer<AgendaListProps>(AgendaList);
+
+propTypesMap.set(AgendaList, propTypes);

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -35,6 +35,7 @@ import WeekCalendar from './WeekCalendar';
 import asCalendarConsumer from './asCalendarConsumer';
 
 import constants from '../commons/constants';
+import propTypesMap from '../propTypesMap';
 const commons = require('./commons');
 const updateSources = commons.UpdateSources;
 enum Positions {
@@ -84,6 +85,21 @@ interface State {
   screenReaderEnabled: boolean;
 }
 
+export const propTypes = {
+	...CalendarList.propTypes,
+	initialPosition: PropTypes.oneOf(values(Positions)),
+	onCalendarToggled: PropTypes.func,
+	disablePan: PropTypes.bool,
+	hideKnob: PropTypes.bool,
+	leftArrowImageSource: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.func]),
+	rightArrowImageSource: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.func]),
+	allowShadow: PropTypes.bool,
+	disableWeekScroll: PropTypes.bool,
+	openThreshold: PropTypes.number,
+	closeThreshold: PropTypes.number,
+	closeOnDayPress: PropTypes.bool
+};
+
 /**
  * @description: Expandable calendar component
  * @note: Should be wrapped with 'CalendarProvider'
@@ -94,20 +110,7 @@ interface State {
 class ExpandableCalendar extends Component<ExpandableCalendarProps, State> {
   static displayName = 'ExpandableCalendar';
 
-  static propTypes = {
-    ...CalendarList.propTypes,
-    initialPosition: PropTypes.oneOf(values(Positions)),
-    onCalendarToggled: PropTypes.func,
-    disablePan: PropTypes.bool,
-    hideKnob: PropTypes.bool,
-    leftArrowImageSource: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.func]),
-    rightArrowImageSource: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.func]),
-    allowShadow: PropTypes.bool,
-    disableWeekScroll: PropTypes.bool,
-    openThreshold: PropTypes.number,
-    closeThreshold: PropTypes.number,
-    closeOnDayPress: PropTypes.bool
-  };
+  static propTypes = propTypes;
 
   static defaultProps = {
     horizontal: true,
@@ -603,3 +606,5 @@ class ExpandableCalendar extends Component<ExpandableCalendarProps, State> {
 }
 
 export default asCalendarConsumer<ExpandableCalendarProps>(ExpandableCalendar);
+
+propTypesMap.set(ExpandableCalendar, propTypes);

--- a/src/expandableCalendar/week.tsx
+++ b/src/expandableCalendar/week.tsx
@@ -9,17 +9,20 @@ import {extractComponentProps} from '../componentUpdater';
 import styleConstructor from './style';
 import Calendar, {CalendarProps} from '../calendar';
 import Day from '../calendar/day/index';
+import propTypesMap from '../propTypesMap';
 // import BasicDay from '../calendar/day/basic';
 
 
 export type WeekProps = CalendarProps;
 
+export const propTypes = {
+	...Calendar.propTypes
+};
+
 class Week extends PureComponent<WeekProps> {
   static displayName = 'Week';
 
-  static propTypes = {
-    ...Calendar.propTypes
-  };
+  static propTypes = propTypes;
 
   style = styleConstructor(this.props.theme);
 
@@ -83,3 +86,5 @@ class Week extends PureComponent<WeekProps> {
 }
 
 export default Week;
+
+propTypesMap.set(Week, propTypes);

--- a/src/propTypesMap.ts
+++ b/src/propTypesMap.ts
@@ -1,0 +1,5 @@
+import { ReactComponentLike } from "prop-types";
+
+const propTypesMap = new Map<ReactComponentLike, object>();
+
+export default propTypesMap;


### PR DESCRIPTION
The purpose of this PR is to be able to use this library on the web.
If you try the library locally or on a  CodeSandbox, it works as a charm.
The problem is when CRA (`create-react-app`) builds a release. In its build process, CRA remove the components' `propTypes` for production.
Since the library uses `propTypes` to know what props to pass to lower components, all props can't pass down and it breaks in production (on web).

This PR comes to allow `componentUpdater.ts` to get components' `propTypes` by another way using a shared `Map` called `propTypesMap`. Each component set its own `propTypes` in the `propTypesMap`.

This pattern prevent CRA to remove `propTypes`.
