### PR TITLE
Fixed Issue in agenda where clicking on a new date renders a part of the previously selected date

### DIFF
--- a/src/agenda/index.tsx
+++ b/src/agenda/index.tsx
@@ -137,7 +137,7 @@ export default class Agenda extends Component<AgendaProps, State> {
   componentDidUpdate(prevProps: AgendaProps, prevState: State) {
     const newSelectedDate = this.getSelectedDate(this.props.selected);
     
-    if (!sameDate(newSelectedDate, prevState.selectedDay)) {
+    if (sameDate(newSelectedDate, prevState.selectedDay)) {
       const prevSelectedDate = this.getSelectedDate(prevProps.selected);
       if (!sameDate(newSelectedDate, prevSelectedDate)) {
         this.setState({selectedDay: newSelectedDate});

--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -113,7 +113,7 @@ class ReservationList extends Component<ReservationListProps, State> {
 
   componentDidUpdate(prevProps: ReservationListProps) {
     if (this.props.topDay && prevProps.topDay && prevProps !== this.props) {
-      if (!sameDate(prevProps.topDay, this.props.topDay)) {
+      if (sameDate(prevProps.topDay, this.props.topDay)) {
         this.setState({reservations: []},
           () => this.updateReservations(this.props)
         );


### PR DESCRIPTION
Background : 
Fixes #1791 

Found the component where the data is wrongly updated:

**1. In react-native-calendars/src/agenda/index.js:**
```
...
if (!sameDate(newSelectedDate, prevState.selectedDay)) {
            const prevSelectedDate = this.getSelectedDate(prevProps.selected);
}
...
```

_changes to:_

```
...
if (sameDate(newSelectedDate, prevState.selectedDay)) {
            const prevSelectedDate = this.getSelectedDate(prevProps.selected);
}
...
```
**2. In react-native-calendars/src/agenda/reservation-list/index.js:**

```
...
if (!sameDate(prevProps.topDay, this.props.topDay)) {
                this.setState({ reservations: [] }, () => this.updateReservations(this.props));
            }
...
```

 _changes to:_

```
...
if (sameDate(newSelectedDate, prevState.selectedDay)) {
            const prevSelectedDate = this.getSelectedDate(prevProps.selected);
}
...
```

Hope this helps!

