### PR TITLE
Agenda - scroll to new selected date

### DIFF
--- a/src/agenda/index.tsx
+++ b/src/agenda/index.tsx
@@ -141,6 +141,7 @@ export default class Agenda extends Component<AgendaProps, State> {
       const prevSelectedDate = this.getSelectedDate(prevProps.selected);
       if (!sameDate(newSelectedDate, prevSelectedDate)) {
         this.setState({selectedDay: newSelectedDate});
+        this.calendar?.current?.scrollToDay(newSelectedDate, this.calendarOffset(), true);
       }
     } else if (!prevProps.items) {
       this.loadReservations(this.props);


### PR DESCRIPTION
When 'selected' prop changes we set the new `selectedDate` to state, but the calendar doesn't scroll to that date and keeps its position on the previous `selectedDate`. This is a fix for that scenario.