### PR TITLE
Agenda - fixed reservation list scroll on day select when showOnlySelectedDayItems is true

### DIFF
--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -128,10 +128,10 @@ class ReservationList extends Component<ReservationListProps, State> {
   }
 
   updateReservations(props: ReservationListProps) {
-    const {selectedDay} = props;
+    const {selectedDay, showOnlySelectedDayItems} = props;
     const reservations = this.getReservations(props);
     
-    if (this.list && !sameDate(selectedDay, this.selectedDay)) {
+    if (!showOnlySelectedDayItems && this.list && !sameDate(selectedDay, this.selectedDay)) {
       let scrollPosition = 0;
       for (let i = 0; i < reservations.scrollPosition; i++) {
         scrollPosition += this.heights[i] || 0;


### PR DESCRIPTION
There was a bug when showOnlySelectedDayItems={true} in Agenda. If you click on the day in calendar which is after selected, list will be scrolled to bottom even if there are showOnlySelectedDayItems flag

Link to the issue: [https://github.com/wix/react-native-calendars/issues/1912](https://github.com/wix/react-native-calendars/issues/1912)