### PR TITLE
Fix TimelineCalendars arrow press

### DIFF
--- a/src/expandableCalendar/WeekCalendar/index.tsx
+++ b/src/expandableCalendar/WeekCalendar/index.tsx
@@ -64,7 +64,7 @@ class WeekCalendar extends Component<WeekCalendarProps, State> {
     const {shouldComponentUpdate, getDatesArray, scrollToIndex} = this.presenter;
 
     if (shouldComponentUpdate(this.props.context, prevProps.context)) {
-      if (!sameWeek(context.date, prevProps.context.date, firstDay)) {
+      if (!sameWeek(context.date, prevProps.context.date, firstDay) || context.numberOfDays) {
         // Don't update items if the new date is on the same week
         this.setState({items: getDatesArray(this.props)});
         scrollToIndex(false);


### PR DESCRIPTION
Fix the bug when the arrow press doesn't affect the timeline calendar days
The bug was caused because of this PR - https://github.com/wix/react-native-calendars/pull/1941 
 