### PR TITLE
release script - add 'hotfix' option in release build + fix release tag generator

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,15 @@ steps:
             value: true
           - label: "False"
             value: false
+      - select: "IS_HOTFIX_BUILD"
+        key: "is-hotfix"
+        hint: "Publish hotfix version"
+        default: 'false'
+        options:
+          - label: "True"
+            value: true
+          - label: "False"
+            value: false
 
   - label: "Build"
     command: |


### PR DESCRIPTION
Release script - 1) add a hotfix (patch version) option to the release build process. 2) Fix the release tag generator.