### PR TITLE
Support marking day indexes in markedDates prop.

### DIFF
--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -196,7 +196,7 @@ const CalendarList = (props: CalendarListProps, ref: any) => {
   const getMarkedDatesForItem = useCallback((item?: XDate) => {    
     if (markedDates && item) {      
       for (const [key, _] of Object.entries(markedDates)) {
-        if (sameMonth(new XDate(key), new XDate(item))) {
+        if (sameMonth(new XDate(key), new XDate(item)) || (typeof key === 'number' && key >= 0 && key <= 7)) {
           return markedDates;
         }
       }

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -196,7 +196,7 @@ const CalendarList = (props: CalendarListProps, ref: any) => {
   const getMarkedDatesForItem = useCallback((item?: XDate) => {    
     if (markedDates && item) {      
       for (const [key, _] of Object.entries(markedDates)) {
-        if (sameMonth(new XDate(key), new XDate(item)) || (typeof key === 'number' && key >= 0 && key <= 7)) {
+        if (sameMonth(new XDate(key), new XDate(item)) || (Number.parseInt(key) >= 0 && Number.parseInt(key) <= 7)) {
           return markedDates;
         }
       }

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -199,13 +199,15 @@ const Calendar = (props: CalendarProps) => {
       return <View key={id} style={style.current.emptyDayContainer}/>;
     }
 
+    const _marking = (markedDates?.[toMarkingFormat(day)] ?? markedDates?.[day.getDay()]) || undefined
+
     return (
       <View style={style.current.dayContainer} key={id}>
         <Day
           {...dayProps}
           date={toMarkingFormat(day)}
           state={getState(day, currentMonth, props)}
-          marking={markedDates?.[toMarkingFormat(day)]}
+          marking={_marking}
           onPress={onPressDay}
           onLongPress={onLongPressDay}
         />

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -199,7 +199,7 @@ const Calendar = (props: CalendarProps) => {
       return <View key={id} style={style.current.emptyDayContainer}/>;
     }
 
-    const _marking = (markedDates?.[toMarkingFormat(day)] ?? markedDates?.[day.getDay()]) || undefined
+    const _marking = (markedDates?.[toMarkingFormat(day)] ?? markedDates?.[day.getDay()]) || undefined;
 
     return (
       <View style={style.current.dayContainer} key={id}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import {MarkingProps} from './calendar/day/marking';
 
 export type MarkingTypes = 'dot' | 'multi-dot' | 'period' | 'multi-period' | 'custom';
 export type MarkedDates = {
-  [key: string]: MarkingProps;
+  [key: string | number]: MarkingProps;
 };
 export type DayState = 'selected' | 'disabled' | 'inactive' | 'today' | '';
 export type Direction = 'left' | 'right';

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import {MarkingProps} from './calendar/day/marking';
 
 export type MarkingTypes = 'dot' | 'multi-dot' | 'period' | 'multi-period' | 'custom';
 export type MarkedDates = {
-  [key: string | number]: MarkingProps;
+  [key: string]: MarkingProps;
 };
 export type DayState = 'selected' | 'disabled' | 'inactive' | 'today' | '';
 export type Direction = 'left' | 'right';


### PR DESCRIPTION
Achieves something similar to what was being attempted by PR #965 

Lets users put a day index in for marked date, and uses that for marking when appropriate.
Priorities specific date marks over index mark, so users can, say, mark Mondays as disabled but then allow one specific Monday.


Example usage:
```javascript
markedDates={{
  '0': {disabled: true, disableTouchEvent: true}
}}
```
This prop would disable Sundays.


