### PR TITLE
Fix wrong month setting at examples

### DIFF
--- a/example/src/screens/calendarScreen.tsx
+++ b/example/src/screens/calendarScreen.tsx
@@ -430,7 +430,7 @@ const CalendarScreen = () => {
 
   const setCustomHeaderNewMonth = (next = false) => {
     const add = next ? 1 : -1;
-    const month = customHeaderProps?.current?.month;
+    const month = new Date(customHeaderProps?.current?.month);
     const newMonth = new Date(month.setMonth(month.getMonth() + add));
     customHeaderProps?.current?.addMonth(add);
     setCurrentMonth(newMonth.toISOString().split('T')[0]);


### PR DESCRIPTION
Without these changes instead of adding 1 month, we were adding 2 months