### PR TITLE
fix date.day text not vertically centered

### DIFF
--- a/src/calendar/day/period/style.ts
+++ b/src/calendar/day/period/style.ts
@@ -15,7 +15,8 @@ export default function styleConstructor(theme: Theme = {}) {
     base: {
       width: 38,
       height: FILLER_HEIGHT,
-      alignItems: 'center'
+      alignItems: 'center',
+      justifyContent: 'center'
     },
 
     fillers: {


### PR DESCRIPTION
date.day (number) was not vertically centered on a marked period.