### PR TITLE
Period - fix - text alignment

### DIFF
--- a/example/src/screens/calendarPlaygroundScreen.tsx
+++ b/example/src/screens/calendarPlaygroundScreen.tsx
@@ -139,6 +139,7 @@ const NewCalendarScreen = () => {
 
   const periodWithDotsMarks = useMemo(() => {
     return {
+      [getDate(-3)]: {marked: true, dotColor: 'white', startingDay: true, endingDay: true, color: '#50cebb', textColor: 'white'},
       [INITIAL_DATE]: {marked: true, dotColor: '#50cebb'},
       [getDate(1)]: {disabled: true, marked: true, dotColor: '#50cebb'},
       [getDate(2)]: {startingDay: true, color: '#50cebb', textColor: 'white'},

--- a/src/calendar/day/period/index.tsx
+++ b/src/calendar/day/period/index.tsx
@@ -177,7 +177,9 @@ const PeriodDay = (props: PeriodDayProps) => {
           <Text allowFontScaling={false} style={textStyle}>
             {String(children)}
           </Text>
-          <Dot theme={theme} color={marking?.dotColor} marked={marking?.marked}/>
+          <View style={style.current.dotContainer}>
+            <Dot theme={theme} color={marking?.dotColor} marked={marking?.marked}/>
+          </View>
         </View>
       </View>
     </Component>

--- a/src/calendar/day/period/style.ts
+++ b/src/calendar/day/period/style.ts
@@ -38,12 +38,15 @@ export default function styleConstructor(theme: Theme = {}) {
     },
 
     text: {
-      marginTop: 7,
       fontSize: appStyle.textDayFontSize,
       fontFamily: appStyle.textDayFontFamily,
       fontWeight: appStyle.textDayFontWeight,
       color: appStyle.dayTextColor,
       backgroundColor: 'rgba(255, 255, 255, 0)'
+    },
+    dotContainer: {
+      position: 'absolute',
+      bottom: 3
     },
     today: {
       backgroundColor: appStyle.todayBackgroundColor


### PR DESCRIPTION
Fix text not align to center in period marking
To test go to CalendarPlaygroundScreen and select 'period' for Marking type.