### PR TITLE
Added fix for Agenda theme prop bug

### DIFF
--- a/src/componentUpdater.ts
+++ b/src/componentUpdater.ts
@@ -230,6 +230,7 @@ export function extractReservationListProps(props: AgendaProps) {
     // Reservation props
     date,
     item,
+    theme,
     rowHasChanged,
     renderDay,
     renderItem,
@@ -256,6 +257,7 @@ export function extractReservationListProps(props: AgendaProps) {
     // Reservation props
     date,
     item,
+    theme,
     rowHasChanged,
     renderDay,
     renderItem,


### PR DESCRIPTION
Fix: #2039 

This PR solves the issue of changing the date color in Agenda items via props.

<img width="1792" alt="Change date color in Agenda items fix PR" src="https://user-images.githubusercontent.com/86605635/192231477-3d53d51a-339c-43cb-b1cb-819504fab6e2.png">
