### PR TITLE
fix(#2050): prevent date overflow when the current date day is 31

### DIFF
--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -214,7 +214,7 @@ const CalendarList = (props: CalendarListProps, ref: any) => {
 
   const isDateInRange = useCallback((date) => {
     for(let i = -range.current; i <= range.current; i++) {
-      const newMonth = currentMonth?.clone().addMonths(i);
+      const newMonth = currentMonth?.clone().addMonths(i, true);
       if (sameMonth(date, newMonth)) {
         return true;
       }


### PR DESCRIPTION
Fixes this issue: [#2050](https://github.com/wix/react-native-calendars/issues/2050)