### PR TITLE
TodayButton - fix 'disabledOpacity' prop default value

### DIFF
--- a/example/src/screens/expandableCalendarScreen.tsx
+++ b/example/src/screens/expandableCalendarScreen.tsx
@@ -40,7 +40,7 @@ const ExpandableCalendarScreen = (props: Props) => {
       // onDateChanged={onDateChanged}
       // onMonthChange={onMonthChange}
       showTodayButton
-      disabledOpacity={0.5}
+      // disabledOpacity={0.6}
       theme={todayBtnTheme.current}
       // todayBottomMargin={16}
     >

--- a/src/expandableCalendar/Context/todayButton.tsx
+++ b/src/expandableCalendar/Context/todayButton.tsx
@@ -38,7 +38,7 @@ const TodayButton = (props: TodayButtonProps, ref: any) => {
 
   const {
     margin = 0,
-    disabledOpacity = 0,
+    disabledOpacity = 0.3,
     theme,
     style: propsStyle,
   } = props;


### PR DESCRIPTION
Was set to 0 so when scrolling the AgendaList the button text disappeared.
This should be hotfixed when merged.