### PR TITLE
Fix Android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,20 @@ buildscript {
 
 allprojects {
     repositories {
+        exclusiveContent {
+           // We get React Native's Android binaries exclusively through npm,
+           // from a local Maven repo inside node_modules/react-native/.
+           // (The use of exclusiveContent prevents looking elsewhere like Maven Central
+           // and potentially getting a wrong version.)
+           filter {
+               includeGroup "com.facebook.react"
+           }
+           forRepository {
+               maven {
+                   url "$rootDir/../node_modules/react-native/android"
+               }
+           }
+        }
         mavenCentral {
             // We don't want to fetch react-native from Maven Central as there are
             // older versions over there.

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react": "17.0.2",
     "react-component-driver": "^0.10.0",
     "react-native": "0.68.3",
-    "react-native-navigation": "^7.29.0",
+    "react-native-navigation": "7.30.0",
     "react-recipes": "^1.4.0",
     "react-test-renderer": "^17.0.2",
     "reassure": "^0.4.1",


### PR DESCRIPTION
Fix Android build: lock rnn version and add `exclusiveContent` to build.gradle