### PR TITLE
Add marking.fillerColor prop

### DIFF
--- a/src/calendar/day/marking/index.tsx
+++ b/src/calendar/day/marking/index.tsx
@@ -56,6 +56,7 @@ export interface MarkingProps extends DotProps {
   endingDay?: boolean;
   accessibilityLabel?: string;
   customStyles?: CustomStyle;
+  fillerColor?: string;
 }
 
 const Marking = (props: MarkingProps) => {

--- a/src/calendar/day/period/index.tsx
+++ b/src/calendar/day/period/index.tsx
@@ -128,9 +128,9 @@ const PeriodDay = (props: PeriodDayProps) => {
     const end = markingStyle.endingDay;
 
     if (start && !end) {
-      rightFillerStyle.backgroundColor = markingStyle.startingDay?.backgroundColor;
+      rightFillerStyle.backgroundColor = marking?.fillerColor ?? markingStyle.startingDay?.backgroundColor;
     } else if (end && !start) {
-      leftFillerStyle.backgroundColor = markingStyle.endingDay?.backgroundColor;
+      leftFillerStyle.backgroundColor = marking?.fillerColor ?? markingStyle.endingDay?.backgroundColor;
     } else if (markingStyle.day) {
       leftFillerStyle.backgroundColor = markingStyle.day?.backgroundColor;
       rightFillerStyle.backgroundColor = markingStyle.day?.backgroundColor;


### PR DESCRIPTION
Adds an ability to set a filler color for a specific marked point. Possible use case is when you need to set a different background color for day-start, day-end and filler points. Like so:

![2022-12-16 13 50 34](https://user-images.githubusercontent.com/102020833/208071773-8dbfdfd3-4f3c-4505-b26b-2676ce42366c.jpg)

Here is an example of how it could be achieved:
```
marked[startDate] = {
      startingDay: true,
      color: COLORS.primaryLight,
      fillerColor: COLORS.secondaryFaint,
};
marked[fillerDate] = {
      color: COLORS.secondaryFaint,
};
marked[endDate] = {
      endingDay: true,
      color: COLORS.primaryLight,
      fillerColor: COLORS.secondaryFaint,
};
``` 

