### PR TITLE
Enable pageHeight to be set as prop in calendar list and week calendar

### DIFF
--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -37,6 +37,8 @@ export interface CalendarListProps extends CalendarProps, Omit<FlatListProps<any
   showScrollIndicator?: boolean;
   /** Whether to animate the auto month scroll */
   animateScroll?: boolean;
+  /** Page height to set week calendar height or calendar list height */
+  pageHeight?: number;
 }
 
 export interface CalendarListImperativeMethods {

--- a/src/calendar-list/new.tsx
+++ b/src/calendar-list/new.tsx
@@ -37,7 +37,8 @@ const CalendarList = (props: CalendarListProps) => {
     staticHeader, 
     scrollViewProps,
     calendarProps,
-    testID
+    testID,
+    pageHeight = CALENDAR_HEIGHT
   } = props;
   const style = useRef(styleConstructor(calendarProps?.theme));
   const list = useRef<ScrollView>();
@@ -209,7 +210,7 @@ const CalendarList = (props: CalendarListProps) => {
         style={style.current.container}
         initialPageIndex={scrollRange}
         positionIndex={positionIndex}
-        pageHeight={CALENDAR_HEIGHT}
+        pageHeight={pageHeight}
         pageWidth={constants.screenWidth}
         onPageChange={onPageChange}
         scrollViewProps={scrollProps}

--- a/src/calendar-list/new.tsx
+++ b/src/calendar-list/new.tsx
@@ -24,6 +24,8 @@ export interface CalendarListProps {
   calendarProps?: CalendarProps;
   /** Identifier for testing */
   testID?: string;
+  /** Page height to set week calendar height or calendar list height */
+  pageHeight?: number;
 }
 
 const NUMBER_OF_PAGES = 50;

--- a/src/expandableCalendar/WeekCalendar/new.tsx
+++ b/src/expandableCalendar/WeekCalendar/new.tsx
@@ -23,7 +23,7 @@ export interface WeekCalendarProps extends CalendarListProps {
 const NUMBER_OF_PAGES = 50;
 
 const WeekCalendar = (props: WeekCalendarProps) => {
-  const {current, firstDay = 0, markedDates, allowShadow = true, hideDayNames, theme, calendarWidth, testID} = props;
+  const {current, firstDay = 0, markedDates, allowShadow = true, hideDayNames, theme, calendarWidth, testID, pageHeight = 48} = props;
   const context = useContext(CalendarContext);
   const {date, updateSource} = context;
   const style = useRef(styleConstructor(theme));
@@ -119,7 +119,7 @@ const WeekCalendar = (props: WeekCalendarProps) => {
           extendedState={extraData}
           style={style.current.container}
           initialPageIndex={NUMBER_OF_PAGES}
-          pageHeight={48}
+          pageHeight={pageHeight}
           pageWidth={containerWidth}
           onPageChange={onPageChange}
           scrollViewProps={{


### PR DESCRIPTION
Currently the pageHeight param on WeekCalendar and CalendarList was hardcoded to 48 in WeekCalendar and 360 in CalendarList. In this PR you can also override the pageHeight with your custom value.