### PR TITLE
WeekCalendar - Fix day item not re-rendered when using `dayComponent`

### DIFF
--- a/src/expandableCalendar/WeekCalendar/index.tsx
+++ b/src/expandableCalendar/WeekCalendar/index.tsx
@@ -96,7 +96,7 @@ const WeekCalendar = (props: WeekCalendarProps) => {
     return [{width: containerWidth}, propsStyle];
   }, [containerWidth, propsStyle]);
 
-  const renderItem = useCallback(({item}: {item: string}) => {
+  const renderItem = ({item}: {item: string}) => {
     const currentContext = sameWeek(date, item, firstDay) ? context : undefined;
 
     return (
@@ -111,7 +111,7 @@ const WeekCalendar = (props: WeekCalendarProps) => {
         timelineLeftInset={timelineLeftInset}
       />
     );
-  },[firstDay, _onDayPress, context, date]);
+  };
 
   const keyExtractor = useCallback((item) => item, []);
 

--- a/src/expandableCalendar/WeekCalendar/new.tsx
+++ b/src/expandableCalendar/WeekCalendar/new.tsx
@@ -74,28 +74,25 @@ const WeekCalendar = (props: WeekCalendarProps) => {
     [items]
   );
 
-  const renderItem = useCallback(
-    (_type: any, item: string) => {
-      const {allowShadow, ...calendarListProps} = props;
-      const {/* style,  */ ...others} = extractCalendarProps(calendarListProps);
+  const renderItem = (_type: any, item: string) => {
+    const {allowShadow, ...calendarListProps} = props;
+    const {/* style,  */ ...others} = extractCalendarProps(calendarListProps);
 
-      const isSameWeek = sameWeek(item, date, firstDay);
+    const isSameWeek = sameWeek(item, date, firstDay);
 
-      return (
-        <Week
-          {...others}
-          key={item}
-          current={isSameWeek ? date : item}
-          firstDay={firstDay}
-          style={weekStyle}
-          markedDates={markedDates}
-          onDayPress={onDayPress}
-          context={context}
-        />
-      );
-    },
-    [date, markedDates]
-  );
+    return (
+      <Week
+        {...others}
+        key={item}
+        current={isSameWeek ? date : item}
+        firstDay={firstDay}
+        style={weekStyle}
+        markedDates={markedDates}
+        onDayPress={onDayPress}
+        context={context}
+      />
+    );
+  };
 
   return (
     <View


### PR DESCRIPTION
There is problem with current `renderItem` on `WeekCalendar/new.tsx` and `WeekCalendar/index.tsx` where it doesn’t get updated when using custom `dayComponent`. This PR removes `useCallback` to fix it.