### PR TITLE
Remove unused dependency on immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "license": "MIT",
   "dependencies": {
     "hoist-non-react-statics": "^3.3.1",
-    "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",
     "memoize-one": "^5.2.1",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
It looks like this dependency isn't used anymore — this change removes it. I spotted this while looking at our bundle and realized `immutable` doesn't seem to be used.

Thanks for the library!