### PR TITLE
fix overriding agenda list style

### DIFF
--- a/src/agenda/reservation-list/style.ts
+++ b/src/agenda/reservation-list/style.ts
@@ -38,6 +38,6 @@ export default function styleConstructor(theme: Theme = {}) {
       marginTop: 80
     },
     // @ts-expect-error
-    ...(theme['stylesheet.agenda.list'] || {})
+    ...(theme.stylesheet.agenda.list || {})
   });
 }


### PR DESCRIPTION
hello friends,

I was trying to change the background colour on the agenda list and I have spotted the below bug. The container styling was not being overridden. 

Cheers