### PR TITLE
fix broken links in docs

### DIFF
--- a/docsRNC/docs/Agenda.md
+++ b/docsRNC/docs/Agenda.md
@@ -1,7 +1,7 @@
 Agenda component  
 [(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/agenda.tsx)
 :::info
-This component extends **[CalendarList, FlatList](https://github.com/wix/react-native-calendars/blob/master/src/calendar-list/index.tsx,https://reactnative.dev/docs/flatlist)** props.
+This component extends **[CalendarList](https://github.com/wix/react-native-calendars/blob/master/src/calendar-list/index.tsx), [FlatList](https://reactnative.dev/docs/flatlist)** props.
 :::
 
 <div style={{display: 'flex', flexDirection: 'row', overflowX: 'auto', maxHeight: '500px', alignItems: 'center'}}><img style={{maxHeight: '420px'}} src={'https://github.com/wix/react-native-calendars/blob/master/demo/assets/agenda.gif?raw=true'}/>

--- a/docsRNC/docs/Agenda.md
+++ b/docsRNC/docs/Agenda.md
@@ -1,5 +1,5 @@
 Agenda component  
-[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/agenda.tsx)
+[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/agendaScreen.tsx)
 :::info
 This component extends **[CalendarList](https://github.com/wix/react-native-calendars/blob/master/src/calendar-list/index.tsx), [FlatList](https://reactnative.dev/docs/flatlist)** props.
 :::

--- a/docsRNC/docs/AgendaList.md
+++ b/docsRNC/docs/AgendaList.md
@@ -1,5 +1,5 @@
 Agenda list component for the `ExpandableCalendar` component.  
-[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendar.tsx)
+[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendarScreen.tsx)
 :::info
 This component extends **[FlatList](https://reactnative.dev/docs/flatlist)** props.
 :::

--- a/docsRNC/docs/Calendar.md
+++ b/docsRNC/docs/Calendar.md
@@ -1,5 +1,5 @@
 Calendar component  
-[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/calendars.tsx)
+[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/calendarScreen.tsx)
 :::info
 This component extends **[CalendarHeader](https://github.com/wix/react-native-calendars/blob/master/src/calendar/header/index.tsx), [BasicDay](https://github.com/wix/react-native-calendars/blob/master/src/calendar/day/basic/index.tsx)** props.
 :::

--- a/docsRNC/docs/Calendar.md
+++ b/docsRNC/docs/Calendar.md
@@ -1,7 +1,7 @@
 Calendar component  
 [(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/calendars.tsx)
 :::info
-This component extends **[CalendarHeader, BasicDay](https://github.com/wix/react-native-calendars/blob/master/src/calendar/header/index.tsx,https://github.com/wix/react-native-calendars/blob/master/src/calendar/day/basic/index.tsx)** props.
+This component extends **[CalendarHeader](https://github.com/wix/react-native-calendars/blob/master/src/calendar/header/index.tsx), [BasicDay](https://github.com/wix/react-native-calendars/blob/master/src/calendar/day/basic/index.tsx)** props.
 :::
 
 <div style={{display: 'flex', flexDirection: 'row', overflowX: 'auto', maxHeight: '500px', alignItems: 'center'}}><img style={{maxHeight: '420px'}} src={'https://github.com/wix/react-native-calendars/blob/master/demo/assets/calendar.gif?raw=true'}/>

--- a/docsRNC/docs/CalendarList.md
+++ b/docsRNC/docs/CalendarList.md
@@ -1,5 +1,5 @@
 Calendar list component  
-[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/calendarsList.tsx)
+[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/calendarListScreen.tsx)
 :::info
 This component extends **[Calendar](https://github.com/wix/react-native-calendars/blob/master/src/calendar/index.tsx), [FlatList](https://reactnative.dev/docs/flatlist)** props.
 :::

--- a/docsRNC/docs/CalendarProvider.md
+++ b/docsRNC/docs/CalendarProvider.md
@@ -1,5 +1,5 @@
 Calendar context provider component  
-[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendar.tsx)
+[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendarScreen.tsx)
 :::info
 This component extends **[Context](https://reactjs.org/docs/context.html)** props.
 :::

--- a/docsRNC/docs/ExpandableCalendar.md
+++ b/docsRNC/docs/ExpandableCalendar.md
@@ -1,5 +1,5 @@
 Expandable calendar component  
-[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendar.tsx)
+[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendarScreen.tsx)
 :::info
 This component extends **[CalendarList](https://github.com/wix/react-native-calendars/blob/master/src/calendar-list/index.tsx)** props.
 :::

--- a/docsRNC/docs/Timeline.md
+++ b/docsRNC/docs/Timeline.md
@@ -1,5 +1,5 @@
 Timeline component  
-[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/timelineCalendar.tsx)
+[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/timelineCalendarScreen.tsx)
 :::info
 This component extends **[ScrollView](https://reactnative.dev/docs/scrollview)** props.
 :::

--- a/docsRNC/docs/WeekCalendar.md
+++ b/docsRNC/docs/WeekCalendar.md
@@ -1,5 +1,5 @@
 Week calendar component  
-[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendar.tsx)
+[(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendarScreen.tsx)
 :::info
 This component extends **[CalendarList](https://github.com/wix/react-native-calendars/blob/master/src/calendar-list/index.tsx)** props.
 :::

--- a/docsRNC/docusaurus.config.js
+++ b/docsRNC/docusaurus.config.js
@@ -25,7 +25,7 @@ const config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/'
+          editUrl: 'https://github.com/wix/react-native-calendars/tree/master/docsRNC'
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
Fixing:

- Links to other components where there's more than 1 are broken because of invalid Markdown code, splitting them into their own links
- Links to example screens are broken, replacing with new file names
- Clicking `Edit this page` in the docs takes to a 404 because URL is not specified, setting is to the correct path in docs config