### PR TITLE
Prevent date overflow on pressing arrows ( if currentDate > days in month)

### DIFF
--- a/src/calendar-list/item.tsx
+++ b/src/calendar-list/item.tsx
@@ -59,7 +59,7 @@ const CalendarListItem = React.memo((props: CalendarListItemProps) => {
         onPressArrowLeft(method, monthClone);
       } else if (scrollToMonth) {
         const currentMonth = monthClone.getMonth();
-        monthClone.addMonths(-1);
+        monthClone.addMonths(-1, true);
         // Make sure we actually get the previous month, not just 30 days before currentMonth.
         while (monthClone.getMonth() === currentMonth) {
           monthClone.setDate(monthClone.getDate() - 1);
@@ -75,7 +75,7 @@ const CalendarListItem = React.memo((props: CalendarListItemProps) => {
       if (onPressArrowRight) {
         onPressArrowRight(method, monthClone);
       } else if (scrollToMonth) {
-        monthClone.addMonths(1);
+        monthClone.addMonths(1, true);
         scrollToMonth(monthClone);
       }
     }


### PR DESCRIPTION
Prevent date overflow when the current date is greater than days in the next month (for example current 30 or 31 and switch from January to February, with only 28 or 29 days) (familiar to #2051)