### PR TITLE
Fix date number not centered vertically

### DIFF
--- a/src/calendar/day/basic/style.ts
+++ b/src/calendar/day/basic/style.ts
@@ -13,7 +13,8 @@ export default function styleConstructor(theme: Theme = {}) {
     base: {
       width: 32,
       height: 32,
-      alignItems: 'center'
+      alignItems: 'center',
+      justifyContent: 'center'
     },
     text: {
       marginTop: constants.isAndroid ? 4 : 6,


### PR DESCRIPTION
When using a custom font, the date number of the selected date in the standard calendar is not vertically centered.

![calendar_before](https://user-images.githubusercontent.com/12571550/230644677-351caf16-2684-4897-b312-17931c952ee5.png)


![calendar_after](https://user-images.githubusercontent.com/12571550/230644681-4e328831-602f-4b06-a244-7e12642532be.png)

Same thing was already done for the "period" styling in a different PR, see: https://github.com/wix/react-native-calendars/pull/2026