### PR TITLE
Dynamic height on CalendarListItem

### DIFF
--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -20,6 +20,7 @@ const CALENDAR_WIDTH = constants.screenWidth;
 const CALENDAR_HEIGHT = 360;
 const PAST_SCROLL_RANGE = 50;
 const FUTURE_SCROLL_RANGE = 50;
+const CALENDAR_LINE_HEIGHT = 70;
 
 export interface CalendarListProps extends CalendarProps, Omit<FlatListProps<any>, 'data' | 'renderItem'> {
   /** Max amount of months allowed to scroll to the past. Default = 50 */
@@ -223,10 +224,16 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
     return false;
   }, [currentMonth]);
 
-  const renderItem = useCallback(({item}: {item: XDate}) => {
+  const renderItem = useCallback(({item, index}: {item: XDate, index: number}) => {
     const dateString = toMarkingFormat(item);
     const [year, month] = dateString.split('-');
     const testId = `${testID}.item_${year}-${month}`;
+    let dynamicHeight;
+    if(index === 0) {
+      const daysInCurrentMonth = new Date(Number(year), Number(month), 0).getDate();
+      const latestDays = daysInCurrentMonth - initialDate.current.getDate();
+      dynamicHeight = latestDays / 7 * CALENDAR_LINE_HEIGHT;
+    };
     return (
       <CalendarListItem
         {...calendarProps}
@@ -237,7 +244,7 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
         // @ts-expect-error - type mismatch - ScrollView's 'horizontal' is nullable
         horizontal={horizontal}
         calendarWidth={calendarWidth}
-        calendarHeight={calendarHeight}
+        calendarHeight={dynamicHeight || calendarHeight}
         scrollToMonth={scrollToMonth}
         visible={isDateInRange(item)}
       />

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -232,7 +232,7 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
     if(index === 0) {
       const daysInCurrentMonth = new Date(Number(year), Number(month), 0).getDate();
       const latestDays = daysInCurrentMonth - initialDate.current.getDate();
-      dynamicHeight = latestDays / 7 * CALENDAR_LINE_HEIGHT;
+      dynamicHeight = Math.round(latestDays / 7) * CALENDAR_LINE_HEIGHT
     };
     return (
       <CalendarListItem

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -15,12 +15,13 @@ import styleConstructor from './style';
 import Calendar, {CalendarProps} from '../calendar';
 import CalendarListItem from './item';
 import CalendarHeader from '../calendar/header/index';
+import { BASIC_DAY_HEIGHT } from 'src/calendar/day/basic/style';
+import { HEADER_HEIGHT } from 'src/expandableCalendar/style';
 
 const CALENDAR_WIDTH = constants.screenWidth;
 const CALENDAR_HEIGHT = 360;
 const PAST_SCROLL_RANGE = 50;
 const FUTURE_SCROLL_RANGE = 50;
-const CALENDAR_LINE_HEIGHT = 70;
 
 export interface CalendarListProps extends CalendarProps, Omit<FlatListProps<any>, 'data' | 'renderItem'> {
   /** Max amount of months allowed to scroll to the past. Default = 50 */
@@ -39,8 +40,12 @@ export interface CalendarListProps extends CalendarProps, Omit<FlatListProps<any
   showScrollIndicator?: boolean;
   /** Whether to animate the auto month scroll */
   animateScroll?: boolean;
-    /** Used to makes the calendar height dynamic based on how much days are showing */
-    calendarHeightDynamic?: boolean
+  /** Used to makes the calendar height dynamic based on how much days are showing */
+  calendarHeightDynamic?: boolean
+  /** Used to have the height of the day compoent for calculate the dynamic height */
+  dayHeight?: number;
+  /** Used to have the height of the custom header for calculate the dynamic height */
+  headerHeight?: number;
 }
 
 export interface CalendarListImperativeMethods {
@@ -80,6 +85,8 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
     calendarHeight = CALENDAR_HEIGHT,
     calendarWidth = CALENDAR_WIDTH,
     calendarHeightDynamic = false,
+    dayHeight = BASIC_DAY_HEIGHT,
+    headerHeight = HEADER_HEIGHT,
     calendarStyle,
     animateScroll = false,
     showScrollIndicator = false,
@@ -229,9 +236,11 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
 
   const getCalendarHeight = useCallback(({index, month, year}: {index: number, month: string, year: string}) => {
     if(calendarHeightDynamic && index === 0) {
-        const daysInCurrentMonth = new Date(Number(year), Number(month), 0).getDate();
-        const latestDays = daysInCurrentMonth - initialDate.current.getDate()
-        return Math.round(latestDays / 7) * CALENDAR_LINE_HEIGHT
+      const daysInCurrentMonth = new Date(Number(year), Number(month), 0).getDate();
+      const latestDays = daysInCurrentMonth - initialDate.current.getDate() + 1
+      const numWeeks = Math.round(latestDays / 7)
+
+      return (dayHeight * numWeeks) + headerHeight
     }
     return calendarHeight
   }, [])

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -39,6 +39,8 @@ export interface CalendarListProps extends CalendarProps, Omit<FlatListProps<any
   showScrollIndicator?: boolean;
   /** Whether to animate the auto month scroll */
   animateScroll?: boolean;
+    /** Used to makes the calendar height dynamic based on how much days are showing */
+    calendarHeightDynamic?: boolean
 }
 
 export interface CalendarListImperativeMethods {
@@ -77,6 +79,7 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
     futureScrollRange = FUTURE_SCROLL_RANGE,
     calendarHeight = CALENDAR_HEIGHT,
     calendarWidth = CALENDAR_WIDTH,
+    calendarHeightDynamic = false,
     calendarStyle,
     animateScroll = false,
     showScrollIndicator = false,
@@ -224,16 +227,20 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
     return false;
   }, [currentMonth]);
 
+  const getCalendarHeight = useCallback(({index, month, year}: {index: number, month: string, year: string}) => {
+    if(calendarHeightDynamic && index === 0) {
+        const daysInCurrentMonth = new Date(Number(year), Number(month), 0).getDate();
+        const latestDays = daysInCurrentMonth - initialDate.current.getDate()
+        return Math.round(latestDays / 7) * CALENDAR_LINE_HEIGHT
+    }
+    return calendarHeight
+  }, [])
+
   const renderItem = useCallback(({item, index}: {item: XDate, index: number}) => {
     const dateString = toMarkingFormat(item);
     const [year, month] = dateString.split('-');
     const testId = `${testID}.item_${year}-${month}`;
-    let dynamicHeight;
-    if(index === 0) {
-      const daysInCurrentMonth = new Date(Number(year), Number(month), 0).getDate();
-      const latestDays = daysInCurrentMonth - initialDate.current.getDate();
-      dynamicHeight = Math.round(latestDays / 7) * CALENDAR_LINE_HEIGHT
-    };
+
     return (
       <CalendarListItem
         {...calendarProps}
@@ -244,7 +251,7 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
         // @ts-expect-error - type mismatch - ScrollView's 'horizontal' is nullable
         horizontal={horizontal}
         calendarWidth={calendarWidth}
-        calendarHeight={dynamicHeight || calendarHeight}
+        calendarHeight={getCalendarHeight(index, month, year)}
         scrollToMonth={scrollToMonth}
         visible={isDateInRange(item)}
       />

--- a/src/calendar/day/basic/style.ts
+++ b/src/calendar/day/basic/style.ts
@@ -3,12 +3,15 @@ import * as defaultStyle from '../../../style';
 import {Theme} from '../../../types';
 import constants from '../../../commons/constants';
 
+export const BASIC_DAY_HEIGHT = 32
+
 export default function styleConstructor(theme: Theme = {}) {
   const appStyle = {...defaultStyle, ...theme};
   return StyleSheet.create({
     container: {
       alignSelf: 'stretch',
-      alignItems: 'center'
+      alignItems: 'center',
+      height: BASIC_DAY_HEIGHT,
     },
     base: {
       width: 32,

--- a/src/calendar/header/style.ts
+++ b/src/calendar/header/style.ts
@@ -3,6 +3,8 @@ import * as defaultStyle from '../../style';
 import {Theme} from '../../types';
 import constants from '../../commons/constants';
 
+export const HEADER_HEIGHT = 40
+
 export default function (theme: Theme = {}) {
   const appStyle = {...defaultStyle, ...theme};
   const rtlStyle = constants.isRTL ? {transform: [{scaleX: -1}]} : undefined;
@@ -15,6 +17,7 @@ export default function (theme: Theme = {}) {
       paddingRight: 10,
       marginTop: 6,
       alignItems: 'center',
+      height: HEADER_HEIGHT,
     },
     partialHeader: {
       paddingHorizontal: 15


### PR DESCRIPTION
## Description

### Issue related: Doesn't exist a feature of dynamic height on CalendarListItem #2209 

I've been using the react-native-calendars in my project to show the list of one year in the calendar list component. Unfortully until the beginner I prepared if the first mount didn't start on the first day, for example, on April 15, the height of the calendar will be the same then the end of the mouth will be empty (example above)

<div>
<img src='https://user-images.githubusercontent.com/33518714/231162569-501bee6d-dc80-4d84-b7e1-2d26f3b88e94.png' height='500'/>
<img src='https://user-images.githubusercontent.com/33518714/231162577-4f6f0983-6ced-4137-b355-0244eb827b2a.jpg' height='500'/>
</div>

## Propose Solution
for me, the CalendarListItem height needs to be dynamic based on the initial date of the month. So if the month is full like starting on the 1st the height will be full but if the month started on the 15th the height need to be half of the full month.

I made a little change to the code and works for me, however, I would like to see with this PR if I need to consider more use cases of that and which improvement I need to do for this PR to be merged.

here we have these examples of the same screen, one with the current code and the other with my code.

<div>
<img src='https://user-images.githubusercontent.com/33518714/231163630-5f324b42-d833-45de-ae2e-6861eca377c9.png' height='500'/>
<img src='https://user-images.githubusercontent.com/33518714/231163638-099165da-8605-41d3-bfd1-0541ac9fb7c1.png' height='500'/>
</div>
<br>
To give a breath explanation of the code, I'm basically using the index of the renderItem to look for the first element of the calendar. after that, I take how many days this month has in total, and then after already knowing the initial date I can subtract the initial date of the total days to have the latest days of the month. With that value, I can divide it by 7 (a week) to get how many lines the calendar will have and then multiply by the CALENDAR_LINE_HEIGHT to get the height of this month.