### PR TITLE
Fix the render issue of CalendarList in Agenda component caused by a race condition on layout change

### DIFF
--- a/src/agenda/index.tsx
+++ b/src/agenda/index.tsx
@@ -269,6 +269,7 @@ export default class Agenda extends Component<AgendaProps, State> {
   onLayout = (event: LayoutChangeEvent) => {
     this.viewHeight = event.nativeEvent.layout.height;
     this.viewWidth = event.nativeEvent.layout.width;
+    this.calendar?.current?.scrollToDay(this.state.selectedDay, this.calendarOffset(), false);
     this.forceUpdate();
   };
 


### PR DESCRIPTION
Sometimes the header with days in an agenda component is not displayed correctly after the initial render. For example, in the screenshot below, the selected day is 19th April, but the header shows the days from the previous week. 

The cause I found is that `onLayout` callback sometimes is called after [`onCalendarListLayout`](https://github.com/wix/react-native-calendars/blob/master/src/agenda/index.tsx#L265). The `calendarOffset` used in `onCalendarListLayout` depends on the `viewHeight` that is updated by `onLayout`. When this happens, the offset passed to `CalendarList.scrollToDay` will be incorrect, and therefore causes the rendering issue. 

The fix may help [issue 1228](https://github.com/wix/react-native-calendars/issues/1228) and [issue 519](https://github.com/wix/react-native-calendars/issues/519) too. 

![Simulator Screenshot - iPhone 14 - 2023-04-19 at 17 18 25](https://user-images.githubusercontent.com/31921080/233141102-02700054-0b02-4257-a765-1dd80b49838a.png)
