### PR TITLE
WeekCalendar - fix scroll position when 'numberOfDays' prop changes

### DIFF
--- a/src/expandableCalendar/WeekCalendar/index.tsx
+++ b/src/expandableCalendar/WeekCalendar/index.tsx
@@ -55,6 +55,7 @@ const WeekCalendar = (props: WeekCalendarProps) => {
     items.current = getDatesArray(date, firstDay, numberOfDays);
     setListData(items.current);
     visibleWeek.current = date;
+    list?.current?.scrollToIndex({index: NUMBER_OF_PAGES, animated: false});
   }, [numberOfDays]);
 
   useDidUpdate(() => {


### PR DESCRIPTION
WeekCalendar - fix scroll position when 'numberOfDays' prop changes