### PR TITLE
upgrade recyclerlistview to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "memoize-one": "^5.2.1",
     "prop-types": "^15.5.10",
     "react-native-swipe-gestures": "^1.0.5",
-    "recyclerlistview": "^3.0.5",
+    "recyclerlistview": "^4.0.0",
     "xdate": "^0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade is needed b/c this project brings in an old version of `promise` that breaks Sentry's promise swizzle

```
├─┬ @wix/glimpse@0.2.0
│   └── promise@8.3.0
└─┬ @wix/wix-react-native-ui-lib@5.51.6
  └─┬ react-native-calendars@1.1295.0
    └─┬ recyclerlistview@3.0.5
      └─┬ prop-types@15.5.8
        └─┬ fbjs@0.8.18
          └── promise@7.3.1 /// <--- we want v8
```
After the upgrade:
```
└─┬ recyclerlistview@4.2.0
  └─┬ react-native@0.71.8
    └── promise@8.3.0
```