### PR TITLE
CalendarList - fix staticHeader moves month out of range

### DIFF
--- a/example/src/screens/calendarListScreen.tsx
+++ b/example/src/screens/calendarListScreen.tsx
@@ -44,8 +44,8 @@ const CalendarListScreen = (props: Props) => {
     <CalendarList
       testID={testIDs.calendarList.CONTAINER}
       current={initialDate}
-      pastScrollRange={0}
-      futureScrollRange={12}
+      pastScrollRange={RANGE}
+      futureScrollRange={RANGE}
       onDayPress={onDayPress}
       markedDates={marked}
       renderHeader={!horizontalView ? renderCustomHeader : undefined}
@@ -54,7 +54,6 @@ const CalendarListScreen = (props: Props) => {
       horizontal={horizontalView}
       pagingEnabled={horizontalView}
       staticHeader={horizontalView}
-      minDate={initialDate}
     />
   );
 };

--- a/example/src/screens/calendarListScreen.tsx
+++ b/example/src/screens/calendarListScreen.tsx
@@ -44,8 +44,8 @@ const CalendarListScreen = (props: Props) => {
     <CalendarList
       testID={testIDs.calendarList.CONTAINER}
       current={initialDate}
-      pastScrollRange={RANGE}
-      futureScrollRange={RANGE}
+      pastScrollRange={0}
+      futureScrollRange={12}
       onDayPress={onDayPress}
       markedDates={marked}
       renderHeader={!horizontalView ? renderCustomHeader : undefined}
@@ -54,6 +54,7 @@ const CalendarListScreen = (props: Props) => {
       horizontal={horizontalView}
       pagingEnabled={horizontalView}
       staticHeader={horizontalView}
+      minDate={initialDate}
     />
   );
 };

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -137,6 +137,12 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
     });
   }, [items]);
 
+  const getDateIndex = useCallback((date: string) => {
+    return findIndex(items, function(item) {
+      return item.toString() === date.toString();
+    });
+  }, [items]);
+
   useEffect(() => {
     if (current) {
       scrollToMonth(new XDate(current));
@@ -188,7 +194,7 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
 
   const addMonth = useCallback((count: number) => {
     const day = currentMonth?.clone().addMonths(count, true);
-    if (sameMonth(day, currentMonth)) {
+    if (sameMonth(day, currentMonth) || getDateIndex(day) === -1) {
       return;
     }
     scrollToMonth(day);
@@ -280,7 +286,7 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
       onViewableItemsChanged
     },
   ]);
-
+ 
   return (
     <View style={style.current.flatListContainer} testID={testID}>
       <FlatList


### PR DESCRIPTION
The arrow press should stop passing months in the static header when getting to the end of the past/future scroll range.

To test: in the **horizontal CalendarList screen** change the `past/futureScrollRange` prop to 0 or a small number and press the arrows to move btw months - when you get to the edges you can see the months in the header changing but the calendar is off - the months should not change at all. This PR fix this bug.