### PR TITLE
Add minDate and maxDate props in WeekCalendar component

### DIFF
--- a/src/expandableCalendar/WeekCalendar/new.tsx
+++ b/src/expandableCalendar/WeekCalendar/new.tsx
@@ -1,4 +1,4 @@
-import isEqual from 'lodash/isEqual'
+import isEqual from 'lodash/isEqual';
 
 import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
@@ -25,7 +25,7 @@ export interface WeekCalendarProps extends CalendarListProps {
 const NUMBER_OF_PAGES = 50;
 const DEFAULT_PAGE_HEIGHT = 48;
 
-const WeekCalendar = (props: WeekCalendarProps) => {
+const WeekCalendar = (props: WeekCalendarProps): JSX.Element => {
   const {current, firstDay = 0, markedDates, allowShadow = true, hideDayNames, theme, calendarWidth, calendarHeight = DEFAULT_PAGE_HEIGHT, testID, minDate, maxDate} = props;
   const context = useContext(CalendarContext);
   const {date, updateSource} = context;
@@ -142,7 +142,7 @@ const WeekCalendar = (props: WeekCalendarProps) => {
 export default WeekCalendar;
 
 function getNearEdgeThreshold(elements: number){
-  const threshold = Math.round((elements / 2) * 0.5)
+  const threshold = Math.round((elements / 2) * 0.5);
   return threshold;
 }
 
@@ -154,17 +154,16 @@ function getInitialIndex(date: string, elements: string[], firstDay: number){
         {
           index = i;
         }
-      })
+      });
   }
-  return index !== undefined ? index : Math.round((elements.length - 1) / 2)
+  return index !== undefined ? index : Math.round((elements.length - 1) / 2);
 }
 
 function countWeekDaysBetween(weekDay: number, startDate: string, endDate: string){
   const start = XDate(startDate);
   const end = XDate(endDate);
   const diff = 1 +  Math.abs(end.diffDays(start));
-  let weekDaysBetween =  Math.abs(Math.floor( (diff+(start.getDay()+6-weekDay) % 7 ) / 7 ));
-  return weekDaysBetween;
+  return  Math.abs(Math.floor( (diff+(start.getDay()+6-weekDay) % 7 ) / 7 ));
 }
 
 // function getDate({current, context, firstDay = 0}: WeekCalendarProps, weekIndex: number) {
@@ -185,15 +184,15 @@ function getDate(date: string, firstDay: number, weekIndex: number) {
 
 // function getDatesArray(args: WeekCalendarProps, numberOfPages = NUMBER_OF_PAGES) => {
 function getDatesArray(date: string, firstDay: number, numberOfPages = NUMBER_OF_PAGES,  minDate: string | null = null, maxDate: string | null = null) {
-  let pages = numberOfPages
+  let pages = numberOfPages;
 
   let countFirstDays = minDate ?  countWeekDaysBetween(firstDay, date, minDate) : null;
   let countLastDays = maxDate ? countWeekDaysBetween(firstDay === 0 ? firstDay + 6 : 0, date, maxDate) : null;
 
-  countFirstDays = minDate && countFirstDays === 1 && sameWeek(minDate, date, firstDay) ? 0 : countFirstDays
-  countLastDays = maxDate && countLastDays === 1 && sameWeek(maxDate, date, firstDay) ? 0 : countLastDays
+  countFirstDays = minDate && countFirstDays === 1 && sameWeek(minDate, date, firstDay) ? 0 : countFirstDays;
+  countLastDays = maxDate && countLastDays === 1 && sameWeek(maxDate, date, firstDay) ? 0 : countLastDays;
 
-  const pageFilters = [countFirstDays, countLastDays].filter(c => c !== null)
+  const pageFilters = [countFirstDays, countLastDays].filter(c => c !== null);
 
   if (pageFilters.length > 0) {
       if (numberOfPages > Math.min(...pageFilters)){
@@ -219,7 +218,7 @@ function getDatesArray(date: string, firstDay: number, numberOfPages = NUMBER_OF
           array.push(d);
       } else {
           const d = getDate(date, firstDay, -1);
-          array.unshift(d)
+          array.unshift(d);
       }
   }
   return array;

--- a/src/expandableCalendar/week.tsx
+++ b/src/expandableCalendar/week.tsx
@@ -84,8 +84,8 @@ const Week = React.memo((props: WeekProps) => {
 
   const renderWeek = () => {
     const dates = numberOfDays > 1 ? getPartialWeekDates(current, numberOfDays) : getWeek(current);
-    const minD = minDate && new XDate(minDate)
-    const maxD = maxDate && new XDate(maxDate)
+    const minD = minDate && new XDate(minDate);
+    const maxD = maxDate && new XDate(maxDate);
     const week: JSX.Element[] = [];
 
     if (dates) {
@@ -94,7 +94,7 @@ const Week = React.memo((props: WeekProps) => {
       const datesToRender = numberOfDays > 1 && todayIndex > -1 ? sliced : dates;
       datesToRender.forEach((day: XDate | string, id: number) => {
         const d = day instanceof XDate ? day : new XDate(day);
-        const disabled = minD && d.diffDays(minD) > 0 || maxD && d.diffDays(maxD) < 0
+        const disabled = minD && d.diffDays(minD) > 0 || maxD && d.diffDays(maxD) < 0;
         week.push(renderDay(d, id, disabled));
       }, this);
     }

--- a/src/expandableCalendar/week.tsx
+++ b/src/expandableCalendar/week.tsx
@@ -30,6 +30,8 @@ const Week = React.memo((props: WeekProps) => {
     firstDay,
     hideExtraDays,
     markedDates,
+    minDate,
+    maxDate,
     onDayPress,
     onDayLongPress,
     style: propsStyle,
@@ -56,7 +58,7 @@ const Week = React.memo((props: WeekProps) => {
   const dayProps = extractDayProps(props);
   const currXdate = useMemo(() => parseDate(current), [current]);
 
-  const renderDay = (day: XDate, id: number) => {
+  const renderDay = (day: XDate, id: number, disabled: boolean) => {
     // hide extra days
     if (current && hideExtraDays) {
       if (!sameMonth(day, currXdate)) {
@@ -68,6 +70,7 @@ const Week = React.memo((props: WeekProps) => {
       <View style={style.current.dayContainer} key={id}>
         <Day
           {...dayProps}
+          disabled={disabled}
           testID={`${testID}.day_${dayString}`}
           date={dayString}
           state={getState(day, currXdate, props, disableDaySelection)}
@@ -81,6 +84,8 @@ const Week = React.memo((props: WeekProps) => {
 
   const renderWeek = () => {
     const dates = numberOfDays > 1 ? getPartialWeekDates(current, numberOfDays) : getWeek(current);
+    const minD = minDate && new XDate(minDate)
+    const maxD = maxDate && new XDate(maxDate)
     const week: JSX.Element[] = [];
 
     if (dates) {
@@ -89,7 +94,8 @@ const Week = React.memo((props: WeekProps) => {
       const datesToRender = numberOfDays > 1 && todayIndex > -1 ? sliced : dates;
       datesToRender.forEach((day: XDate | string, id: number) => {
         const d = day instanceof XDate ? day : new XDate(day);
-        week.push(renderDay(d, id));
+        const disabled = minD && d.diffDays(minD) > 0 || maxD && d.diffDays(maxD) < 0
+        week.push(renderDay(d, id, disabled));
       }, this);
     }
 

--- a/src/infinite-list/index.tsx
+++ b/src/infinite-list/index.tsx
@@ -4,7 +4,7 @@ import noop from 'lodash/noop';
 
 import React, {forwardRef, useCallback, useEffect, useMemo, useRef} from 'react';
 import {ScrollViewProps} from 'react-native';
-import {AutoScroll, DataProvider, LayoutProvider, RecyclerListView, RecyclerListViewProps} from 'recyclerlistview';
+import {DataProvider, LayoutProvider, RecyclerListView, RecyclerListViewProps} from 'recyclerlistview';
 
 import constants from '../commons/constants';
 import {useCombinedRefs} from '../hooks';

--- a/src/infinite-list/index.tsx
+++ b/src/infinite-list/index.tsx
@@ -4,7 +4,7 @@ import noop from 'lodash/noop';
 
 import React, {forwardRef, useCallback, useEffect, useMemo, useRef} from 'react';
 import {ScrollViewProps} from 'react-native';
-import {DataProvider, LayoutProvider, RecyclerListView, RecyclerListViewProps} from 'recyclerlistview';
+import {AutoScroll, DataProvider, LayoutProvider, RecyclerListView, RecyclerListViewProps} from 'recyclerlistview';
 
 import constants from '../commons/constants';
 import {useCombinedRefs} from '../hooks';
@@ -25,6 +25,7 @@ export interface InfiniteListProps
   scrollViewProps?: ScrollViewProps;
   reloadPages?: (pageIndex: number) => void;
   positionIndex?: number;
+  autoScroll?: boolean;
 }
 
 const InfiniteList = (props: InfiniteListProps, ref: any) => {
@@ -42,7 +43,8 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
     initialPageIndex = 0,
     extendedState,
     scrollViewProps,
-    positionIndex = 0
+    positionIndex = 0,
+    autoScroll = true
   } = props;
 
   const dataProvider = useMemo(() => {
@@ -67,13 +69,15 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
   const reloadPagesDebounce = useCallback(debounce(reloadPages, 500, {leading: false, trailing: true}), [reloadPages]);
 
   useEffect(() => {
-    setTimeout(() => {
-      const x = isHorizontal ? Math.floor(data.length / 2) * pageWidth : 0;
-      const y = isHorizontal ? 0 : positionIndex * pageHeight;
-      // @ts-expect-error
-      listRef.current?.scrollToOffset?.(x, y, false);
-    }, 0);
-  }, [data]);
+    if (autoScroll) {
+      setTimeout(() => {
+        const x = isHorizontal ? Math.floor(data.length / 2) * pageWidth : 0;
+        const y = isHorizontal ? 0 : positionIndex * pageHeight;
+        // @ts-expect-error
+        listRef.current?.scrollToOffset?.(x, y, false);
+      }, 0);
+    }
+  }, [data, autoScroll]);
 
   const onScroll = useCallback(
     (event, offsetX, offsetY) => {

--- a/src/infinite-list/index.tsx
+++ b/src/infinite-list/index.tsx
@@ -117,7 +117,7 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
 
   const onMomentumScrollEnd = useCallback(
     event => {
-      if (pageIndex.current) {
+      if (pageIndex.current !== undefined) {
         if (isOnEdge.current) {
           onReachEdge?.(pageIndex.current!);
           reloadPagesDebounce?.(pageIndex.current);


### PR DESCRIPTION
This PR introduces the inclusion of two optional properties, `minDate` and `maxDate`, in the `WeekCalendar` component. These properties offer the option to set a specific range of dates, limiting the scrolling functionality within that range.

This PR fixes [issue 2253](https://github.com/wix/react-native-calendars/issues/2253)


https://github.com/wix/react-native-calendars/assets/100431414/0cb3e2a5-b6df-44f0-914e-9eddea0566ee

