### PR TITLE
Added descending order to CalendarList

### DIFF
--- a/example/src/screens/calendarListScreen.tsx
+++ b/example/src/screens/calendarListScreen.tsx
@@ -54,6 +54,7 @@ const CalendarListScreen = (props: Props) => {
       horizontal={horizontalView}
       pagingEnabled={horizontalView}
       staticHeader={horizontalView}
+      descendingOrder={false}
     />
   );
 };

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -38,6 +38,8 @@ export interface CalendarListProps extends CalendarProps, Omit<FlatListProps<any
   showScrollIndicator?: boolean;
   /** Whether to animate the auto month scroll */
   animateScroll?: boolean;
+  /** Whether to load the calendar list items in descending order (most recent month at the top) */
+  descendingOrder?: boolean;
 }
 
 export interface CalendarListImperativeMethods {
@@ -78,6 +80,7 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
     calendarWidth = CALENDAR_WIDTH,
     calendarStyle,
     animateScroll = false,
+    descendingOrder = false,
     showScrollIndicator = false,
     staticHeader,
     /** View props */
@@ -120,7 +123,7 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
       const rangeDate = initialDate.current?.clone().addMonths(i - pastScrollRange, true);
       months.push(rangeDate);
     }
-    return months;
+    return descendingOrder ? months.reverse() : months;
   }, [pastScrollRange, futureScrollRange]);
 
   const staticHeaderStyle = useMemo(() => {


### PR DESCRIPTION
This PR will allow users the flexibility to view CalendarList months in descending order rather than ascending order (current functionality). Added an optional descendingOrder prop to CalendarList for this (defaults to false). 