### PR TITLE
ExpandableCalendar - limit the max open height

### DIFF
--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -336,8 +336,8 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
   };
 
   const handlePanResponderMove = (_: GestureResponderEvent, gestureState: PanResponderGestureState) => {
-    // limit min height to closed height
-    _wrapperStyles.current.style.height = Math.max(closedHeight, _height.current + gestureState.dy);
+    // limit min height to closed height and max to open height
+    _wrapperStyles.current.style.height = Math.min(Math.max(closedHeight, _height.current + gestureState.dy), openHeight.current);
 
     if (!horizontal) {
       // vertical CalenderList header


### PR DESCRIPTION
ExpandableCalendar - limit the max open height to the open height (not allowing the user to drag lower)