### PR TITLE
Fix: Readme and RNC Docs has wrong import

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Basic usage examples of the library
 ### Importing the `Calendar` component
 
 ```javascript
-import {`[Calendar](#calendar), [CalendarList](#calendarlist), [Agenda](#agenda)`} from 'react-native-calendars';
+import { Calendar, CalendarList, Agenda } from 'react-native-calendars';
 ```
 
 ### Use the `Calendar` component in your app:

--- a/docsRNC/docs/intro.md
+++ b/docsRNC/docs/intro.md
@@ -77,7 +77,7 @@ $ yarn add react-native-calendars
 
 <br/>
 
-`import {[Calendar](#calendar), [CalendarList](#calendarlist), [Agenda](#agenda)} from 'react-native-calendars';`
+`import { Calendar, CalendarList, Agenda } from 'react-native-calendars';`
 
 All parameters for components are optional. By default the month of current local date will be displayed.
 


### PR DESCRIPTION
This commit fixes the demo import in the README.md and docsRNC/docs/intro.md files