### PR TITLE
fix(infiniteAgendaList): fixes

### DIFF
--- a/src/expandableCalendar/agendaList.tsx
+++ b/src/expandableCalendar/agendaList.tsx
@@ -21,8 +21,7 @@ import {
   NativeScrollEvent,
   LayoutChangeEvent,
   ViewToken,
-  TextProps,
-  StyleProp
+  TextProps
 } from 'react-native';
 
 import {useDidUpdate} from '../hooks';
@@ -70,7 +69,6 @@ export interface AgendaListProps extends SectionListProps<any, DefaultSectionT> 
     titleHeight?: number;
     visibleIndicesChangedDebounce?: number;
     renderFooter?: () => React.ReactElement | null;
-    style?: StyleProp<ViewStyle>;
   };
 }
 

--- a/src/expandableCalendar/infiniteAgendaList.tsx
+++ b/src/expandableCalendar/infiniteAgendaList.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 import isUndefined from 'lodash/isUndefined';
 import debounce from 'lodash/debounce';
-import InfiniteList, {InfiniteListProps} from '../infinite-list';
+import InfiniteList from '../infinite-list';
 
 import XDate from 'xdate';
 
@@ -238,7 +238,7 @@ const InfiniteAgendaList = (props: AgendaListProps) => {
       ref={list}
       renderItem={_renderItem}
       data={data}
-      style={infiniteListProps?.style as InfiniteListProps['style']}
+      style={style.current.container}
       layoutProvider={layoutProvider}
       onScroll={_onScroll}
       onVisibleIndicesChanged={_onVisibleIndicesChanged}

--- a/src/expandableCalendar/infiniteAgendaList.tsx
+++ b/src/expandableCalendar/infiniteAgendaList.tsx
@@ -137,10 +137,14 @@ const InfiniteAgendaList = (props: AgendaListProps) => {
     if (list?.current && sectionIndex !== undefined) {
       sectionScroll.current = true; // to avoid setDate() in _onVisibleIndicesChanged
       _topSection.current = sections[findItemTitleIndex(sectionIndex)]?.title;
-
-      list.current?.scrollToIndex(sectionIndex, true);
+      const newDate = sections[findItemTitleIndex(sectionIndex)]?.title;
+      if (newDate !== _topSection.current) {
+        _topSection.current = newDate;
+        list.current?.scrollToIndex(sectionIndex, true);
+      }
+      _onMomentumScrollEnd(); // the RecyclerListView doesn't trigger onMomentumScrollEnd when calling scrollToSection
     }
-  }, 1000, {leading: false, trailing: true}), [ sections]);
+  }, 1000, {leading: false, trailing: true}), [sections]);
 
   const layoutProvider = useMemo(
     () => new LayoutProvider(

--- a/src/expandableCalendar/infiniteAgendaList.tsx
+++ b/src/expandableCalendar/infiniteAgendaList.tsx
@@ -136,7 +136,6 @@ const InfiniteAgendaList = (props: AgendaListProps) => {
 
     if (list?.current && sectionIndex !== undefined) {
       sectionScroll.current = true; // to avoid setDate() in _onVisibleIndicesChanged
-      _topSection.current = sections[findItemTitleIndex(sectionIndex)]?.title;
       const newDate = sections[findItemTitleIndex(sectionIndex)]?.title;
       if (newDate !== _topSection.current) {
         _topSection.current = newDate;

--- a/src/expandableCalendar/infiniteAgendaList.tsx
+++ b/src/expandableCalendar/infiniteAgendaList.tsx
@@ -58,12 +58,14 @@ const InfiniteAgendaList = (props: AgendaListProps) => {
   const didScroll = useRef(false);
   const sectionScroll = useRef(false);
   const [data, setData] = useState([] as any[]);
+  const dataRef = useRef(data);
 
   useEffect(() => {
     const items = sections.reduce((acc: any, cur: any) => {
       return [...acc, {title: cur.title, isTitle: true}, ...cur.data];
     }, []);
     setData(items);
+    dataRef.current = items;
 
     if (date !== _topSection.current) {
       setTimeout(() => {
@@ -149,13 +151,13 @@ const InfiniteAgendaList = (props: AgendaListProps) => {
 
   const layoutProvider = useMemo(
     () => new LayoutProvider(
-      (index) => data[index]?.isTitle ? 'title': 'page',
+      (index) => dataRef.current[index]?.isTitle ? 'title': 'page',
       (type, dim) => {
         dim.width = constants.screenWidth;
         dim.height = type === 'title' ? infiniteListProps?.titleHeight ?? 60 : infiniteListProps?.itemHeight ?? 80;
       }
     ),
-    [data]
+    []
   );
 
   const _onScroll = useCallback((rawEvent: any) => {

--- a/src/expandableCalendar/infiniteAgendaList.tsx
+++ b/src/expandableCalendar/infiniteAgendaList.tsx
@@ -128,20 +128,22 @@ const InfiniteAgendaList = (props: AgendaListProps) => {
     return sectionTitle;
   }, []);
 
-  const scrollToSection = useCallback(debounce((d) => {
-    const sectionIndex = scrollToNextEvent ? getNextSectionIndex(d) : getSectionIndex(d);
+  const scrollToSection = useCallback(debounce((requestedDate) => {
+    const sectionIndex = scrollToNextEvent ? getNextSectionIndex(requestedDate) : getSectionIndex(requestedDate);
     if (isUndefined(sectionIndex)) {
       return;
     }
 
     if (list?.current && sectionIndex !== undefined) {
       sectionScroll.current = true; // to avoid setDate() in _onVisibleIndicesChanged
-      const newDate = sections[findItemTitleIndex(sectionIndex)]?.title;
-      if (newDate !== _topSection.current) {
-        _topSection.current = newDate;
+      if (requestedDate !== _topSection.current) {
+        _topSection.current = sections[findItemTitleIndex(sectionIndex)]?.title;
         list.current?.scrollToIndex(sectionIndex, true);
       }
-      _onMomentumScrollEnd(); // the RecyclerListView doesn't trigger onMomentumScrollEnd when calling scrollToSection
+
+      setTimeout(() => {
+        _onMomentumScrollEnd(); // the RecyclerListView doesn't trigger onMomentumScrollEnd when calling scrollToSection
+      }, 500);
     }
   }, 1000, {leading: false, trailing: true}), [sections]);
 

--- a/src/infinite-list/index.tsx
+++ b/src/infinite-list/index.tsx
@@ -53,7 +53,6 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
     onScroll,
     onEndReached,
     renderFooter,
-    style,
   } = props;
 
   const dataProvider = useMemo(() => {
@@ -161,9 +160,9 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
     };
   }, [onScrollBeginDrag, onMomentumScrollEnd, scrollViewProps, isHorizontal]);
 
-  const _style = useMemo(() => {
-    return [{height: pageHeight}, style];
-  }, [pageHeight, style]);
+  const style = useMemo(() => {
+    return {height: pageHeight};
+  }, [pageHeight]);
 
   return (
     <RecyclerListView
@@ -177,7 +176,7 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
       initialRenderIndex={initialPageIndex}
       renderAheadOffset={5 * pageWidth}
       onScroll={_onScroll}
-      style={_style}
+      style={style}
       scrollViewProps={scrollViewPropsMemo}
       onEndReached={onEndReached}
       onEndReachedThreshold={onEndReachedThreshold}


### PR DESCRIPTION
This PR addresses the following improvements:
- Eliminates jumping when `onEndReach` is called.
- Manually triggers `onMomentumScrollEnd` in `scrollToSection` (mimics automatic behavior in `sectionList`).
- Avoids unnecessary calls to `scrollToIndex` when already in the correct position.
- Reverts [c4bd90f](https://github.com/wix/react-native-calendars/pull/2286) to fix #2292.
