### PR TITLE
feat: imperative setCurrentMonth handler on Calendar

### DIFF
--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 import isEmpty from 'lodash/isEmpty';
-import React, {useRef, useState, useEffect, useCallback, useMemo} from 'react';
+import React, {useRef, useState, useEffect, useCallback, useMemo, forwardRef, useImperativeHandle} from 'react';
 import {View, ViewStyle, StyleProp} from 'react-native';
 // @ts-expect-error
 import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
@@ -65,12 +65,16 @@ export interface CalendarProps extends CalendarHeaderProps, DayProps {
   allowSelectionOutOfRange?: boolean;
 }
 
+export interface CalendarRef {
+  setCurrentMonth: (date: string) => void;
+}
+
 /**
  * @description: Calendar component
  * @example: https://github.com/wix/react-native-calendars/blob/master/example/src/screens/calendars.js
  * @gif: https://github.com/wix/react-native-calendars/blob/master/demo/assets/calendar.gif
  */
-const Calendar = (props: CalendarProps & ContextProp) => {
+const Calendar = forwardRef<CalendarRef, CalendarProps & ContextProp>((props, ref) => {
   const {
     initialDate,
     current,
@@ -100,6 +104,10 @@ const Calendar = (props: CalendarProps & ContextProp) => {
   const style = useRef(styleConstructor(theme));
   const header = useRef();
   const weekNumberMarking = useRef({disabled: true, disableTouchEvent: true});
+
+  useImperativeHandle(ref, () => ({
+    setCurrentMonth: dateString => setCurrentMonth(parseDate(dateString))
+  }), []);
 
   useEffect(() => {
     if (initialDate) {
@@ -293,7 +301,7 @@ const Calendar = (props: CalendarProps & ContextProp) => {
       </View>
     </GestureComponent>
   );
-};
+});
 
 export default Calendar;
 Calendar.displayName = 'Calendar';


### PR DESCRIPTION
Hi. Thanks for this awesome package, I've used it quite extensively in the past for a few projects and have just started using it again for a little hobby project. Much appreciated for all your hard work 😄 

I have a use case where I'll have a "Now" button outside of the calendar which should reset the current month to today's date. I probably could have gotten away with using the `initialDate` since this is wrapped in a `useEffect` but I much prefer just calling `setCurrentMonth` directly as it means less state to manage for this simple use case.

Right now I only require the setCurrentMonth method, however, this could open it up to call other methods within the calendar too.