### PR TITLE
docs: remove duplicate monthNames array

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,20 +168,6 @@ LocaleConfig.locales['fr'] = {
     'Novembre',
     'Décembre'
   ],
-  monthNames: [
-    'Janvier',
-    'Février',
-    'Mars',
-    'Avril',
-    'Mai',
-    'Juin',
-    'Juillet',
-    'Août',
-    'Septembre',
-    'Octobre',
-    'Novembre',
-    'Décembre'
-  ],
   monthNamesShort: ['Janv.', 'Févr.', 'Mars', 'Avril', 'Mai', 'Juin', 'Juil.', 'Août', 'Sept.', 'Oct.', 'Nov.', 'Déc.'],
   dayNames: ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi'],
   dayNamesShort: ['Dim.', 'Lun.', 'Mar.', 'Mer.', 'Jeu.', 'Ven.', 'Sam.'],


### PR DESCRIPTION
Removed duplicate monthNames array in the localeConfig setup section in readme.md 😅 