### PR TITLE
feat: hide days outside min/max date interval

### DIFF
--- a/docsRNC/docs/Components/Calendar.md
+++ b/docsRNC/docs/Components/Calendar.md
@@ -70,6 +70,11 @@ Whether to show weeks numbers
 Whether to hide days of other months in the month page  
 <span style={{color: 'grey'}}>boolean</span>
 
+### hideDaysOutOfInterval
+
+Whether to hide days outside of the min/max date interval  
+<span style={{color: 'grey'}}>boolean</span>
+
 ### showSixWeeks
 
 Whether to always show six weeks on each month (when hideExtraDays = false)  

--- a/example/src/screens/calendarScreen.tsx
+++ b/example/src/screens/calendarScreen.tsx
@@ -75,6 +75,22 @@ const CalendarScreen = () => {
     );
   };
 
+  const renderCalendarWithDaysOutsideIntervalHidden = () => {
+    return (
+      <Fragment>
+        <Text style={styles.text}>Calendar with days outside min/max date hidden</Text>
+        <Calendar
+          style={styles.calendar}
+          hideDaysOutOfInterval
+          current={INITIAL_DATE}
+          minDate={getDate(-6)}
+          maxDate={getDate(6)}
+          disableAllTouchEventsForDisabledDays
+        />
+      </Fragment>
+    );
+  };
+
   const renderCalendarWithMarkedDatesAndHiddenArrows = () => {
     return (
       <Fragment>
@@ -501,6 +517,7 @@ const CalendarScreen = () => {
         {renderCalendarWithSelectableDate()}
         {renderCalendarWithWeekNumbers()}
         {renderCalendarWithMinAndMaxDates()}
+        {renderCalendarWithDaysOutsideIntervalHidden()}
         {renderCalendarWithCustomDay()}
         {renderCalendarWithInactiveDays()}
         {renderCalendarWithCustomHeaderTitle()}

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -7,7 +7,7 @@ import {View, ViewStyle, StyleProp} from 'react-native';
 import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
 
 import constants from '../commons/constants';
-import {page, isGTE, isLTE, sameMonth} from '../dateutils';
+import {page, isGTE, isLTE, sameMonth, isDateNotInRange} from '../dateutils';
 import {xdateToData, parseDate, toMarkingFormat} from '../interface';
 import {getState} from '../day-state-manager';
 import {extractHeaderProps, extractDayProps} from '../componentUpdater';
@@ -42,6 +42,8 @@ export interface CalendarProps extends CalendarHeaderProps, DayProps {
   /** Do not show days of other months in month page */
   hideExtraDays?: boolean;
   /** Always show six weeks on each month (only when hideExtraDays = false) */
+  hideDaysOutOfInterval?: boolean;
+  /** Always hide days when outside of the min/max date interval (only when min/max date !== undefined) */
   showSixWeeks?: boolean;
   /** Handler which gets executed on day press */
   onDayPress?: (date: DateData) => void;
@@ -86,6 +88,7 @@ const Calendar = (props: CalendarProps & ContextProp) => {
     disableMonthChange,
     enableSwipeMonths,
     hideExtraDays,
+    hideDaysOutOfInterval,
     firstDay,
     showSixWeeks,
     displayLoadingIndicator,
@@ -196,7 +199,9 @@ const Calendar = (props: CalendarProps & ContextProp) => {
     if (!sameMonth(day, currentMonth) && hideExtraDays) {
       return <View key={id} style={style.current.emptyDayContainer}/>;
     }
-
+    if (minDate && maxDate && isDateNotInRange(day, minDate, maxDate) && hideDaysOutOfInterval) {
+      return <View key={id} style={style.current.emptyDayContainer}/>;
+    }
     const dateString = toMarkingFormat(day);
     const isControlled = isEmpty(props.context);
 
@@ -311,6 +316,7 @@ Calendar.propTypes = {
   maxDate: PropTypes.string,
   markedDates: PropTypes.object,
   hideExtraDays: PropTypes.bool,
+  hideDaysOutOfInterval: PropTypes.bool,
   showSixWeeks: PropTypes.bool,
   onDayPress: PropTypes.func,
   onDayLongPress: PropTypes.func,

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -41,9 +41,9 @@ export interface CalendarProps extends CalendarHeaderProps, DayProps {
   markedDates?: MarkedDates;
   /** Do not show days of other months in month page */
   hideExtraDays?: boolean;
-  /** Always show six weeks on each month (only when hideExtraDays = false) */
-  hideDaysOutOfInterval?: boolean;
   /** Always hide days when outside of the min/max date interval (only when min/max date !== undefined) */
+  hideDaysOutOfInterval?: boolean;
+  /** Always show six weeks on each month (only when hideExtraDays = false) */
   showSixWeeks?: boolean;
   /** Handler which gets executed on day press */
   onDayPress?: (date: DateData) => void;

--- a/src/calendar/style.ts
+++ b/src/calendar/style.ts
@@ -17,6 +17,10 @@ export default function getStyle(theme: Theme = {}) {
     emptyDayContainer: {
       flex: 1
     },
+    hiddenDayContainer: {
+      width: 0,
+      height: 0,
+    },
     monthView: {
       backgroundColor: appStyle.calendarBackground
     },

--- a/src/calendar/style.ts
+++ b/src/calendar/style.ts
@@ -17,10 +17,6 @@ export default function getStyle(theme: Theme = {}) {
     emptyDayContainer: {
       flex: 1
     },
-    hiddenDayContainer: {
-      width: 0,
-      height: 0,
-    },
     monthView: {
       backgroundColor: appStyle.calendarBackground
     },


### PR DESCRIPTION
You can now hide days that's outside the min/max date interval.
Usefull to reduce the height of the Calendar component and to display only required days.

Documentation & example added.