### PR TITLE
Update: Avoid date selection on scroll | WeekCalendar

### DIFF
--- a/src/expandableCalendar/WeekCalendar/new.tsx
+++ b/src/expandableCalendar/WeekCalendar/new.tsx
@@ -18,13 +18,17 @@ import {DateData} from '../../types';
 export interface WeekCalendarProps extends CalendarListProps {
   /** whether to have shadow/elevation for the calendar */
   allowShadow?: boolean;
+  /**
+   * @avoidSelectionOnScroll To avoid the selection of first day on scroll. Default value is false
+   */
+  avoidSelectionOnScroll?: boolean
 }
 
 const NUMBER_OF_PAGES = 50;
 const DEFAULT_PAGE_HEIGHT = 48;
 
 const WeekCalendar = (props: WeekCalendarProps) => {
-  const {current, firstDay = 0, markedDates, allowShadow = true, hideDayNames, theme, calendarWidth, calendarHeight = DEFAULT_PAGE_HEIGHT, testID} = props;
+  const {current, firstDay = 0, markedDates, allowShadow = true, hideDayNames, theme, calendarWidth, calendarHeight = DEFAULT_PAGE_HEIGHT, testID, avoidSelectionOnScroll = false} = props;
   const context = useContext(CalendarContext);
   const {date, updateSource} = context;
   const style = useRef(styleConstructor(theme));
@@ -60,11 +64,11 @@ const WeekCalendar = (props: WeekCalendarProps) => {
 
   const onPageChange = useCallback(
     (pageIndex: number, _prevPage, {scrolledByUser}) => {
-      if (scrolledByUser) {
+      if (scrolledByUser && !avoidSelectionOnScroll) {
         context?.setDate(items[pageIndex], UpdateSources.WEEK_SCROLL);
       }
     },
-    [items]
+    [items, avoidSelectionOnScroll]
   );
 
   const reloadPages = useCallback(


### PR DESCRIPTION
To avoid the selection of first day of the week on scroll in week calendar. This is very crucial for our UX and I also found the following issues: https://github.com/wix/react-native-calendars/issues/1937