### PR TITLE
Add accessibility label to header arrows

### DIFF
--- a/src/calendar/header/index.tsx
+++ b/src/calendar/header/index.tsx
@@ -235,6 +235,7 @@ const CalendarHeader = forwardRef((props: CalendarHeaderProps, ref) => {
         style={style.current.arrow}
         hitSlop={hitSlop}
         testID={`${testID}.${arrowId}`}
+        accessibilityLabel={`Arrow ${renderArrowDirection}`}
       >
         {renderArrow ? (
           renderArrow(renderArrowDirection)


### PR DESCRIPTION
Accessibilty label added to the header arrows, because Google Play Console may display an accessibilty alert without it.