### PR TITLE
Allow full replacement of EventBlock component in Timeline

### DIFF
--- a/src/timeline/EventBlock.tsx
+++ b/src/timeline/EventBlock.tsx
@@ -19,11 +19,23 @@ export interface PackedEvent extends Event {
   height: number;
 }
 
+interface EventStyle {
+  left: number;
+  height: number;
+  width: number;
+  top: number;
+  backgroundColor: string;
+}
+
 export interface EventBlockProps {
   index: number;
   event: PackedEvent;
   onPress: (eventIndex: number) => void;
-  renderEvent?: (event: PackedEvent) => JSX.Element;
+  renderEvent?: (
+    event: PackedEvent,
+    onPress: () => void,
+    styles: [baseStyle: ViewStyle | TextStyle, computedStyle: EventStyle]
+  ) => JSX.Element;
   format24h?: boolean;
   styles: {[key: string]: ViewStyle | TextStyle};
 }
@@ -38,7 +50,7 @@ const EventBlock = (props: EventBlockProps) => {
   // However it would make sense to overflow the title to a new line if needed
   const numberOfLines = Math.floor(event.height / TEXT_LINE_HEIGHT);
   const formatTime = format24h ? 'HH:mm' : 'hh:mm A';
-  const eventStyle = useMemo(() => {
+  const eventStyle = useMemo<EventStyle>(() => {
     return {
       left: event.left,
       height: event.height,
@@ -52,27 +64,25 @@ const EventBlock = (props: EventBlockProps) => {
     onPress(index);
   }, [index, onPress]);
 
-  return (
+  return renderEvent ? (
+    renderEvent(event, _onPress, [styles.event, eventStyle])
+  ) : (
     <TouchableOpacity activeOpacity={0.9} onPress={_onPress} style={[styles.event, eventStyle]}>
-      {renderEvent ? (
-        renderEvent(event)
-      ) : (
-        <View>
-          <Text numberOfLines={1} style={styles.eventTitle}>
-            {event.title || 'Event'}
+      <View>
+        <Text numberOfLines={1} style={styles.eventTitle}>
+          {event.title || 'Event'}
+        </Text>
+        {numberOfLines > 1 ? (
+          <Text numberOfLines={numberOfLines - 1} style={[styles.eventSummary]}>
+            {event.summary || ' '}
           </Text>
-          {numberOfLines > 1 ? (
-            <Text numberOfLines={numberOfLines - 1} style={[styles.eventSummary]}>
-              {event.summary || ' '}
-            </Text>
-          ) : null}
-          {numberOfLines > 2 ? (
-            <Text style={styles.eventTimes} numberOfLines={1}>
-              {new XDate(event.start).toString(formatTime)} - {new XDate(event.end).toString(formatTime)}
-            </Text>
-          ) : null}
-        </View>
-      )}
+        ) : null}
+        {numberOfLines > 2 ? (
+          <Text style={styles.eventTimes} numberOfLines={1}>
+            {new XDate(event.start).toString(formatTime)} - {new XDate(event.end).toString(formatTime)}
+          </Text>
+        ) : null}
+      </View>
     </TouchableOpacity>
   );
 };

--- a/src/timeline/Timeline.tsx
+++ b/src/timeline/Timeline.tsx
@@ -14,7 +14,7 @@ import styleConstructor from './style';
 import {populateEvents, HOUR_BLOCK_HEIGHT, UnavailableHours} from './Packer';
 import {calcTimeOffset} from './helpers/presenter';
 import TimelineHours, {TimelineHoursProps} from './TimelineHours';
-import EventBlock, {Event, PackedEvent} from './EventBlock';
+import EventBlock, {Event, EventBlockProps, PackedEvent} from './EventBlock';
 import NowIndicator from './NowIndicator';
 import useTimelineOffset from './useTimelineOffset';
 
@@ -76,7 +76,7 @@ export interface TimelineProps {
   /**
    * Render a custom event block
    */
-  renderEvent?: (event: PackedEvent) => JSX.Element;
+  renderEvent?: EventBlockProps['renderEvent'];
   /**
    * Whether to show now indicator
    */


### PR DESCRIPTION
For the timeline `EventBlock` component, my use case requires me to render my own custom component that's NOT wrapped in a `TouchableOpacity`. So the go to prop would be `renderEvent` which you can pass a function to render your own event block element. The problem is even when passing this function, internally it wraps this element with it's own `<TouchableOpacity />`.

In my case, i wan't the parent element to be `Animated.View`, as I'd like to put some animation on the event blocks. Since it's wrapped with `TouchableOpacity` though, it's tough to animate my component and intercept native events on the event block.

This will also allow us to provide our own event handlers which can intercept native events on the block element. Currently we can't intercept the native events in the `onEventPress` timeline prop handler, as it only supplies us with the timeline `Event` object.

e.g.

```jsx
<Timeline
  onEventPress={timelineEvent => console.log(timelineEvent)} // no access to nativeEvent
  renderEvent={(event) => <View />} // this gets wrapped with the <TouchableOpacity>
/>
```

with these changes now we can do:

```jsx
<Timeline
  renderEvent={(event, onPress /* still have access to this if we need it */, styles) => (
    <Animated.View
      style={[
        ...styles,
        {
          transform: [], // transformations
        },
      ]}
      {...panResponder.panHandlers}
    />
  )}
/>
```

Unfortunately with these changes, developers will need to update their existing `renderEvent` prop to wrap their existing component in a `TouchableOpacity` to maintain the old behaviour.

```jsx
<Timeline
  onEventPress={timelineEvent => console.log(timelineEvent)}
  renderEvent={(event, onPress, styles) => (
  <TouchableOpacity activeOpacity={0.9} onPress={onPress} style={styles}>
    <CustomView />
  </TouchableOpacity>
  )}
/>
```