### PR TITLE
fix: WeekCalendar date when no params passed got an error

### DIFF
--- a/src/expandableCalendar/WeekCalendar/new.tsx
+++ b/src/expandableCalendar/WeekCalendar/new.tsx
@@ -153,6 +153,11 @@ function getDate(date: string, firstDay: number, weekIndex: number) {
 // function getDatesArray(args: WeekCalendarProps, numberOfPages = NUMBER_OF_PAGES) => {
 function getDatesArray(date: string, firstDay: number, numberOfPages = NUMBER_OF_PAGES) {
   const array: string[] = [];
+  
+  //if there is no date selected, use current date as starting point
+  if (!date)
+    date =  new XDate().toString('yyyy-MM-dd');
+  
   for (let index = -numberOfPages; index <= numberOfPages; index++) {
     const d = getDate(date, firstDay, index);
     array.push(d);


### PR DESCRIPTION
![Immagine WhatsApp 2023-11-30 ore 21 51 00_61e148c3](https://github.com/wix/react-native-calendars/assets/77461343/2c9da59e-dbd7-4d61-a3c0-48866fe2ef69)
 I got this error when using WeekCalendar component without any extra params ( just `<WeekCalendar/>`) The function causing the error was attempting to make toString() an undefined object. What I've done is to see if it's undefined, and if so, replaced it with today's date.