### PR TITLE
fix(calendar-list): fix new calendar hide extra days prop

### DIFF
--- a/src/calendar-list/new.tsx
+++ b/src/calendar-list/new.tsx
@@ -186,7 +186,7 @@ const CalendarList = (props: CalendarListProps) => {
         hideArrows={!horizontal}
         onPressArrowRight={scrollToNextMonth}
         onPressArrowLeft={scrollToPreviousMonth} 
-        hideExtraDays={calendarProps?.hideExtraDays || true}
+        hideExtraDays={calendarProps?.hideExtraDays ?? true}
         style={[style.current.calendar, calendarProps?.style]}
         headerStyle={horizontal ? calendarProps?.headerStyle : undefined}
         testID={`${testID}_${item}`}


### PR DESCRIPTION
Fix the behavior causing `hideExtraDays`, from the `NewCalendarList`, to never be `false`.