### PR TITLE
fix(expandable calendar): Adding "expandableKnobColor" property to the Theme interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export interface Theme {
   arrowHeight?: number;
   arrowWidth?: number;
   weekVerticalMargin?: number;
+  expandableKnobColor?: string;
   stylesheet?: {
     calendar?: {
       main?: object; 


### PR DESCRIPTION
### Description

Add the `expandableKnobColor` property to the `Theme` interface to avoid the error below:

<img width="869" alt="Screenshot 2023-12-13 at 23 30 53" src="https://github.com/wix/react-native-calendars/assets/41406021/0aedaf0c-a5e3-4e7f-9b4c-0e2a209ec30b">


________
With ❤️ by [andrecoelho.dev](https://andrecoelho.dev)