### PR TITLE
fix: multi-dot markedDates textColor

### DIFF
--- a/src/calendar/day/basic/index.tsx
+++ b/src/calendar/day/basic/index.tsx
@@ -98,7 +98,7 @@ const BasicDay = (props: BasicDayProps) => {
   };
 
   const getTextStyle = () => {
-    const {customStyles, selectedTextColor} = _marking;
+    const {customStyles, selectedTextColor, textColor} = _marking;
     const styles = [style.current.text];
 
     if (isSelected) {
@@ -112,6 +112,8 @@ const BasicDay = (props: BasicDayProps) => {
       styles.push(style.current.todayText);
     } else if (isInactive) {
       styles.push(style.current.inactiveText);
+    } else if (textColor) {
+      styles.push({color: textColor});
     }
 
     //Custom marking type


### PR DESCRIPTION
So far it was impossible to set a day text color to multi-dot calendar

Now this will work - to provide a `textColor`:
```
<Calendar
  markingType={'multi-dot'}
  markedDates={{
    '2023-12-25': {dots: [{key: 'vacation', color: 'red', selectedDotColor: 'blue'}], selectedColor: 'red', textColor: 'blue'},
  }}
/>;
```