### PR TITLE
fix AgendaList component documentation

### DIFF
--- a/docsRNC/docs/Components/AgendaList.md
+++ b/docsRNC/docs/Components/AgendaList.md
@@ -1,7 +1,7 @@
 Agenda list component for the `ExpandableCalendar` component.  
 [(code example)](https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendarScreen.tsx)
 :::info
-This component extends **[FlatList](https://reactnative.dev/docs/flatlist)** props.
+This component extends **[SectionList](https://reactnative.dev/docs/sectionlist)** props.
 :::
 **NOTE: This component should be wrapped with `CalendarProvider` component.**
 


### PR DESCRIPTION
As per the code https://github.com/wix/react-native-calendars/blob/fbbdbbaa6eefd148b6df76ad5f1bf81d9bbf1fec/src/expandableCalendar/AgendaListsCommon.tsx#L6
This component is extending SectionList not FlatList and so has a different set of props