### PR TITLE
fix: ExpandableCalendar week header height wrong after textMonthFontSize changed #2379

### DIFF
--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -171,14 +171,22 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
 
   const [position, setPosition] = useState(numberOfDays ? Positions.CLOSED : initialPosition);
   const isOpen = position === Positions.OPEN;
+  const getTotalClosedHeight = () => {
+    if(theme) {
+      if(theme.textMonthFontSize) {
+        return KNOB_CONTAINER_HEIGHT + (theme.textMonthFontSize! > 16 ? (theme.textMonthFontSize! - 16) : 0)
+      }
+    }
+    return KNOB_CONTAINER_HEIGHT
+  }
   const getOpenHeight = () => {
     if (!horizontal) {
       return Math.max(constants.screenHeight, constants.screenWidth);
     }
-    return CLOSED_HEIGHT + (WEEK_HEIGHT * (numberOfWeeks.current - 1)) + (hideKnob ? 12 : KNOB_CONTAINER_HEIGHT) + (constants.isAndroid ? 3 : 0);
+    return CLOSED_HEIGHT + (WEEK_HEIGHT * (numberOfWeeks.current - 1)) + (hideKnob ? 12 : KNOB_CONTAINER_HEIGHT) + (constants.isAndroid ? 3 + getTotalClosedHeight() : 0);
   };
   const openHeight = useRef(getOpenHeight());
-  const closedHeight = useMemo(() => CLOSED_HEIGHT + (hideKnob || Number(numberOfDays) > 1 ? 0 : KNOB_CONTAINER_HEIGHT), [numberOfDays, hideKnob]);
+  const closedHeight = useMemo(() => CLOSED_HEIGHT + (hideKnob || Number(numberOfDays) > 1 ? 0 : constants.isAndroid ? getTotalClosedHeight() : KNOB_CONTAINER_HEIGHT), [numberOfDays, hideKnob]);
   const startHeight = useMemo(() => isOpen ? openHeight.current : closedHeight, [closedHeight, isOpen]);
   const _height = useRef(startHeight);
   const deltaY = useMemo(() => new Animated.Value(startHeight), [startHeight]);
@@ -281,6 +289,16 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
   const handleScreenReaderStatus = (screenReaderEnabled: any) => {
     setScreenReaderEnabled(screenReaderEnabled);
   };
+
+  /** top calculation as per header height, total height & font size  */
+  const getTopPosition = () => {
+    if(theme) {
+      if(theme.textMonthFontSize) {
+        return theme.textMonthFontSize! > 16 ? closedHeight - HEADER_HEIGHT + 4 : HEADER_HEIGHT + 8
+      }
+    }
+    return HEADER_HEIGHT + 8
+  }
 
   /** Scroll */
 
@@ -546,7 +564,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
     return (
       <Animated.View
         ref={weekCalendarWrapper}
-        style={weekCalendarStyle}
+        style={[weekCalendarStyle, {top: constants.isAndroid ? getTopPosition() : HEADER_HEIGHT + 9}]}
         pointerEvents={isOpen ? 'none' : 'auto'}
       >
         <WeekComponent


### PR DESCRIPTION
fixed: ExpandableCalendar week header height wrong after textMonthFontSize changed by calculating total height and subtracting total height to HEADER_HEIGHT to get the week height using default font size as 16

<img width="853" alt="Screenshot 2024-01-05 at 11 14 43 AM" src="https://github.com/wix/react-native-calendars/assets/151492137/af8f6981-3567-4d37-ae4e-3aedef9cd483">
<img width="984" alt="Screenshot 2024-01-05 at 11 15 49 AM" src="https://github.com/wix/react-native-calendars/assets/151492137/668dddb4-f067-48ed-b449-3ad605531869">
<img width="1006" alt="Screenshot 2024-01-05 at 11 16 04 AM" src="https://github.com/wix/react-native-calendars/assets/151492137/29e87271-9e65-46a5-bb3b-fac66e487d7d">
<img width="567" alt="Screenshot 2024-01-05 at 11 16 22 AM" src="https://github.com/wix/react-native-calendars/assets/151492137/37bc2dae-95dc-4d35-9fd4-8a422d85e848">
