### PR TITLE
fix: fix custom style on Calendar type: period

### DIFF
--- a/example/src/screens/calendarScreen.tsx
+++ b/example/src/screens/calendarScreen.tsx
@@ -205,7 +205,8 @@ const CalendarScreen = () => {
               textColor: 'white',
               customContainerStyle: {
                 borderTopRightRadius: 5,
-                borderBottomRightRadius: 5
+                borderBottomRightRadius: 5,
+                backgroundColor: "green"
               }
             },
             [getDate(25)]: {inactive: true, disableTouchEvent: true}

--- a/src/calendar/day/period/index.tsx
+++ b/src/calendar/day/period/index.tsx
@@ -46,7 +46,7 @@ const PeriodDay = (props: PeriodDayProps) => {
       } else if (marking.selected) {
         defaultStyle.textStyle = {color: style.current.selectedText.color};
       }
-  
+
       if (marking.startingDay) {
         defaultStyle.startingDay = {backgroundColor: marking.color};
       }
@@ -56,7 +56,7 @@ const PeriodDay = (props: PeriodDayProps) => {
       if (!marking.startingDay && !marking.endingDay) {
         defaultStyle.day = {backgroundColor: marking.color};
       }
-      
+
       if (marking.textColor) {
         defaultStyle.textStyle = {color: marking.textColor};
       }
@@ -66,7 +66,7 @@ const PeriodDay = (props: PeriodDayProps) => {
       if (marking.customContainerStyle) {
         defaultStyle.containerStyle = marking.customContainerStyle;
       }
-  
+
       return defaultStyle;
     }
   }, [marking]);
@@ -83,10 +83,6 @@ const PeriodDay = (props: PeriodDayProps) => {
         borderRadius: 17,
         overflow: 'hidden'
       });
-      
-      if (markingStyle.containerStyle) {
-        containerStyle.push(markingStyle.containerStyle);
-      }
 
       const start = markingStyle.startingDay;
       const end = markingStyle.endingDay;
@@ -95,6 +91,11 @@ const PeriodDay = (props: PeriodDayProps) => {
       } else if (end && !start || end && start) {
         containerStyle.push({backgroundColor: markingStyle.endingDay?.backgroundColor});
       }
+
+      if (markingStyle.containerStyle) {
+        containerStyle.push(markingStyle.containerStyle);
+      }
+
     }
     return containerStyle;
   }, [marking, state]);
@@ -158,9 +159,9 @@ const PeriodDay = (props: PeriodDayProps) => {
   const _onLongPress = useCallback(() => {
     onLongPress?.(dateData);
   }, [onLongPress]);
-    
+
   const Component = marking ? TouchableWithoutFeedback : TouchableOpacity;
-  
+
   return (
     <Component
       testID={testID}

--- a/src/calendar/day/period/index.tsx
+++ b/src/calendar/day/period/index.tsx
@@ -46,7 +46,7 @@ const PeriodDay = (props: PeriodDayProps) => {
       } else if (marking.selected) {
         defaultStyle.textStyle = {color: style.current.selectedText.color};
       }
-
+  
       if (marking.startingDay) {
         defaultStyle.startingDay = {backgroundColor: marking.color};
       }
@@ -56,7 +56,7 @@ const PeriodDay = (props: PeriodDayProps) => {
       if (!marking.startingDay && !marking.endingDay) {
         defaultStyle.day = {backgroundColor: marking.color};
       }
-
+      
       if (marking.textColor) {
         defaultStyle.textStyle = {color: marking.textColor};
       }
@@ -66,7 +66,7 @@ const PeriodDay = (props: PeriodDayProps) => {
       if (marking.customContainerStyle) {
         defaultStyle.containerStyle = marking.customContainerStyle;
       }
-
+  
       return defaultStyle;
     }
   }, [marking]);
@@ -83,7 +83,7 @@ const PeriodDay = (props: PeriodDayProps) => {
         borderRadius: 17,
         overflow: 'hidden'
       });
-
+      
       const start = markingStyle.startingDay;
       const end = markingStyle.endingDay;
       if (start && !end) {
@@ -95,7 +95,6 @@ const PeriodDay = (props: PeriodDayProps) => {
       if (markingStyle.containerStyle) {
         containerStyle.push(markingStyle.containerStyle);
       }
-
     }
     return containerStyle;
   }, [marking, state]);
@@ -159,9 +158,9 @@ const PeriodDay = (props: PeriodDayProps) => {
   const _onLongPress = useCallback(() => {
     onLongPress?.(dateData);
   }, [onLongPress]);
-
+    
   const Component = marking ? TouchableWithoutFeedback : TouchableOpacity;
-
+  
   return (
     <Component
       testID={testID}


### PR DESCRIPTION
Fix the bug that the backgroundColor defined in customContainerStyle will be overwritten
<img width="843" alt="image" src="https://github.com/wix/react-native-calendars/assets/30222775/5fafe140-4dbb-4b25-a099-2cfe839bc84a">
<img width="959" alt="image" src="https://github.com/wix/react-native-calendars/assets/30222775/a61bf31b-f7a0-45dd-947f-2f89d6d4736e">