### PR TITLE
fix: infinite-list reload data bug

### DIFF
--- a/src/infinite-list/index.tsx
+++ b/src/infinite-list/index.tsx
@@ -137,17 +137,14 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
 
   const onMomentumScrollEnd = useCallback(
     event => {
-      if (pageIndex.current) {
-        if (isOnEdge.current) {
-          onReachEdge?.(pageIndex.current!);
-          reloadPagesDebounce?.(pageIndex.current);
-        } else if (isNearEdge.current) {
-          reloadPagesDebounce?.(pageIndex.current);
-          onReachNearEdge?.(pageIndex.current!);
-        }
-
-        scrollViewProps?.onMomentumScrollEnd?.(event);
+      if (isOnEdge.current) {
+        onReachEdge?.(pageIndex.current!);
+        reloadPagesDebounce?.(pageIndex.current);
+      } else if (isNearEdge.current) {
+        reloadPagesDebounce?.(pageIndex.current);
+        onReachNearEdge?.(pageIndex.current!);
       }
+      scrollViewProps?.onMomentumScrollEnd?.(event);
     },
     [scrollViewProps?.onMomentumScrollEnd, onReachEdge, onReachNearEdge, reloadPagesDebounce]
   );


### PR DESCRIPTION
in infinite-list/index.tsx, when onReachNearEdgeThreshold is 1, onMomentumScrollEnd will never be triggered

because case: pageIndex.current === 0 is never going to trigger
```
if (pageIndex.current) {
```

I know now `NUMBER_OF_PAGES` is 50, so we got enough space for `onNearEdge`, but actully it's a bug.