### PR TITLE
fix: calendar selected day text color(2386)

### DIFF
--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -114,10 +114,10 @@ const Calendar = (props: CalendarProps & ContextProp) => {
   }, [currentMonth]);
 
   const updateMonth = useCallback((newMonth: XDate) => {
+    setCurrentMonth(newMonth);
     if (sameMonth(newMonth, currentMonth)) {
       return;
     }
-    setCurrentMonth(newMonth);
   }, [currentMonth]);
 
   const addMonth = useCallback((count: number) => {
@@ -206,7 +206,7 @@ const Calendar = (props: CalendarProps & ContextProp) => {
           {...dayProps}
           testID={`${testID}.day_${dateString}`}
           date={dateString}
-          state={getState(day, currentMonth, props, isControlled)}
+          state={getState(day, currentMonth, props, !isControlled)}
           marking={markedDates?.[dateString]}
           onPress={_onDayPress}
           onLongPress={onLongPressDay}


### PR DESCRIPTION
(2386) - Calendar selectedDayTextColor not working as currentMonth state was not getting updated and the flag isControlled should have an not operator which determines the context is present or not.

<img width="468" alt="Screenshot 2024-01-15 at 12 39 33 PM" src="https://github.com/wix/react-native-calendars/assets/151492137/28fd531b-729d-402e-8049-0889b05a45e3">

<img width="478" alt="Screenshot 2024-01-15 at 12 39 49 PM" src="https://github.com/wix/react-native-calendars/assets/151492137/f0d4e8b1-40a0-49b0-a53a-3087a85a77e5">
