### PR TITLE
fix horizontal loading spinner jump

### DIFF
--- a/src/calendar/header/index.tsx
+++ b/src/calendar/header/index.tsx
@@ -249,6 +249,7 @@ const CalendarHeader = forwardRef((props: CalendarHeaderProps, ref) => {
     if (displayLoadingIndicator) {
       return (
         <ActivityIndicator
+          style={style.current.loadingIndicator}
           color={theme?.indicatorColor as ColorValue}
           testID={`${testID}.loader`}
         />

--- a/src/calendar/header/style.ts
+++ b/src/calendar/header/style.ts
@@ -68,6 +68,10 @@ export default function (theme: Theme = {}) {
     disabledDayHeader: {
       color: appStyle.textSectionTitleDisabledColor
     },
+    loadingIndicator: {
+      position: 'absolute',
+      right: -30,
+    },
     ...(theme['stylesheet.calendar.header'] || {})
   });
 }


### PR DESCRIPTION
The loading spinner causes the title to jump horizontally when it appears. This is due to the fact that an extra element is being rendered into the flex box. This PR adds a style to the loading spinner that does not cause the title to jump when the loading spinner is rendered

### Issue:
https://github.com/wix/react-native-calendars/assets/45606434/88793fa2-ce67-43a5-986c-33d2ab398fb2

### Fix:

https://github.com/wix/react-native-calendars/assets/45606434/9b8bca6d-4a99-445d-9b42-b3c4d7e6fd80

