### PR TITLE
refactor: simplified isDateInRange func to improve large calendar lis…

### DIFF
--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -223,11 +223,10 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
   }, []);
 
   const isDateInRange = useCallback((date) => {
-    for(let i = -range.current; i <= range.current; i++) {
-      const newMonth = currentMonth?.clone().addMonths(i, true);
-      if (sameMonth(date, newMonth)) {
-        return true;
-      }
+    const diffInMonths = currentMonth?.diffMonths(date);
+    const integerDiff = diffInMonths ? Math.floor(diffInMonths) : undefined;
+    if (integerDiff !== undefined) {
+      return integerDiff >= -range.current && integerDiff <= range.current;
     }
     return false;
   }, [currentMonth]);

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -224,11 +224,8 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
 
   const isDateInRange = useCallback((date) => {
     const diffInMonths = currentMonth?.diffMonths(date);
-    const integerDiff = diffInMonths ? Math.floor(diffInMonths) : undefined;
-    if (integerDiff !== undefined) {
-      return integerDiff >= -range.current && integerDiff <= range.current;
-    }
-    return false;
+    const integerDiff = diffInMonths !== undefined ? Math.floor(diffInMonths) : range.current+1;
+    return integerDiff >= -range.current && integerDiff <= range.current;
   }, [currentMonth]);
 
   const renderItem = useCallback(({item}: {item: XDate}) => {


### PR DESCRIPTION
When debugging to improve performance for a large calendar list ( eg. 15 months calendar list ), we found the `isDateInRange` not super optimize as we needed to complete some not-necessary loop action for each month each time we scroll through the calendar list.

|  Current `isDateInRange`  |  Next `isDateInRange`  |
|---|---|
|  ![Screenshot 2024-01-22 at 23 29 56](https://github.com/wix/react-native-calendars/assets/26269088/81ecf584-4812-4849-8e4d-014e9d82ab4c)  | ![Screenshot 2024-01-22 at 23 33 35](https://github.com/wix/react-native-calendars/assets/26269088/4e7e63bb-6eee-421b-80ac-d5da7535784b) |

As you can see, we can get rid of the `not-necessary loop action`