### PR TITLE
fix: added startOffset to change the now indicator to time now.

### DIFF
--- a/src/timeline/NowIndicator.tsx
+++ b/src/timeline/NowIndicator.tsx
@@ -7,14 +7,16 @@ export interface NowIndicatorProps {
   styles: {[key: string]: ViewStyle | TextStyle};
   width: number;
   left: number;
+  startOffset: number;
 }
 
 const NowIndicator = (props: NowIndicatorProps) => {
-  const {styles, width, left} = props;
+  const {styles, width, left, startOffset} = props;
 
-  const indicatorPosition = calcTimeOffset(HOUR_BLOCK_HEIGHT);
+  let indicatorPosition = calcTimeOffset(HOUR_BLOCK_HEIGHT);
 
   const nowIndicatorStyle = useMemo(() => {
+    indicatorPosition = calcTimeOffset(HOUR_BLOCK_HEIGHT) - calcTimeOffset(HOUR_BLOCK_HEIGHT, startOffset) + calcTimeOffset(HOUR_BLOCK_HEIGHT, 0, new Date().getMinutes());
     return [styles.nowIndicator, {top: indicatorPosition, left}];
   }, [indicatorPosition, left]);
 

--- a/src/timeline/Timeline.tsx
+++ b/src/timeline/Timeline.tsx
@@ -178,7 +178,7 @@ const Timeline = (props: TimelineProps) => {
   useEffect(() => {
     let initialPosition = 0;
     if (scrollToNow) {
-      initialPosition = calcTimeOffset(HOUR_BLOCK_HEIGHT);
+      initialPosition = calcTimeOffset(HOUR_BLOCK_HEIGHT) - calcTimeOffset(HOUR_BLOCK_HEIGHT, start);
     } else if (scrollToFirst && packedEvents[0].length > 0) {
       initialPosition = min(map(packedEvents[0], 'top')) ?? 0;
     } else if (initialTime) {
@@ -237,7 +237,7 @@ const Timeline = (props: TimelineProps) => {
     return (
       <React.Fragment key={dayIndex}>
         {renderEvents(dayIndex)}
-        {indexOfToday !== -1 && showNowIndicator && <NowIndicator width={width / numberOfDays} left={left} styles={styles.current} />}
+        {indexOfToday !== -1 && showNowIndicator && <NowIndicator startOffset={start} width={width / numberOfDays} left={left} styles={styles.current} />}
       </React.Fragment>
     );
   };


### PR DESCRIPTION
Added the fixes provided by the user who raised it in this issue. 

[Now indicator appears ahead of time when TimelineProps start is not 0](https://github.com/wix/react-native-calendars/issues/2235)