### PR TITLE
Added `reservationsBackgroundColor` to Theme typings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export interface Theme {
   arrowHeight?: number;
   arrowWidth?: number;
   weekVerticalMargin?: number;
+  reservationsBackgroundColor?: string;
   stylesheet?: {
     calendar?: {
       main?: object; 


### PR DESCRIPTION
Added `reservationsBackgroundColor` to `Theme` typings, it was causing a confusion on updating the background colour of the reservations, leaving people without a clue on what to use to be able to change the background colour [convo here ](https://github.com/wix/react-native-calendars/issues/2000)