### PR TITLE
refactor expandable calendar to have a configurable week height

### DIFF
--- a/example/src/screens/expandableCalendarScreen.tsx
+++ b/example/src/screens/expandableCalendarScreen.tsx
@@ -63,6 +63,7 @@ const ExpandableCalendarScreen = (props: Props) => {
           markedDates={marked.current}
           leftArrowImageSource={leftArrowIcon}
           rightArrowImageSource={rightArrowIcon}
+          weekHeight={46}
           // animateScroll
           // closeOnDayPress={false}
         />

--- a/src/expandableCalendar/expandableCalendar.api.json
+++ b/src/expandableCalendar/expandableCalendar.api.json
@@ -5,7 +5,9 @@
   "images": [
     "https://github.com/wix/react-native-calendars/blob/master/demo/assets/expandable-calendar.gif?raw=true"
   ],
-  "extends": ["CalendarList"],
+  "extends": [
+    "CalendarList"
+  ],
   "extendsLink": [
     "https://github.com/wix/react-native-calendars/blob/master/src/calendar-list/index.tsx"
   ],
@@ -70,6 +72,12 @@
       "type": "boolean",
       "description": "Whether to close the calendar on day press",
       "default": "true"
+    },
+    {
+      "name": "weekHeight",
+      "type": "number",
+      "description": "Overrides the default value for a week's row height",
+      "default": "46"
     }
   ]
 }

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -69,6 +69,8 @@ export interface ExpandableCalendarProps extends CalendarListProps {
   closeThreshold?: number;
   /** Whether to close the calendar on day press. Default = true */
   closeOnDayPress?: boolean;
+  /** overrides the default week height */
+  weekHeight?: number;
 }
 
 const headerStyleOverride = {
@@ -109,6 +111,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
     openThreshold = PAN_GESTURE_THRESHOLD,
     closeThreshold = PAN_GESTURE_THRESHOLD,
     closeOnDayPress = true,
+    weekHeight = WEEK_HEIGHT,
 
     /** CalendarList props */
     horizontal = true,
@@ -175,7 +178,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
     if (!horizontal) {
       return Math.max(constants.screenHeight, constants.screenWidth);
     }
-    return CLOSED_HEIGHT + (WEEK_HEIGHT * (numberOfWeeks.current - 1)) + (hideKnob ? 12 : KNOB_CONTAINER_HEIGHT) + (constants.isAndroid ? 3 : 0);
+    return CLOSED_HEIGHT + (weekHeight * (numberOfWeeks.current - 1)) + (hideKnob ? 12 : KNOB_CONTAINER_HEIGHT) + (constants.isAndroid ? 3 : 0);
   };
   const openHeight = useRef(getOpenHeight());
   const closedHeight = useMemo(() => CLOSED_HEIGHT + (hideKnob || Number(numberOfDays) > 1 ? 0 : KNOB_CONTAINER_HEIGHT), [numberOfDays, hideKnob]);


### PR DESCRIPTION
This pull requests introduces a new property `weekHeight` to the expandable calendar component which uses the constant `WEEK_HEIGHT` as its default value.