### PR TITLE
fix: fdow taken into account when calculating daysBefore

### DIFF
--- a/src/dateutils.spec.js
+++ b/src/dateutils.spec.js
@@ -181,6 +181,13 @@ describe('dateutils', function () {
       expect(days[days.length - 1].toString()).toBe(XDate(2014, 3, 5, 0, 0, 0, true).toString());
     });
 
+    it('2023 November - week starts on monday', function () {
+      const days = page(XDate(2023, 9, 1, true), 1, true);
+      expect(days.length).toBe(42);
+      expect(days[0].toString()).toBe(XDate(2023, 8, 25, 0, 0, 0, true).toString());
+      expect(days[days.length - 1].toString()).toBe(XDate(2023, 10, 5, 0, 0, 0, true).toString());
+    });
+
     it('2014 May', function () {
       const days = page(XDate(2014, 4, 23));
       expect(days.length).toBe(35);

--- a/src/dateutils.ts
+++ b/src/dateutils.ts
@@ -131,25 +131,25 @@ export function page(date: XDate, firstDayOfWeek = 0, showSixWeeks = false) {
   let after: XDate[] = [];
 
   const fdow = (7 + firstDayOfWeek) % 7 || 7;
-  const ldow = (fdow + 6) % 7;
-
+    const ldow = (fdow + 6) % 7;
+  
   firstDayOfWeek = firstDayOfWeek || 0;
-
+  
   const from = days[0].clone();
-  const daysBefore = from.getDay();
+  const daysBefore = (from.getDay() + 7 - fdow) % 7;
 
-  if (from.getDay() !== fdow) {
+    if (from.getDay() !== fdow) {
     from.addDays(-(from.getDay() + 7 - fdow) % 7);
   }
 
   const to = days[days.length - 1].clone();
-  const day = to.getDay();
-  if (day !== ldow) {
+    const day = to.getDay();
+    if (day !== ldow) {
     to.addDays((ldow + 7 - day) % 7);
   }
 
   const daysForSixWeeks = (daysBefore + days.length) / 6 >= 6;
-
+    
   if (showSixWeeks && !daysForSixWeeks) {
     to.addDays(7);
   }

--- a/src/dateutils.ts
+++ b/src/dateutils.ts
@@ -139,7 +139,7 @@ export function page(date: XDate, firstDayOfWeek = 0, showSixWeeks = false) {
   const daysBefore = (from.getDay() + 7 - fdow) % 7;
 
     if (from.getDay() !== fdow) {
-    from.addDays(-(from.getDay() + 7 - fdow) % 7);
+    from.addDays(-daysBefore);
   }
 
   const to = days[days.length - 1].clone();


### PR DESCRIPTION
fix for [this issue](https://github.com/wix/react-native-calendars/issues/2350)

The first week wasn't well calculated when the first day of week isn't sunday