### PR TITLE
Allow styling of week numbers

### DIFF
--- a/src/calendar/day/basic/index.tsx
+++ b/src/calendar/day/basic/index.tsx
@@ -54,6 +54,7 @@ const BasicDay = (props: BasicDayProps) => {
   const isDisabled = typeof _marking.disabled !== 'undefined' ? _marking.disabled : state === 'disabled';
   const isInactive = _marking?.inactive;
   const isToday = state === 'today';
+  const isWeekNumber = state === 'weekNumber';
   const isMultiDot = markingType === Marking.markings.MULTI_DOT;
   const isMultiPeriod = markingType === Marking.markings.MULTI_PERIOD;
   const isCustom = markingType === Marking.markings.CUSTOM;
@@ -84,6 +85,8 @@ const BasicDay = (props: BasicDayProps) => {
       }
     } else if (isToday) {
       styles.push(style.current.today);
+    } else if (isWeekNumber) {
+      styles.push(style.current.weekNumberContainer);
     }
 
     //Custom marking type
@@ -112,6 +115,10 @@ const BasicDay = (props: BasicDayProps) => {
       styles.push(style.current.todayText);
     } else if (isInactive) {
       styles.push(style.current.inactiveText);
+    } 
+    
+    if (isWeekNumber) {
+      styles.push(style.current.weekNumberText);
     }
 
     //Custom marking type

--- a/src/calendar/day/basic/style.ts
+++ b/src/calendar/day/basic/style.ts
@@ -47,6 +47,9 @@ export default function styleConstructor(theme: Theme = {}) {
     inactiveText: {
       color: appStyle.textInactiveColor
     },
+    weekNumberText: {
+      color: appStyle.textDisabledColor
+    },
     dot: {
       width: 4,
       height: 4,

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -180,7 +180,7 @@ const Calendar = (props: CalendarProps & ContextProp) => {
         <BasicDay
           key={`week-${weekNumber}`}
           marking={weekNumberMarking.current}
-          // state='disabled'
+          state='weekNumber'
           theme={theme}
           testID={`${testID}.weekNumber_${weekNumber}`}
         >

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type MarkingTypes = 'dot' | 'multi-dot' | 'period' | 'multi-period' | 'cu
 export type MarkedDates = {
   [key: string]: MarkingProps;
 };
-export type DayState = 'selected' | 'disabled' | 'inactive' | 'today' | '';
+export type DayState = 'selected' | 'disabled' | 'inactive' | 'today' | 'weekNumber' | '';
 export type Direction = 'left' | 'right';
 export type DateData = {
   year: number;


### PR DESCRIPTION
There was already a PR for styling week numbers that unfortunately never made it into master: https://github.com/wix/react-native-calendars/pull/1075

I adapted the code a bit and have it working in production.