### PR TITLE
docs: Removes MD links from code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Basic usage examples of the library
 ### Importing the `Calendar` component
 
 ```javascript
-import {`[Calendar](#calendar), [CalendarList](#calendarlist), [Agenda](#agenda)`} from 'react-native-calendars';
+import {Calendar, CalendarList, Agenda} from 'react-native-calendars';
 ```
 
 ### Use the `Calendar` component in your app:


### PR DESCRIPTION
Noticed a small typo where the markdown links are included in the code blocks. Thanks in advance for your review!