### PR TITLE
fix: [ExpandableCalendar] setting screenReaderEnabled to true causing error

### DIFF
--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -515,7 +515,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
     );
   };
 
-  const renderAnimatedHeader = () => {
+  const RenderAnimatedHeader = () => {
     const monthYear = new XDate(date)?.toString('MMMM yyyy');
 
     return (
@@ -532,7 +532,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
     );
   };
 
-  const renderKnob = () => {
+  const RenderKnob = () => {
     return (
       <View style={style.current.knobContainer} pointerEvents={'box-none'}>
         <TouchableOpacity style={style.current.knob} testID={`${testID}.knob`} onPress={toggleCalendarPosition} hitSlop={knobHitSlop} /* activeOpacity={isOpen ? undefined : 1} *//>
@@ -540,7 +540,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
     );
   };
 
-  const renderWeekCalendar = () => {
+  const RenderWeekCalendar = () => {
     const WeekComponent = disableWeekScroll ? Week : WeekCalendar;
 
     return (
@@ -566,7 +566,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
     );
   };
 
-  const renderCalendarList = () => {
+  const RenderCalendarList = () => {
     return (
       <CalendarList
         testID={`${testID}.calendarList`}
@@ -608,10 +608,10 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
         />
       ) : (
         <Animated.View testID={`${testID}.expandableContainer`} ref={wrapper} style={wrapperStyle} {...panResponder.panHandlers}>
-          {renderCalendarList()}
-          {renderWeekCalendar()}
-          {!hideKnob && renderKnob()}
-          {!horizontal && renderAnimatedHeader()}
+          <RenderCalendarList />
+          <RenderWeekCalendar />
+          {!hideKnob && <RenderKnob />}
+          {!horizontal && <RenderAnimatedHeader />}
         </Animated.View>
       )}
     </View>


### PR DESCRIPTION
## The issue
On `ExpandableCalendar` component, when `screenReaderEnabled` state is set to `true`, it causes a _"rendered fewer Hooks than expected"_ error

https://github.com/wix/react-native-calendars/blob/da9b1bd702e1221002d6e30aaf888e350b627b6a/src/expandableCalendar/index.tsx#L128

### Demo

- On the left, the application with the screen reader enabled
- One the right, the application without the screen reader

![RNC-Screen-reader-error](https://github.com/wix/react-native-calendars/assets/86483570/2186e841-1ce2-4672-923e-3f251a623d46)

## Analysis

Based on this part of react documentation : [Never call component functions directly](https://react.dev/reference/rules/react-calls-components-and-hooks#never-call-component-functions-directly)

This error is occuring because some components are called as regular functions instead of JSX : 

https://github.com/wix/react-native-calendars/blob/da9b1bd702e1221002d6e30aaf888e350b627b6a/src/expandableCalendar/index.tsx#L610-L617

## Suggested Fix

My fix involves few changes by simply converting render functions name to **Pascal case**, and then calling them as JSX

## Demo 

![scrcpy_xxsxQswVqw](https://github.com/wix/react-native-calendars/assets/86483570/1a1ac8fb-3c21-418e-aba2-83d3b2445e4c)

