### PR TITLE
fix: XDate uses wrong format for formatting date in 12 h format in timeline EventBlock.js

### DIFF
--- a/src/timeline/EventBlock.tsx
+++ b/src/timeline/EventBlock.tsx
@@ -37,7 +37,7 @@ const EventBlock = (props: EventBlockProps) => {
   // Fixing the number of lines for the event title makes this calculation easier.
   // However it would make sense to overflow the title to a new line if needed
   const numberOfLines = Math.floor(event.height / TEXT_LINE_HEIGHT);
-  const formatTime = format24h ? 'HH:mm' : 'hh:mm A';
+  const formatTime = format24h ? 'HH:mm' : 'hh:mm TT';
   const eventStyle = useMemo(() => {
     return {
       left: event.left,


### PR DESCRIPTION
This PR addresses an issue with the 12-hour format display on the timeline event component. Previously, the component did not correctly format the time when using a 12-hour clock, which caused confusion for users relying on AM/PM distinctions.

Screenshots:
![image](https://github.com/wix/react-native-calendars/assets/28515918/41a7082d-ee0b-438b-8977-37a148a2b448)

[XDate docs](https://arshaw.com/xdate/#Formatting)


