### PR TITLE
created new props to fix timeline width

### DIFF
--- a/src/timeline/Timeline.tsx
+++ b/src/timeline/Timeline.tsx
@@ -115,6 +115,10 @@ export interface TimelineProps {
   timelineLeftInset?: number;
   /** Identifier for testing */
   testID?: string;
+  /**
+   * Width for the timeline component
+   */
+  availableWidth?: number;
 }
 
 const Timeline = (props: TimelineProps) => {
@@ -143,6 +147,7 @@ const Timeline = (props: TimelineProps) => {
     numberOfDays = 1,
     timelineLeftInset = 0,
     testID,
+    availableWidth,
   } = props;
 
   const pageDates = useMemo(() => {
@@ -161,7 +166,7 @@ const Timeline = (props: TimelineProps) => {
   const {scrollEvents} = useTimelineOffset({onChangeOffset, scrollOffset, scrollViewRef: scrollView});
 
   const width = useMemo(() => {
-    return constants.screenWidth - timelineLeftInset;
+    return (availableWidth ?? constants.screenWidth) - timelineLeftInset;
   }, [timelineLeftInset]);
 
   const packedEvents = useMemo(() => {
@@ -247,7 +252,7 @@ const Timeline = (props: TimelineProps) => {
       // @ts-expect-error
       ref={scrollView}
       style={styles.current.container}
-      contentContainerStyle={[styles.current.contentStyle, {width: constants.screenWidth}]}
+      contentContainerStyle={[styles.current.contentStyle, {width: (availableWidth ?? constants.screenWidth)}]}
       showsVerticalScrollIndicator={false}
       {...scrollEvents}
       testID={testID}

--- a/src/timeline/Timeline.tsx
+++ b/src/timeline/Timeline.tsx
@@ -167,7 +167,7 @@ const Timeline = (props: TimelineProps) => {
 
   const width = useMemo(() => {
     return (availableWidth ?? constants.screenWidth) - timelineLeftInset;
-  }, [timelineLeftInset]);
+  }, [availableWidth, timelineLeftInset]);
 
   const packedEvents = useMemo(() => {
     return map(pageEvents, (_e, i) => {


### PR DESCRIPTION
Currently, the timeline events and hour rows are taking the width of a screen, which makes the event box overflow
added a prop where you can pass your container width to contain everything within


Before:
<img width="1810" alt="Screenshot 2024-07-02 at 12 51 48 PM" src="https://github.com/wix/react-native-calendars/assets/37795321/7a3b1d09-d493-4bc9-85bc-9f03bf342a77">


After:
<img width="1810" alt="Screenshot 2024-07-02 at 12 56 15 PM" src="https://github.com/wix/react-native-calendars/assets/37795321/44aa8ea5-9611-4c53-a83d-3d8ea0288428">
