### PR TITLE
feat(infiniteAgendaList): support passing scrollViewProps

### DIFF
--- a/src/expandableCalendar/infiniteAgendaList.tsx
+++ b/src/expandableCalendar/infiniteAgendaList.tsx
@@ -47,7 +47,7 @@ const InfiniteAgendaList = ({
   onEndReached,
   onEndReachedThreshold,
   ...others
-}: AgendaListProps) => {
+}: Omit<AgendaListProps, 'viewOffset'>) => {
   const {date, updateSource, setDate} = useContext(Context);
 
   const style = useRef(styleConstructor(theme));

--- a/src/expandableCalendar/infiniteAgendaList.tsx
+++ b/src/expandableCalendar/infiniteAgendaList.tsx
@@ -47,7 +47,6 @@ const InfiniteAgendaList = (props: AgendaListProps) => {
     renderItem,
     onEndReached,
     onEndReachedThreshold,
-    refreshControl
   } = props;
 
   const {date, updateSource, setDate} = useContext(Context);
@@ -244,7 +243,7 @@ const InfiniteAgendaList = (props: AgendaListProps) => {
       layoutProvider={layoutProvider}
       onScroll={_onScroll}
       onVisibleIndicesChanged={_onVisibleIndicesChanged}
-      scrollViewProps={{onMomentumScrollEnd: _onMomentumScrollEnd, nestedScrollEnabled: true, refreshControl}}
+      scrollViewProps={{nestedScrollEnabled: true, ...props, onMomentumScrollEnd: _onMomentumScrollEnd}}
       onEndReached={_onEndReached}
       onEndReachedThreshold={onEndReachedThreshold as number | undefined}
       disableScrollOnDataChange

--- a/src/expandableCalendar/infiniteAgendaList.tsx
+++ b/src/expandableCalendar/infiniteAgendaList.tsx
@@ -30,25 +30,24 @@ import {AgendaSectionHeader, AgendaListProps} from "./AgendaListsCommon";
  * @extends: InfiniteList
  * @example: https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendar.js
  */
-const InfiniteAgendaList = (props: AgendaListProps) => {
-  const {
-    theme,
-    sections,
-    scrollToNextEvent,
-    avoidDateUpdates,
-    onScroll,
-    renderSectionHeader,
-    sectionStyle,
-    dayFormatter,
-    dayFormat = 'dddd, MMM d',
-    useMoment,
-    markToday = true,
-    infiniteListProps,
-    renderItem,
-    onEndReached,
-    onEndReachedThreshold,
-  } = props;
-
+const InfiniteAgendaList = ({
+  theme,
+  sections,
+  scrollToNextEvent,
+  avoidDateUpdates,
+  onScroll,
+  renderSectionHeader,
+  sectionStyle,
+  dayFormatter,
+  dayFormat = 'dddd, MMM d',
+  useMoment,
+  markToday = true,
+  infiniteListProps,
+  renderItem,
+  onEndReached,
+  onEndReachedThreshold,
+  ...others
+}: AgendaListProps) => {
   const {date, updateSource, setDate} = useContext(Context);
 
   const style = useRef(styleConstructor(theme));
@@ -243,7 +242,7 @@ const InfiniteAgendaList = (props: AgendaListProps) => {
       layoutProvider={layoutProvider}
       onScroll={_onScroll}
       onVisibleIndicesChanged={_onVisibleIndicesChanged}
-      scrollViewProps={{nestedScrollEnabled: true, ...props, onMomentumScrollEnd: _onMomentumScrollEnd}}
+      scrollViewProps={{nestedScrollEnabled: true, ...others, onMomentumScrollEnd: _onMomentumScrollEnd}}
       onEndReached={_onEndReached}
       onEndReachedThreshold={onEndReachedThreshold as number | undefined}
       disableScrollOnDataChange


### PR DESCRIPTION
Since the `AgendaListProps` extends `SectionListProps` we can receive any section list props.
This PR just moves them to the right place inside `InfiniteAgendaList`