### PR TITLE
fix(AgendaList):  renderSectionHeader do not match the expected signature

### DIFF
--- a/src/expandableCalendar/agendaList.tsx
+++ b/src/expandableCalendar/agendaList.tsx
@@ -213,7 +213,7 @@ const AgendaList = (props: AgendaListProps) => {
     const title = info?.section?.title;
 
     if (renderSectionHeader) {
-      return renderSectionHeader(title);
+      return renderSectionHeader(info);
     }
 
     const headerTitle = getSectionTitle(title);

--- a/src/expandableCalendar/infiniteAgendaList.tsx
+++ b/src/expandableCalendar/infiniteAgendaList.tsx
@@ -208,7 +208,7 @@ const InfiniteAgendaList = ({
     const title = info?.section?.title;
 
     if (renderSectionHeader) {
-      return renderSectionHeader(title);
+      return renderSectionHeader(info);
     }
 
     const headerTitle = getSectionTitle(title);


### PR DESCRIPTION
The renderSectionHeader prop is not a custom property of AgendaList; it is expected to match the signature of the SectionList, which aligns with the current typing.

It is also useful in cases when users do not want to render headers when data is empty.