### PR TITLE
Add disableMonthScroll

### DIFF
--- a/docsRNC/docs/Components/ExpandableCalendar.md
+++ b/docsRNC/docs/Components/ExpandableCalendar.md
@@ -51,7 +51,7 @@ Whether to have shadow/elevation for the calendar
 Whether to disable the week scroll in closed position  
 <span style={{color: 'grey'}}>boolean</span>
 
-### disablMonthScroll
+### disableMonthScroll
 
 Whether to disable the month scroll in opened position  
 <span style={{color: 'grey'}}>boolean</span>

--- a/docsRNC/docs/Components/ExpandableCalendar.md
+++ b/docsRNC/docs/Components/ExpandableCalendar.md
@@ -51,6 +51,11 @@ Whether to have shadow/elevation for the calendar
 Whether to disable the week scroll in closed position  
 <span style={{color: 'grey'}}>boolean</span>
 
+### disablMonthScroll
+
+Whether to disable the month scroll in opened position  
+<span style={{color: 'grey'}}>boolean</span>
+
 ### openThreshold
 
 The threshold for opening the calendar with the pan gesture  

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -63,6 +63,8 @@ export interface ExpandableCalendarProps extends CalendarListProps {
   allowShadow?: boolean;
   /** whether to disable the week scroll in closed position */
   disableWeekScroll?: boolean;
+  /** whether to disable the month scroll in opened position */
+  disableMonthScroll?: boolean;
   /** a threshold for opening the calendar with the pan gesture */
   openThreshold?: number;
   /** a threshold for closing the calendar with the pan gesture */
@@ -106,6 +108,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
     rightArrowImageSource = RIGHT_ARROW,
     allowShadow = true,
     disableWeekScroll,
+    disableMonthScroll,
     openThreshold = PAN_GESTURE_THRESHOLD,
     closeThreshold = PAN_GESTURE_THRESHOLD,
     closeOnDayPress = true,
@@ -580,7 +583,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
         onDayPress={_onDayPress}
         onVisibleMonthsChange={onVisibleMonthsChange}
         pagingEnabled
-        scrollEnabled={isOpen}
+        scrollEnabled={isOpen && !disableMonthScroll}
         hideArrows={shouldHideArrows}
         onPressArrowLeft={_onPressArrowLeft}
         onPressArrowRight={_onPressArrowRight}


### PR DESCRIPTION
The current expandable calendar is missing properties to disable scroll when it is in the opened state (like CalendarList). This implementation will resolve that issue and also provide some workaround for some bugs