### PR TITLE
feat: add custom header prop type

### DIFF
--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -60,7 +60,7 @@ export interface CalendarProps extends CalendarHeaderProps, DayProps {
   /** Style passed to the header */
   headerStyle?: StyleProp<ViewStyle>;
   /** Allow rendering a totally custom header */
-  customHeader?: any;
+  customHeader?: (props: CalendarHeaderProps) => React.ReactNode;
   /** Allow selection of dates before minDate or after maxDate */
   allowSelectionOutOfRange?: boolean;
 }
@@ -258,8 +258,7 @@ const Calendar = (props: CalendarProps & ContextProp) => {
   const renderHeader = () => {
     const headerProps = extractHeaderProps(props);
     const ref = customHeader ? undefined : header;
-    const CustomHeader = customHeader;
-    const HeaderComponent = customHeader ? CustomHeader : CalendarHeader;
+    const HeaderComponent = customHeader ? customHeader : CalendarHeader;
 
     return (
       <HeaderComponent
@@ -320,6 +319,6 @@ Calendar.propTypes = {
   enableSwipeMonths: PropTypes.bool,
   disabledByDefault: PropTypes.bool,
   headerStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.number, PropTypes.array]),
-  customHeader: PropTypes.any,
+  customHeader: PropTypes.func,
   allowSelectionOutOfRange: PropTypes.bool
 };

--- a/src/componentUpdater.ts
+++ b/src/componentUpdater.ts
@@ -4,6 +4,7 @@ import {AgendaProps} from './agenda';
 import {ReservationListProps} from './agenda/reservation-list';
 
 import {MarkingProps} from './calendar/day/marking';
+import {CalendarHeaderProps} from './calendar/header';
 
 const get = require('lodash/get');
 const omit = require('lodash/omit');
@@ -117,7 +118,7 @@ export function extractHeaderProps(props: CalendarProps) {
     testID
   } = props;
 
-  const headerProps = {
+  const headerProps: CalendarHeaderProps = {
     month,
     addMonth,
     theme,


### PR DESCRIPTION
Updated the customHeader prop type from any to (props: CalendarHeaderProps) => React.ReactNode

https://github.com/wix/react-native-calendars/issues/2535