### PR TITLE
FIX: Enable nestedScrollEnabled prop for Android api level 21+

### DIFF
--- a/src/timeline/Timeline.tsx
+++ b/src/timeline/Timeline.tsx
@@ -115,6 +115,10 @@ export interface TimelineProps {
   timelineLeftInset?: number;
   /** Identifier for testing */
   testID?: string;
+  /**
+   * Enables nested scrolling for Android API level 21+
+   */
+  nestedScrollEnabled?: boolean;
 }
 
 const Timeline = (props: TimelineProps) => {
@@ -143,6 +147,7 @@ const Timeline = (props: TimelineProps) => {
     numberOfDays = 1,
     timelineLeftInset = 0,
     testID,
+    nestedScrollEnabled = false,
   } = props;
 
   const pageDates = useMemo(() => {
@@ -250,6 +255,7 @@ const Timeline = (props: TimelineProps) => {
       style={styles.current.container}
       contentContainerStyle={[styles.current.contentStyle, {width: constants.screenWidth}]}
       showsVerticalScrollIndicator={false}
+      nestedScrollEnabled={nestedScrollEnabled}
       {...scrollEvents}
       testID={testID}
     >


### PR DESCRIPTION
Adds a new prop to Timeline to enable nested scrolling.
I was trying to add the pull to refresh feature to a wrapper ScrollView on my calendar and noticed that I can not enable nested scrolling for the android devices.
This creates an unwanted behaviour where you are unable to swip downwards (scroll up) without triggering the pull to refresh feature.
Without adding this prop to the Timeline's ScrollView the only way to scroll up is to start scrolling down then changing direction while still touching the screen.

**Current behaviour:**
https://github.com/user-attachments/assets/1e365832-0ac7-413a-991f-a148f1dc5726

**Expected behaviour:**
https://github.com/user-attachments/assets/56f8be5a-3d3f-4ec0-8e12-36628abed9da



