### PR TITLE
fix: Invariant Violation: scrollToIndex out of range: item length 0 but minimum is 1, js engine: hermes

### DIFF
--- a/src/expandableCalendar/agendaList.tsx
+++ b/src/expandableCalendar/agendaList.tsx
@@ -143,22 +143,27 @@ const AgendaList = (props: AgendaListProps) => {
   }, []);
 
   const scrollToSection = useCallback(debounce((d) => {
-    const sectionIndex = scrollToNextEvent ? getNextSectionIndex(d) : getSectionIndex(d);
-    if (isUndefined(sectionIndex)) {
-      return;
-    }
-    if (list?.current && sectionIndex !== undefined) {
-      sectionScroll.current = true; // to avoid setDate() in onViewableItemsChanged
-      _topSection.current = sections[sectionIndex]?.title;
+    try {
+      const sectionIndex = scrollToNextEvent ? getNextSectionIndex(d) : getSectionIndex(d);
+      if (isUndefined(sectionIndex)) {
+        return;
+      }
+      if (list?.current && sectionIndex !== undefined) {
+        sectionScroll.current = true; // to avoid setDate() in onViewableItemsChanged
+        _topSection.current = sections[sectionIndex]?.title;
 
-      list?.current.scrollToLocation({
-        animated: true,
-        sectionIndex: sectionIndex,
-        itemIndex: 1,
-        viewPosition: 0, // position at the top
-        viewOffset: (constants.isAndroid ? sectionHeight.current : 0) + viewOffset
-      });
+        list?.current.scrollToLocation({
+          animated: true,
+          sectionIndex: sectionIndex,
+          itemIndex: 1,
+          viewPosition: 0, // position at the top
+          viewOffset: (constants.isAndroid ? sectionHeight.current : 0) + viewOffset
+        });
+      }
+    } catch (err) {
+      return
     }
+    
   }, 1000, {leading: false, trailing: true}), [viewOffset, sections]);
 
   const _onViewableItemsChanged = useCallback((info: {viewableItems: Array<ViewToken>; changed: Array<ViewToken>}) => {


### PR DESCRIPTION
Fix for: `Invariant Violation: scrollToIndex out of range: item length 0 but minimum is 1, js engine: hermes`

Certain times on low end devices or slow state management the error pops up leading to crash in devices