### PR TITLE
Fix renderSectionHeader callback of AgendaList

### DIFF
--- a/src/expandableCalendar/AgendaListsCommon.tsx
+++ b/src/expandableCalendar/AgendaListsCommon.tsx
@@ -1,9 +1,9 @@
 import isEqual from 'lodash/isEqual';
 import React from 'react';
-import {DefaultSectionT, SectionListProps, Text, TextProps, ViewStyle} from 'react-native';
+import {DefaultSectionT, SectionListData, SectionListProps, Text, TextProps, ViewStyle} from 'react-native';
 import {Theme} from '../types';
 
-export interface AgendaListProps extends SectionListProps<any, DefaultSectionT> {
+export interface AgendaListProps extends Omit<SectionListProps<any, DefaultSectionT>, 'renderSectionHeader'> {
   /** Specify theme properties to override specific styles for calendar parts */
   theme?: Theme;
   /** day format in section title. Formatting values: http://arshaw.com/xdate/#Formatting */
@@ -23,6 +23,8 @@ export interface AgendaListProps extends SectionListProps<any, DefaultSectionT> 
   viewOffset?: number;
   /** enable scrolling the agenda list to the next date with content when pressing a day without content */
   scrollToNextEvent?: boolean;
+  /** Rendered at the top of each section. Sticky headers are not yet supported. **/
+  renderSectionHeader?: (title: string, info: { section: SectionListData<any, DefaultSectionT> }) => React.ReactElement | null;
   /**
    * @experimental
    * If defined, uses InfiniteList instead of SectionList. This feature is experimental and subject to change.

--- a/src/expandableCalendar/agendaList.tsx
+++ b/src/expandableCalendar/agendaList.tsx
@@ -213,7 +213,7 @@ const AgendaList = (props: AgendaListProps) => {
     const title = info?.section?.title;
 
     if (renderSectionHeader) {
-      return renderSectionHeader(title);
+      return renderSectionHeader(title, info);
     }
 
     const headerTitle = getSectionTitle(title);


### PR DESCRIPTION
Current implementation has an incorrect function signature for `renderSectionHeader` inherited from `SectionList` props. Only the title string is passed as an argument at runtime, but it's typed as `{ section: SectionListData<any, DefaultSectionT> }`.

This PR does two things:

1. Fix the first argument type to match the runtime value
2. Add the full props of `SectionList` as the second argument for more flexibility while preserving backwards compatibility