### PR TITLE
fix: README code (Adding a global theme to the calendar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,23 +188,23 @@ export default App;
 ### Adding a global theme to the calendar:
 
 ```javascript
-    <Calendar
-      style={{
-        borderWidth: 1,
-        borderColor: 'gray',
-        height: 350,
-      }}
-      theme={{
-        backgroundColor: '#ffffff',
-        calendarBackground: '#ffffff',
-        textSectionTitleColor: '#b6c1cd',
-        selectedDayBackgroundColor: '#00adf5',
-        selectedDayTextColor: '#ffffff',
-        todayTextColor: '#00adf5',
-        dayTextColor: '#2d4150',
-        textDisabledColor: '#dd99ee'
-      }}
-    </Calendar>
+<Calendar
+  style={{
+    borderWidth: 1,
+    borderColor: 'gray',
+    height: 350,
+  }}
+  theme={{
+    backgroundColor: '#ffffff',
+    calendarBackground: '#ffffff',
+    textSectionTitleColor: '#b6c1cd',
+    selectedDayBackgroundColor: '#00adf5',
+    selectedDayTextColor: '#ffffff',
+    todayTextColor: '#00adf5',
+    dayTextColor: '#2d4150',
+    textDisabledColor: '#dd99ee'
+  }}
+/>
 ```
 
 ## Customized Calendar Examples


### PR DESCRIPTION
- Fixed a closing tag issue in the [Calendar component example in the README file](https://github.com/wix/react-native-calendars?tab=readme-ov-file#adding-a-global-theme-to-the-calendar), ensuring it renders correctly.
- Removed unnecessary indentation to maintain code consistency and improve readability.