### PR TITLE
fix: update theme stylesheet access pattern

### DIFF
--- a/src/agenda/reservation-list/style.ts
+++ b/src/agenda/reservation-list/style.ts
@@ -37,6 +37,6 @@ export default function styleConstructor(theme: Theme = {}) {
     indicator: {
       marginTop: 80
     },
-    ...(theme['stylesheet.agenda.list'] || {})
+    ...(theme.stylesheet?.agenda?.list ?? {})
   });
 }

--- a/src/agenda/style.ts
+++ b/src/agenda/style.ts
@@ -52,6 +52,6 @@ export default function styleConstructor(theme: Theme = {}) {
       width: '100%',
       alignSelf: 'center'
     },
-    ...(theme['stylesheet.agenda.main'] || {})
+    ...(theme.stylesheet?.agenda?.main ?? {})
   });
 }

--- a/src/calendar-list/style.ts
+++ b/src/calendar-list/style.ts
@@ -33,6 +33,6 @@ export default function getStyle(theme: Theme = {}) {
       backgroundColor: appStyle.calendarBackground,
       paddingHorizontal: 15
     },
-    ...(theme['stylesheet.calendar-list.main'] || {})
+    ...(theme.stylesheet?.['calendar-list']?.main ?? {})
   });
 }

--- a/src/calendar/day/basic/style.ts
+++ b/src/calendar/day/basic/style.ts
@@ -45,7 +45,6 @@ export default function styleConstructor(theme: Theme = {}) {
     inactiveText: {
       color: appStyle.textInactiveColor
     },
-    
-    ...(theme['stylesheet.day.basic'] || {})
+    ...(theme.stylesheet?.day?.basic ?? {})
   });
 }

--- a/src/calendar/day/dot/style.ts
+++ b/src/calendar/day/dot/style.ts
@@ -30,6 +30,6 @@ export default function styleConstructor(theme: Theme = {}) {
     todayDot: {
       backgroundColor: appStyle.todayDotColor
     },
-    ...(theme['stylesheet.dot'] || {})
+    ...(theme.stylesheet?.dot ?? {})
   });
 }

--- a/src/calendar/day/marking/style.ts
+++ b/src/calendar/day/marking/style.ts
@@ -26,6 +26,6 @@ export default function styleConstructor(theme: Theme = {}) {
       borderBottomRightRadius: 2,
       marginRight: 4
     },
-    ...(theme['stylesheet.marking'] || {})
+    ...(theme.stylesheet?.marking ?? {})
   });
 }

--- a/src/calendar/day/period/style.ts
+++ b/src/calendar/day/period/style.ts
@@ -60,7 +60,6 @@ export default function styleConstructor(theme: Theme = {}) {
     inactiveText: {
       color: appStyle.textInactiveColor
     },
-    
-    ...(theme['stylesheet.day.period'] || {})
+    ...(theme.stylesheet?.day?.period ?? {})
   });
 }

--- a/src/calendar/header/style.ts
+++ b/src/calendar/header/style.ts
@@ -68,6 +68,6 @@ export default function (theme: Theme = {}) {
     disabledDayHeader: {
       color: appStyle.textSectionTitleDisabledColor
     },
-    ...(theme['stylesheet.calendar.header'] || {})
+    ...(theme.stylesheet?.calendar?.header ?? {})
   });
 }

--- a/src/calendar/style.ts
+++ b/src/calendar/style.ts
@@ -25,6 +25,6 @@ export default function getStyle(theme: Theme = {}) {
       flexDirection: 'row',
       justifyContent: 'space-around'
     },
-    ...(theme['stylesheet.calendar.main'] || {})
+    ...(theme.stylesheet?.calendar?.main ?? {})
   });
 }

--- a/src/expandableCalendar/style.ts
+++ b/src/expandableCalendar/style.ts
@@ -171,6 +171,6 @@ export default function styleConstructor(theme: Theme = {}) {
       marginLeft: appStyle.todayButtonPosition === 'right' ? 7 : undefined,
       marginRight: appStyle.todayButtonPosition === 'right' ? undefined : 7
     },
-    ...(theme?.stylesheet?.expandable?.main || {})
+    ...(theme.stylesheet?.expandable?.main ?? {})
   });
 }


### PR DESCRIPTION
Fixes https://github.com/wix/react-native-calendars/issues/2336

This PR replaces bracket notation for theme access with optional chaining to align with the `Theme` interface style.

## Motivation

The current implementation has a discrepancy between the `Theme` interface defined in TypeScript versus the JavaScript styling logic. This can lead to a poor developer experience, as the interface should serve as a guide for interacting with the library. The following examples illustrate the need for this change.

### Example 1: Conforms to the `Theme` Interface but Does Not Apply the Custom Styling

In this example, the code adheres to the `Theme` interface, but the JavaScript does not apply the theme's styling correctly.

```tsx
import { Calendar } from 'react-native-calendars';
import { Theme } from 'react-native-calendars/src/types';

export default function Foo() {
  const theme: Theme = {
    stylesheet: {
      calendar: {
        header: {
          monthText: {
            color: 'red',
          },
        },
      },
    },
  };

  return <Calendar theme={theme} />;
}
```

<img width="278" alt="Screenshot 2024-12-11 at 12 22 44 AM" src="https://github.com/user-attachments/assets/5978380d-b9e9-4d9c-94cd-626d62e6bab2">

### Example 2: Applies Custom Styles but Does Not Conform to the Theme Interface

In this case, custom styles are applied, but the implementation does not conform to the Theme interface, leading to TypeScript complaints.

```tsx
import { Calendar } from 'react-native-calendars';
import { Theme } from 'react-native-calendars/src/types';

export default function Foo() {
  const theme: Theme = {
    'stylesheet.calendar.header': {
      monthText: {
        color: 'red',
      },
    },
  };

  return <Calendar theme={theme} />;
}
```

<img width="282" alt="Screenshot 2024-12-11 at 12 21 31 AM" src="https://github.com/user-attachments/assets/e297b528-a65d-47a8-b7ed-2cc7c529918c">

<img width="804" alt="Screenshot 2024-12-11 at 12 14 14 AM" src="https://github.com/user-attachments/assets/5c7ccecc-c70a-4c1f-a556-8393c8a993cf"> 

