### PR TITLE
feat: Expose toggleCalendarPosition function using forwardRef

### DIFF
--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -5,7 +5,7 @@ import throttle from 'lodash/throttle';
 
 import XDate from 'xdate';
 
-import React, {useContext, useRef, useState, useEffect, useCallback, useMemo} from 'react';
+import React, { forwardRef, useCallback, useContext, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import {
   AccessibilityInfo,
   PanResponder,
@@ -94,7 +94,7 @@ const headerStyleOverride = {
  * @example: https://github.com/wix/react-native-calendars/blob/master/example/src/screens/expandableCalendar.js
  */
 
-const ExpandableCalendar = (props: ExpandableCalendarProps) => {
+const ExpandableCalendar = forwardRef((props: ExpandableCalendarProps, ref: React.Ref<ExpandableCalendarProps>) => {
   const {date, setDate, numberOfDays, timelineLeftInset} = useContext(Context);
   const {
     /** ExpandableCalendar props */
@@ -487,6 +487,11 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
     }, 100, {trailing: true, leading: false}
   ), [date, scrollPage]);
 
+  /** Expose functions */
+  useImperativeHandle(ref, () => ({
+    toggleCalendarPosition,
+  }));
+
   /** Renders */
 
   const _renderArrow = useCallback((direction: Direction) => {
@@ -615,7 +620,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
       )}
     </View>
   );
-};
+});
 
 export default ExpandableCalendar;
 


### PR DESCRIPTION
## Description
- Implemented forwardRef to expose the toggleCalendarPosition function
- Added useImperativeHandle hook to make the function accessible from parent components
- Enables programmatic control of calendar expansion/collapse

## Changes
- Wrapped component with forwardRef
- Exposed toggleCalendarPosition through useImperativeHandle

## Usage Example
```typescript
const calendarRef = useRef();
// Toggle calendar position programmatically
calendarRef.current.toggleCalendarPosition();
```

## Result
![Dec-19-2024 23-17-24](https://github.com/user-attachments/assets/cd01875b-52b2-4c74-9d9d-10628fa7036b)
