### PR TITLE
feat: Add forceNonDeterministicRendering to InfiniteListProps, pass that to RecyclerListView

### DIFF
--- a/src/expandableCalendar/AgendaListsCommon.tsx
+++ b/src/expandableCalendar/AgendaListsCommon.tsx
@@ -34,6 +34,7 @@ export interface AgendaListProps extends SectionListProps<any, DefaultSectionT> 
     itemHeightByType?: Record<string, number>;
     visibleIndicesChangedDebounce?: number;
     renderFooter?: () => React.ReactElement | null;
+    forceNonDeterministicRendering?: boolean;
   };
 }
 

--- a/src/infinite-list/index.tsx
+++ b/src/infinite-list/index.tsx
@@ -29,6 +29,7 @@ export interface InfiniteListProps
   layoutProvider?: LayoutProvider;
   disableScrollOnDataChange?: boolean;
   renderFooter?: () => React.ReactElement | null;
+  forceNonDeterministicRendering?: boolean;
 }
 
 const InfiniteList = (props: InfiniteListProps, ref: any) => {
@@ -55,6 +56,7 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
     onScroll,
     onEndReached,
     renderFooter,
+    forceNonDeterministicRendering,
   } = props;
 
   const dataProvider = useMemo(() => {
@@ -190,6 +192,7 @@ const InfiniteList = (props: InfiniteListProps, ref: any) => {
       onEndReachedThreshold={onEndReachedThreshold}
       onVisibleIndicesChanged={onVisibleIndicesChanged}
       renderFooter={renderFooter}
+      forceNonDeterministicRendering={forceNonDeterministicRendering}
     />
   );
 };


### PR DESCRIPTION
This PR adds support for the `forceNonDeterministicRendering` prop when using the infinite AgendaList. This prop will be passed to the underlying RecyclerListView to dynamically resize the height of the items rather than using the defined item height.