### PR TITLE
Added inverted prop to invert the calendar list order

### DIFF
--- a/example/src/screens/calendarListScreen.tsx
+++ b/example/src/screens/calendarListScreen.tsx
@@ -54,6 +54,7 @@ const CalendarListScreen = (props: Props) => {
       horizontal={horizontalView}
       pagingEnabled={horizontalView}
       staticHeader={horizontalView}
+      inverted={false}
     />
   );
 };

--- a/src/calendar-list/calendarList.api.json
+++ b/src/calendar-list/calendarList.api.json
@@ -50,6 +50,12 @@
       "type": "boolean",
       "description": "Whether to enable or disable vertical / horizontal scroll indicator",
       "default": "false"
+    },
+    {
+      "name": "inverted",
+      "type": "boolean",
+      "description": "Whether to invert the calendar",
+      "default": "false"
     }
   ]
 }

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -39,6 +39,8 @@ export interface CalendarListProps extends CalendarProps, Omit<FlatListProps<any
   showScrollIndicator?: boolean;
   /** Whether to animate the auto month scroll */
   animateScroll?: boolean;
+  /** Whether to invert the calendar */
+  inverted?: boolean;
 }
 
 export interface CalendarListImperativeMethods {
@@ -79,6 +81,7 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
     calendarWidth = CALENDAR_WIDTH,
     calendarStyle,
     animateScroll = false,
+    inverted = false,
     showScrollIndicator = false,
     staticHeader,
     /** View props */
@@ -124,8 +127,8 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
       const rangeDate = initialDate.current?.clone().addMonths(i - pastScrollRange, true);
       months.push(rangeDate);
     }
-    return months;
-  }, [pastScrollRange, futureScrollRange]);
+    return  inverted ? months.reverse() : months;
+  }, [pastScrollRange, futureScrollRange, inverted]);
 
   const staticHeaderStyle = useMemo(() => {
     return [style.current.staticHeader, headerStyle];


### PR DESCRIPTION
This is a copy of this stale PR: https://github.com/wix/react-native-calendars/pull/2257
I needed the functionality, so I remade it and thought contributing would be good.

Adding an `inverted` prop, to make the CalendarList reverse order.