### PR TITLE
week calendar scroll index correction in RN73

### DIFF
--- a/src/commons/constants.ts
+++ b/src/commons/constants.ts
@@ -8,7 +8,7 @@ const isIOS = Platform.OS === 'ios';
 const screenAspectRatio = screenWidth < screenHeight ? screenHeight / screenWidth : screenWidth / screenHeight;
 const isTablet = (Platform as PlatformIOSStatic).isPad || (screenAspectRatio < 1.6 && Math.max(screenWidth, screenHeight) >= 900);
 const isAndroidRTL = isAndroid && isRTL;
-const isRN73 = Platform.constants.reactNativeVersion.major >= 73;
+const isRN73 = () => Platform.constants.reactNativeVersion.major >= 73;
 
 export default {
   screenWidth,

--- a/src/commons/constants.ts
+++ b/src/commons/constants.ts
@@ -8,6 +8,7 @@ const isIOS = Platform.OS === 'ios';
 const screenAspectRatio = screenWidth < screenHeight ? screenHeight / screenWidth : screenWidth / screenHeight;
 const isTablet = (Platform as PlatformIOSStatic).isPad || (screenAspectRatio < 1.6 && Math.max(screenWidth, screenHeight) >= 900);
 const isAndroidRTL = isAndroid && isRTL;
+const isRN73 = Platform.constants.reactNativeVersion.major >= 73;
 
 export default {
   screenWidth,
@@ -16,5 +17,6 @@ export default {
   isAndroid,
   isIOS,
   isTablet,
-  isAndroidRTL
+  isAndroidRTL,
+  isRN73,
 };

--- a/src/commons/constants.ts
+++ b/src/commons/constants.ts
@@ -8,7 +8,7 @@ const isIOS = Platform.OS === 'ios';
 const screenAspectRatio = screenWidth < screenHeight ? screenHeight / screenWidth : screenWidth / screenHeight;
 const isTablet = (Platform as PlatformIOSStatic).isPad || (screenAspectRatio < 1.6 && Math.max(screenWidth, screenHeight) >= 900);
 const isAndroidRTL = isAndroid && isRTL;
-const isRN73 = () => Platform.constants.reactNativeVersion.major >= 73;
+const isRN73 = () => Platform.constants.reactNativeVersion.minor >= 73;
 
 export default {
   screenWidth,

--- a/src/expandableCalendar/WeekCalendar/index.tsx
+++ b/src/expandableCalendar/WeekCalendar/index.tsx
@@ -69,7 +69,7 @@ const WeekCalendar = (props: WeekCalendarProps) => {
           }) :
           sameWeek(item, date, firstDay));
       if (pageIndex !== currentIndex.current) {
-        const adjustedIndexFrScroll = constants.isAndroidRTL ? NUM_OF_ITEMS - 1 - pageIndex : pageIndex;
+        const adjustedIndexFrScroll = (constants.isAndroidRTL && !constants.isRN73) ? NUM_OF_ITEMS - 1 - pageIndex : pageIndex;
         if (pageIndex >= 0) {
           visibleWeek.current = items.current[adjustedIndexFrScroll];
           currentIndex.current = adjustedIndexFrScroll;

--- a/src/expandableCalendar/WeekCalendar/index.tsx
+++ b/src/expandableCalendar/WeekCalendar/index.tsx
@@ -69,7 +69,7 @@ const WeekCalendar = (props: WeekCalendarProps) => {
           }) :
           sameWeek(item, date, firstDay));
       if (pageIndex !== currentIndex.current) {
-        const adjustedIndexFrScroll = (constants.isAndroidRTL && !constants.isRN73) ? NUM_OF_ITEMS - 1 - pageIndex : pageIndex;
+        const adjustedIndexFrScroll = (constants.isAndroidRTL && !constants.isRN73()) ? NUM_OF_ITEMS - 1 - pageIndex : pageIndex;
         if (pageIndex >= 0) {
           visibleWeek.current = items.current[adjustedIndexFrScroll];
           currentIndex.current = adjustedIndexFrScroll;


### PR DESCRIPTION
with RN 73 the scroll to index method in RTL horizontal Flatlist works as expected which means our previous fix is redundant for those versions, used a check in the calendar itself to avoid sending unnecessary props