### PR TITLE
chore: renamed selectedDotColor to selectedColor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ const App = () => {
         setSelected(day.dateString);
       }}
       markedDates={{
-        [selected]: {selected: true, disableTouchEvent: true, selectedDotColor: 'orange'}
+        [selected]: {selected: true, disableTouchEvent: true, selectedColor: 'orange'}
       }}
     />
   );
@@ -176,7 +176,7 @@ const App = () => {
         setSelected(day.dateString);
       }}
       markedDates={{
-        [selected]: {selected: true, disableTouchEvent: true, selectedDotColor: 'orange'}
+        [selected]: {selected: true, disableTouchEvent: true, selectedColor: 'orange'}
       }}
     />
   );


### PR DESCRIPTION
I noticed the `selectedDotColor` has been renamed to `selectedColor` so I'd like to request a change to the readme to display and example accordingly 