### PR TITLE
Fix ReactImageView warning by conditionally rendering buttonIcon

### DIFF
--- a/src/expandableCalendar/Context/todayButton.tsx
+++ b/src/expandableCalendar/Context/todayButton.tsx
@@ -143,7 +143,7 @@ const TodayButton = (props: TodayButtonProps, ref: any) => {
         onPress={onPress}
         disabled={disabled}
       >
-        <Animated.Image style={[style.current.todayButtonImage, {opacity: opacity.current}]} source={buttonIcon}/>
+        {buttonIcon ? (<Animated.Image style={[style.current.todayButtonImage, {opacity: opacity.current}]} source={buttonIcon}/>)  : null}
         <Animated.Text allowFontScaling={false} style={[style.current.todayButtonText, {opacity: opacity.current}]}>
           {today.current}
         </Animated.Text>


### PR DESCRIPTION
## Summary
This PR fixes the warning:
> WARN  ReactImageView: Image source "null" doesn't exist

The issue was caused by rendering an `Animated.Image` component even when `buttonIcon` was null. 
This fix ensures that `Animated.Image` is only rendered if `buttonIcon` exists.

## Changes
- Wrapped the `Animated.Image` component inside a conditional check (`buttonIcon ? ... : null`).
