### PR TITLE
fix: separate _onDayPress from _onCalendarListDayPress & block unrelated taps with height based _isOpen.

### DIFF
--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -452,6 +452,22 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
   }, [onPressArrowRight, scrollPage]);
 
   const _onDayPress = useCallback((value: DateData) => {
+    const threshold = isOpen ? openHeight.current - closeThreshold : closedHeight + openThreshold;
+    const _isOpen = _height.current >= threshold;
+    if (_isOpen) return;
+    if (numberOfDaysCondition) {
+      setDate?.(value.dateString, UpdateSources.DAY_PRESS);
+    }
+    if (closeOnDayPress) {
+      closeCalendar();
+    }
+    onDayPress?.(value);
+  }, [onDayPress, closeOnDayPress, closeCalendar, numberOfDaysCondition]);
+
+  const _onCalendarListDayPress = useCallback((value) => {
+    const threshold = isOpen ? openHeight.current - closeThreshold : closedHeight + openThreshold;
+    const _isOpen = _height.current >= threshold;
+    if (!_isOpen) return;
     if (numberOfDaysCondition) {
       setDate?.(value.dateString, UpdateSources.DAY_PRESS);
     }
@@ -587,7 +603,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
         current={date}
         theme={themeObject}
         ref={calendarList}
-        onDayPress={_onDayPress}
+        onDayPress={_onCalendarListDayPress}
         onVisibleMonthsChange={onVisibleMonthsChange}
         pagingEnabled
         scrollEnabled={isOpen}


### PR DESCRIPTION
**description**
We are resetting the week calendar in bounceToPosition with resetWeekCalendarOpacity(_isOpen) before the animation completes. It is based on height tracking rather than position local state. This creates a discrepancy between what you see in UI (_isOpen) and what gets tapped on (that is position-based isOpen) causing unintended day changes when the different view is tapped while animation complete callback is not run.

**extra**
We could have moved `setPosition` outside the Animated callback and put it together with `resetWeekCalendarOpacity` (like in below snippet), which would sync the view with what position actually is, but this would destroy the animation (which I think is nice). Hence the main fix is around blocking unintended taps (taps that are different from what you see) and only process those taps that happen after the animation completes and setPosition is updated.

```
    const bounceToPosition = (toValue = 0) => {
        if (!disablePan) {
            const threshold = isOpen ? openHeight.current - closeThreshold : closedHeight + openThreshold;
            let _isOpen = _height.current >= threshold;
            const newValue = _isOpen ? openHeight.current : closedHeight;
            deltaY.setValue(_height.current); // set the start position for the animated value
            _height.current = toValue || newValue;
            _isOpen = _height.current >= threshold; // re-check after _height.current was set
            resetWeekCalendarOpacity(_isOpen);
            setPosition(() => _height.current === closedHeight ? Positions.CLOSED : Positions.OPEN);
            Animated.spring(deltaY, {
                toValue: _height.current,
                speed: SPEED,
                bounciness: BOUNCINESS,
                useNativeDriver: false,
            }).start(() => {
                onCalendarToggled?.(_isOpen);
            });
            closeHeader(_isOpen);
        }
    };
```