### PR TITLE
Fixed crash in RN 0.78.x

### DIFF
--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -107,13 +107,13 @@ class ReservationList extends Component<ReservationListProps, State> {
   }
 
   componentDidUpdate(prevProps: ReservationListProps) {
-    if (this.props.topDay && prevProps.topDay && prevProps !== this.props) {
-      if (!sameDate(prevProps.topDay, this.props.topDay)) {
-        this.setState({reservations: []},
-          () => this.updateReservations(this.props)
-        );
-      } else {
-        this.updateReservations(this.props);
+    if (this.props.topDay && prevProps.topDay) {
+      if (this.props.showOnlySelectedDayItems !== prevProps.showOnlySelectedDayItems || this.props.items !== prevProps.items || !sameDate(this.props.selectedDay, prevProps.selectedDay)) {
+        if (!sameDate(prevProps.topDay, this.props.topDay)) {
+          this.setState({ reservations: [] }, () => this.updateReservations(this.props));
+        } else {
+          this.updateReservations(this.props);
+        }
       }
     }
   }


### PR DESCRIPTION
It seems `prevProps` and `this.props` are always different in RN 0.78.

Compare only the properties used in the  update of the reservation list.