### PR TITLE
refactor(ESModules): replace requires by imports in source files

### DIFF
--- a/src/calendar/header/index.tsx
+++ b/src/calendar/header/index.tsx
@@ -19,6 +19,8 @@ import {
 import {formatNumbers, weekDayNames} from '../../dateutils';
 import styleConstructor from './style';
 import {Theme, Direction} from '../../types';
+import leftArrowIcon from '../img/previous.png';
+import rightArrowIcon from '../img/next.png';
 
 export interface CalendarHeaderProps {
   /** The current month presented in the calendar */
@@ -234,7 +236,7 @@ const CalendarHeader = forwardRef((props: CalendarHeaderProps, ref) => {
     const arrowId = isLeft ? 'leftArrow' : 'rightArrow';
     const shouldDisable = isLeft ? disableArrowLeft : disableArrowRight;
     const onPress = !shouldDisable ? isLeft ? onPressLeft : onPressRight : undefined;
-    const imageSource = isLeft ? require('../img/previous.png') : require('../img/next.png');
+    const imageSource = isLeft ? leftArrowIcon : rightArrowIcon;
     const renderArrowDirection = isLeft ? 'left' : 'right';   
       
     return (

--- a/src/componentUpdater.ts
+++ b/src/componentUpdater.ts
@@ -5,11 +5,11 @@ import {ReservationListProps} from './agenda/reservation-list';
 
 import {MarkingProps} from './calendar/day/marking';
 
-const get = require('lodash/get');
-const omit = require('lodash/omit');
-const pickBy = require('lodash/pickBy');
-const isEqual = require('lodash/isEqual');
-const includes = require('lodash/includes');
+import get from 'lodash/get';
+import omit from 'lodash/omit';
+import pickBy from 'lodash/pickBy';
+import isEqual from 'lodash/isEqual';
+import includes from 'lodash/includes';
 
 export function shouldUpdate(props: any, newProps: any, paths: string[]) {
   for (let i = 0; i < paths.length; i++) {
@@ -28,7 +28,7 @@ export function extractComponentProps(component: any, props: any, ignoreProps?: 
     const keys = Object.keys(componentPropTypes);
     const componentProps = omit(
       pickBy(props, (_value: any, key: any) => includes(keys, key)),
-      ignoreProps
+      ignoreProps || []
     );
     return componentProps;
   }

--- a/src/dateutils.ts
+++ b/src/dateutils.ts
@@ -1,5 +1,7 @@
-const XDate = require('xdate');
-const {toMarkingFormat} = require('./interface');
+import XDateClass from 'xdate';
+import {toMarkingFormat} from './interface';
+
+const XDate = XDateClass as any;
 
 const latinNumbersPattern = /[0-9]/g;
 

--- a/src/day-state-manager.ts
+++ b/src/day-state-manager.ts
@@ -1,5 +1,5 @@
-const {isToday, isDateNotInRange, sameMonth} = require('./dateutils');
-const {toMarkingFormat} = require('./interface');
+import {isToday, isDateNotInRange, sameMonth} from './dateutils';
+import {toMarkingFormat} from './interface';
 
 
 export function getState(day: XDate, current: XDate, props: any, disableDaySelection?: boolean) {

--- a/src/expandableCalendar/Context/todayButton.tsx
+++ b/src/expandableCalendar/Context/todayButton.tsx
@@ -12,8 +12,8 @@ import styleConstructor from '../style';
 import Context from './index';
 
 const TOP_POSITION = 65;
-const DOWN_ICON = require('../../img/down.png');
-const UP_ICON = require('../../img/up.png');
+import DOWN_ICON from '../../img/down.png';
+import UP_ICON from '../../img/up.png';
 
 export interface TodayButtonProps extends ViewProps {
   /** The opacity for the disabled button (0-1) */

--- a/src/expandableCalendar/__test__/expandableCalendarTestKit.tsx
+++ b/src/expandableCalendar/__test__/expandableCalendarTestKit.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-native-calendars';
 import {toMarkingFormat} from '../../interface';
 
-const XDate = require('xdate');
+import XDate from 'xdate';
 
 const today = new XDate();
 export const testIdExpandableCalendar = 'myExpandableCalendar';

--- a/src/expandableCalendar/__test__/index.spec.ts
+++ b/src/expandableCalendar/__test__/index.spec.ts
@@ -7,8 +7,7 @@ import {UpdateSources} from '../commons';
 import times from 'lodash/times';
 import {NUMBER_OF_PAGES} from '../WeekCalendar';
 import {CalendarContextProviderProps} from 'react-native-calendars';
-
-const XDate = require('xdate');
+import XDate from 'xdate';
 
 enum Direction {
   LEFT = 'left',

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -32,6 +32,8 @@ import WeekCalendar from './WeekCalendar';
 import Context from './Context';
 import constants from '../commons/constants';
 import {UpdateSources} from './commons';
+import LEFT_ARROW from '../calendar/img/previous.png';
+import RIGHT_ARROW from'../calendar/img/next.png';
 
 export enum Positions {
   CLOSED = 'closed',
@@ -42,8 +44,7 @@ const BOUNCINESS = 6;
 const WEEK_HEIGHT = 46;
 const DAY_NAMES_PADDING = 24;
 const PAN_GESTURE_THRESHOLD = 30;
-const LEFT_ARROW = require('../calendar/img/previous.png');
-const RIGHT_ARROW = require('../calendar/img/next.png');
+
 const knobHitSlop = {left: 10, right: 10, top: 10, bottom: 10};
 
 export interface ExpandableCalendarProps extends CalendarListProps {

--- a/src/images.d.ts
+++ b/src/images.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+  const value: import('react-native').ImageSourcePropType;
+  export default value;
+}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,4 +1,4 @@
-const XDate = require('xdate');
+import XDate from 'xdate';
 
 export function padNumber(n: number) {
   if (n < 10) {

--- a/src/momentResolver.ts
+++ b/src/momentResolver.ts
@@ -1,10 +1,10 @@
 let moment: any;
 
 // Moment is an optional dependency
-export const getMoment = () => {
+export const getMoment = async () => {
   if (!moment) {
     try {
-      moment = require('moment');
+      moment = await import('moment');
     } catch {
       // Moment is not available
     }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,9 +3,8 @@ import isDate from 'lodash/isDate';
 import isString from 'lodash/isString';
 import isNumber from 'lodash/isNumber';
 import XDate from 'xdate';
-
-const {getLocale} = require('../dateutils');
-const {padNumber, toMarkingFormat} = require('../interface');
+import {getLocale} from '../dateutils';
+import {padNumber, toMarkingFormat} from '../interface';
 
 export function getCalendarDateString(date?: Date | string | number) {
   if (!isUndefined(date)) {


### PR DESCRIPTION
This package is incompatible with storybook 8+ with `vite` because `require` is not allowed in `ES modules`.

Fixes #2396