### PR TITLE
Hide ExpandableCalendar header when going out of container

### DIFF
--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -260,7 +260,7 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
   }, [allowShadow, propsStyle, headerHeight]);
 
   const wrapperStyle = useMemo(() => {
-    return {height: deltaY};
+    return {height: deltaY, overflow: 'hidden'};
   }, [deltaY]);
 
   const numberOfDaysHeaderStyle = useMemo(() => {

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -256,11 +256,11 @@ const ExpandableCalendar = (props: ExpandableCalendarProps) => {
   }, [isOpen, headerHeight]);
 
   const containerStyle = useMemo(() => {
-    return [allowShadow && style.current.containerShadow, propsStyle, headerHeight === 0  && style.current.hidden];
+    return [allowShadow && style.current.containerShadow, propsStyle, headerHeight === 0  && style.current.hidden, {overflow: 'hidden'} as const];
   }, [allowShadow, propsStyle, headerHeight]);
 
   const wrapperStyle = useMemo(() => {
-    return {height: deltaY, overflow: 'hidden'};
+    return {height: deltaY};
   }, [deltaY]);
 
   const numberOfDaysHeaderStyle = useMemo(() => {


### PR DESCRIPTION
Added overflow hidden so vertical calendar header won't go outside of the component.