### PR TITLE
Fix error with Platform.constants doesn't exists on react-native-web

### DIFF
--- a/src/commons/constants.ts
+++ b/src/commons/constants.ts
@@ -8,7 +8,7 @@ const isIOS = Platform.OS === 'ios';
 const screenAspectRatio = screenWidth < screenHeight ? screenHeight / screenWidth : screenWidth / screenHeight;
 const isTablet = (Platform as PlatformIOSStatic).isPad || (screenAspectRatio < 1.6 && Math.max(screenWidth, screenHeight) >= 900);
 const isAndroidRTL = isAndroid && isRTL;
-const isRN73 = () => Platform.constants.reactNativeVersion && Platform.constants.reactNativeVersion?.minor >= 73;
+const isRN73 = () => !!Platform?.constants?.reactNativeVersion && Platform.constants.reactNativeVersion?.minor >= 73;
 
 export default {
   screenWidth,

--- a/src/commons/constants.ts
+++ b/src/commons/constants.ts
@@ -8,7 +8,7 @@ const isIOS = Platform.OS === 'ios';
 const screenAspectRatio = screenWidth < screenHeight ? screenHeight / screenWidth : screenWidth / screenHeight;
 const isTablet = (Platform as PlatformIOSStatic).isPad || (screenAspectRatio < 1.6 && Math.max(screenWidth, screenHeight) >= 900);
 const isAndroidRTL = isAndroid && isRTL;
-const isRN73 = () => Platform.constants.reactNativeVersion?.minor >= 73;
+const isRN73 = () => Platform.constants.reactNativeVersion && Platform.constants.reactNativeVersion?.minor >= 73;
 
 export default {
   screenWidth,


### PR DESCRIPTION
When running in a web (react-native-web) env `Platform.constants` doesn't exist. This falls back to false in that case instead of throwing an error.