### PR TITLE
fix: Transparent ExpandableCalendar

### DIFF
--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -151,8 +151,9 @@ const ExpandableCalendar = forwardRef<ExpandableCalendarRef, ExpandableCalendarP
         layout: {height}
       }
     }: LayoutChangeEvent) => {
+      const _height = (height || DEFAULT_HEADER_HEIGHT) + 5;
       if (height !== headerHeight) {
-        setHeaderHeight(height || DEFAULT_HEADER_HEIGHT);
+        setHeaderHeight(_height);
       }
       shouldMeasureHeader.current = false;
     },

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -143,9 +143,21 @@ const ExpandableCalendar = forwardRef<ExpandableCalendarRef, ExpandableCalendarP
 
   const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
   const [headerHeight, setHeaderHeight] = useState(0);
-  const onHeaderLayout = useCallback(({nativeEvent: {layout: {height}}}: LayoutChangeEvent) => {
-      setHeaderHeight(height || DEFAULT_HEADER_HEIGHT);
-  }, []);
+
+  const shouldMeasureHeader = useRef(true);
+  const onHeaderLayout = useCallback(
+    ({
+      nativeEvent: {
+        layout: {height}
+      }
+    }: LayoutChangeEvent) => {
+      if (height !== headerHeight) {
+        setHeaderHeight(height || DEFAULT_HEADER_HEIGHT);
+      }
+      shouldMeasureHeader.current = false;
+    },
+    [headerHeight]
+  );
 
   /** Date */
 
@@ -637,7 +649,13 @@ const ExpandableCalendar = forwardRef<ExpandableCalendarRef, ExpandableCalendarP
           renderArrow={_renderArrow}
         />
       ) : (
-        <Animated.View testID={`${testID}.expandableContainer`} ref={wrapper} style={wrapperStyle} {...panResponder.panHandlers}>
+        <Animated.View
+          testID={`${testID}.expandableContainer`}
+          ref={wrapper}
+          style={wrapperStyle}
+          onLayout={shouldMeasureHeader.current ? onHeaderLayout : undefined}
+          {...panResponder.panHandlers}
+        >
           {renderCalendarList()}
           {renderWeekCalendar()}
           {!hideKnob && renderKnob()}


### PR DESCRIPTION
The issue related to **dynamic headerHeight was not set**.

- Introduced a ref to conditionally measure header height only when necessary.
- Updated onHeaderLayout to prevent unnecessary state updates.
- Adjusted onLayout prop for Animated.View to utilize the new measurement logic.

Related issues: 
#2625 
#2693 
#2681 
#2670 
#2657 
#2571 
#2722