### PR TITLE
feat(Timeline): expose onScroll prop for ScrollView event handling

### DIFF
--- a/src/timeline/Timeline.tsx
+++ b/src/timeline/Timeline.tsx
@@ -4,7 +4,7 @@ import times from 'lodash/times';
 import groupBy from 'lodash/groupBy';
 
 import React, {useCallback, useEffect, useMemo, useRef} from 'react';
-import {View, ScrollView} from 'react-native';
+import {View, ScrollView, NativeSyntheticEvent, NativeScrollEvent} from 'react-native';
 
 import constants from '../commons/constants';
 import {generateDay} from '../dateutils';
@@ -115,6 +115,11 @@ export interface TimelineProps {
   timelineLeftInset?: number;
   /** Identifier for testing */
   testID?: string;
+  /**
+   * Callback fired when the Timeline's internal ScrollView scrolls.
+   * Receives the native scroll event to allow consumers to track scroll position or implement custom behaviors.
+   */
+  onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
 }
 
 const Timeline = (props: TimelineProps) => {
@@ -142,7 +147,8 @@ const Timeline = (props: TimelineProps) => {
     eventTapped,
     numberOfDays = 1,
     timelineLeftInset = 0,
-    testID
+    testID,
+    onScroll
   } = props;
 
   const pageDates = useMemo(() => {
@@ -252,6 +258,7 @@ const Timeline = (props: TimelineProps) => {
       showsVerticalScrollIndicator={false}
       {...scrollEvents}
       testID={testID}
+      onScroll={onScroll}
     >
       <TimelineHours
         start={start}


### PR DESCRIPTION
### Description
This PR adds an onScroll prop to the Timeline component, exposing the native scroll event from the internal ScrollView.

### Changes
- Added an optional onScroll prop to TimelineProps.
- Forwarded the onScroll event handler to the internal ScrollView alongside existing scrollEvents.
- Updated typings and documentation for the new prop.


### Motivation
In a project I work on that uses react-native-calendars, there was a requirement to create a floating button inside the Timeline that would animate based on the user’s vertical scrolling (shrinking when scrolling down, expanding when scrolling up).

I was frustrated to find that the Timeline component — via the timelineProps — did not expose any prop to capture scroll events, which made it impossible to implement this behavior without modifying the library.

This led me to create a fork to handle the case, and it also motivated me to contribute this small improvement back to the community so others can more easily implement similar features.

### Here’s a quick demo showing how exposing the `onScroll` prop enables UI animations like a floating button reacting to scroll direction:

https://github.com/user-attachments/assets/a5c122e4-bdeb-4cda-8c94-610d15e00bdc

