### PR TITLE
Fix ExpandableCalendar StartHeight calculations

### DIFF
--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -191,15 +191,16 @@ const ExpandableCalendar = forwardRef<ExpandableCalendarRef, ExpandableCalendarP
 
   const [position, setPosition] = useState(numberOfDays ? Positions.CLOSED : initialPosition);
   const isOpen = position === Positions.OPEN;
-  const getOpenHeight = () => {
+  const getOpenHeight = useCallback(() => {
     if (!horizontal) {
       return Math.max(constants.screenHeight, constants.screenWidth);
     }
     return headerHeight + (WEEK_HEIGHT * (numberOfWeeks.current)) + (hideKnob ? 0 : KNOB_CONTAINER_HEIGHT);
-  };
+  }, [headerHeight, horizontal, hideKnob, numberOfWeeks]);
+
   const openHeight = useRef(getOpenHeight());
   const closedHeight = useMemo(() => headerHeight + WEEK_HEIGHT + (hideKnob || Number(numberOfDays) > 1 ? 0 : KNOB_CONTAINER_HEIGHT), [numberOfDays, hideKnob, headerHeight]);
-  const startHeight = useMemo(() => isOpen ? openHeight.current : closedHeight, [closedHeight, isOpen]);
+  const startHeight = useMemo(() => isOpen ? getOpenHeight() : closedHeight, [closedHeight, isOpen, getOpenHeight]);
   const _height = useRef(startHeight);
   const deltaY = useMemo(() => new Animated.Value(startHeight), [startHeight]);
   const headerDeltaY = useRef(new Animated.Value(isOpen ? -headerHeight : 0));
@@ -207,6 +208,7 @@ const ExpandableCalendar = forwardRef<ExpandableCalendarRef, ExpandableCalendarP
   useEffect(() => {
     _height.current = startHeight;
     deltaY.setValue(startHeight);
+    _wrapperStyles.current.style.height = startHeight;
   }, [startHeight]);
 
   useEffect(() => {


### PR DESCRIPTION
**Problem Cause:**
When `ExpandableCalendar` was configured with `initialPosition={Positions.OPEN}`, the calendar's total open height `startHeight` was calculated before the actual height of the header section `headerHeight` was determined. This led to headerHeight being treated as `0` or an incorrect value, causing the calendar content to appear clipped or the layout to be misaligned, even though the calendar was in an open state.

**Solution:**
1. Fixed that when the `headerHeight` value changes, the logic that calculates the height when the calendar is open `getOpenHeight` immediately reflects this and recalculates the startHeight correctly.
2.  Also, synchronize the correctly calculated startHeight value to the object that manages native component styles internally `_wrapperStyles` to ensure the correct height is applied to the actual UI.

#2646