### PR TITLE
Fix: ensure unique keys in WeekCalendar FlatList to prevent React war…

### DIFF
--- a/src/expandableCalendar/WeekCalendar/index.tsx
+++ b/src/expandableCalendar/WeekCalendar/index.tsx
@@ -133,7 +133,7 @@ const WeekCalendar = (props: WeekCalendarProps) => {
     );
   },[firstDay, _onDayPress, context, date, markedDates]);
 
-  const keyExtractor = useCallback((item) => item, []);
+  const keyExtractor = useCallback((item, index) => `key-${item.date}-${index}`, []);
 
   const renderWeekDaysNames = useMemo(() => {
     return (


### PR DESCRIPTION
…nings

### Problem

When using `<ExpandableCalendar>`, React logs the warning:

This is caused by the `FlatList` inside `WeekCalendar`, which uses only the date string as a key. When multiple weeks contain the same day (e.g., overlapping transitions), duplicate keys occur.

### Fix

This issue originates from the `FlatList` inside `WeekCalendar`, which uses only the date string as a key. When multiple weeks contain the same day (due to overlapping render ranges), this leads to duplicate React keys.

This PR updates the `keyExtractor` to ensure each key is unique by including the item’s index:


From:

```ts
const keyExtractor = useCallback((item) => item, []);
```

To:

```ts
const keyExtractor = useCallback((item, index) => `key-${item.date}-${index}`, []);
```

Fixes #2335
