### PR TITLE
Add support for disableAutoDaySelection to the Expandable calendar

### DIFF
--- a/src/expandableCalendar/WeekCalendar/index.tsx
+++ b/src/expandableCalendar/WeekCalendar/index.tsx
@@ -115,7 +115,6 @@ const WeekCalendar = (props: WeekCalendarProps) => {
   }, [containerWidth, propsStyle]);
 
   const renderItem = useCallback(({item}: {item: string}) => {
-    const currentContext = sameWeek(date, item, firstDay) ? context : undefined;
     const markings = getCurrentWeekMarkings(item, markedDates);
 
     return (
@@ -125,7 +124,7 @@ const WeekCalendar = (props: WeekCalendarProps) => {
         current={item}
         firstDay={firstDay}
         style={weekStyle}
-        context={currentContext}
+        context={context}
         onDayPress={_onDayPress}
         numberOfDays={numberOfDays}
         timelineLeftInset={timelineLeftInset}

--- a/src/expandableCalendar/index.tsx
+++ b/src/expandableCalendar/index.tsx
@@ -324,7 +324,7 @@ const ExpandableCalendar = forwardRef<ExpandableCalendarRef, ExpandableCalendarP
       const d = parseDate(date);
 
       if (isOpen) {
-        d.setDate(1);
+        d.setDate(1, CalendarNavigationTypes.MONTH_SCROLL);
         d.addMonths(next ? 1 : -1);
       } else {
         let dayOfTheWeek = d.getDay();


### PR DESCRIPTION
[Add missing navigation type for setDate](https://github.com/wix/react-native-calendars/commit/b733c72474dddf063a51f6fa55ef8bd285c48c0e)
This allow the provide to filter the `setDate` actions that are disabled by `disableAutoDaySelection`.

[Use the same context for every week of WeekCalendar](https://github.com/wix/react-native-calendars/commit/3cd6920cc69b77c44b6ee34005f5f27321f3cfab)
This allow the week to know the current date to select and prevent the fallback on the first day of the week.