### PR TITLE
fix: correctly type style override props

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -75,28 +75,16 @@ export interface Theme {
   arrowWidth?: number;
   weekVerticalMargin?: number;
   reservationsBackgroundColor?: string;
-  stylesheet?: {
-    calendar?: {
-      main?: object;
-      header?: object;
-    };
-    day?: {
-      basic?: object;
-      period?: object;
-    };
-    dot?: object;
-    marking?: object;
-    'calendar-list'?: {
-      main?: object;
-    };
-    agenda?: {
-      main?: object;
-      list?: object;
-    };
-    expandable?: {
-      main?: object;
-    };
-  };
+  'stylesheet.calendar.main'?: object;
+  'stylesheet.calendar.header'?: object;
+  'stylesheet.day.basic'?: object;
+  'stylesheet.day.period'?: object;
+  'stylesheet.dot'?: object;
+  'stylesheet.marking'?: object;
+  'calendar-list.main'?: object;
+  'stylesheet.agenda.main'?: object;
+  'stylesheet.agenda.list'?: object;
+  'stylesheet.expandable.main'?: object;
 }
 
 export type AgendaEntry = {


### PR DESCRIPTION
Current typing incorrectly enforces passing styling props as:
```tsx
<Calendar
    theme={{
      stylesheet: {
        calendar: {
          header: {
            dayTextAtIndex0: { color: 'fuchsia', fontSize: 42 },
          }
        }
      }
    }}
/>
```
although this leads to ignored styling. Correct usage is:
```tsx
<Calendar
    theme={{
      'stylesheet.calendar.header': {
        dayTextAtIndex0: { color: 'fuchsia', fontSize: 42 },
      }
    }}
/>
```