### PR TITLE
fix code in section basic calendar with default settings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ const App = () => {
         setSelected(day.dateString);
       }}
       markedDates={{
-        [selected]: {selected: true, disableTouchEvent: true, selectedDotColor: 'orange'}
+        [selected]: {selected: true, disableTouchEvent: true, selectedColor: 'orange'}
       }}
     />
   );


### PR DESCRIPTION
the current code in the basic calendar with default settings (line 106 of README) gives this error:

Type '{ [x: string]: { selected: true; disableTouchEvent: true; selectedDotColor: string; }; }' is not assignable to type 'MarkedDates'.
  'string' index signatures are incompatible.
    Object literal may only specify known properties, but 'selectedDotColor' does not exist in type 'MarkingProps'. Did you mean to write 'selectedColor'?ts(2322)
index.d.ts(22, 5): The expected type comes from property 'markedDates' which is declared here on type 'IntrinsicAttributes & CalendarProps & ContextProp'


The fix makes it work as intended, highlighting the selected date in orange.