### PR TITLE
fix agenda reservation list exceeded update depth for expo sdk53

### DIFF
--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -107,13 +107,17 @@ class ReservationList extends Component<ReservationListProps, State> {
   }
 
   componentDidUpdate(prevProps: ReservationListProps) {
-    if (this.props.topDay && prevProps.topDay && prevProps !== this.props) {
-      if (!sameDate(prevProps.topDay, this.props.topDay)) {
-        this.setState({reservations: []},
-          () => this.updateReservations(this.props)
-        );
-      } else {
-        this.updateReservations(this.props);
+    if (this.props.topDay && prevProps.topDay) {
+      if (
+        this.props.showOnlySelectedDayItems !== prevProps.showOnlySelectedDayItems ||
+        this.props.items !== prevProps.items ||
+        !sameDate(this.props.selectedDay, prevProps.selectedDay)
+      ) {
+        if (!sameDate(prevProps.topDay, this.props.topDay)) {
+          this.setState({reservations: []}, () => this.updateReservations(this.props));
+        } else {
+          this.updateReservations(this.props);
+        }
       }
     }
   }


### PR DESCRIPTION
This pull request will fix the issue mentioned here: #2705 

Fix: Avoid infinite update loop in Agenda > ReservationList on Expo SDK 53+

**Problem**

When using react-native-calendars in Expo SDK 53+, the app crashes due to a Maximum update depth exceeded error in the ReservationList component of the Agenda.

This was caused by an infinite re-render triggered in componentDidUpdate, due to the state being set on every prop change without proper guarding.

**Solution**

Updated the componentDidUpdate method to check for meaningful changes in props (showOnlySelectedDayItems, items, and selectedDay) before calling setState or updating reservations.

This patch was submitted using @dangthequan 's contribution.