### PR TITLE
fix: missing defined key prop in the timeline list component

### DIFF
--- a/src/timeline-list/index.tsx
+++ b/src/timeline-list/index.tsx
@@ -142,7 +142,7 @@ const TimelineList = (props: TimelineListProps) => {
 
       return (
         <>
-          <Timeline {..._timelineProps}/>
+          <Timeline {..._timelineProps} key={item}/>
           {/* NOTE: Keeping this for easy debugging */}
           {/* <Text style={{position: 'absolute'}}>{item}</Text>*/}
         </>


### PR DESCRIPTION
**Problem**
When using the TimelineList component the error bellow is logged.

```
A props object containing a "key" prop is being spread into JSX:
  let props = %s;
  <%s {...props} />
React keys must be passed directly to JSX without using spread:
  let props = %s;
  <%s key={someKey} {...props} /> {key: someKey, onEventPress: ..., format24h: ..., date: ..., events: ..., scrollToNow: ..., initialTime: ..., scrollToFirst: ..., scrollOffset: ..., onChangeOffset: ..., showNowIndicator: ..., numberOfDays: ..., timelineLeftInset: ...} Timeline {onEventPress: ..., format24h: ..., date: ..., events: ..., scrollToNow: ..., initialTime: ..., scrollToFirst: ..., scrollOffset: ..., onChangeOffset: ..., showNowIndicator: ..., numberOfDays: ..., timelineLeftInset: ...} Timeline
```

**Solution**
Set the key prop explicitly and not rely on the props spread which breaks the rules of react.