### PR TITLE
docs: remove duplicate LocaleConfig import in examples (#2726)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ export default App;
 ### Configuring the locale:
 
 ```javascript
-import {LocaleConfig} from 'react-native-calendars';
 import React, {useState} from 'react';
 import {Calendar, LocaleConfig} from 'react-native-calendars';
 


### PR DESCRIPTION
Fixes #2726

This PR removes the duplicate import of LocaleConfig in the examples docs.