### PR TITLE
fix(agenda): Prevent infinite loop in ReservationList

### DIFF
--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -106,14 +106,15 @@ class ReservationList extends Component<ReservationListProps, State> {
     this.updateDataSource(this.getReservations(this.props).reservations);
   }
 
-  componentDidUpdate(prevProps: ReservationListProps) {
-    if (this.props.topDay && prevProps.topDay && prevProps !== this.props) {
-      if (!sameDate(prevProps.topDay, this.props.topDay)) {
-        this.setState({reservations: []},
-          () => this.updateReservations(this.props)
-        );
-      } else {
-        this.updateReservations(this.props);
+  componentDidUpdate(prevProps) {
+    if (this.props.topDay && prevProps.topDay) {
+      if (this.props.items !== prevProps.items || !sameDate(this.props.selectedDay, prevProps.selectedDay)) {
+        if (!sameDate(prevProps.topDay, this.props.topDay)) {
+          this.setState({ reservations: [] }, () => this.updateReservations(this.props));
+        }
+        else {
+          this.updateReservations(this.props);
+        }
       }
     }
   }


### PR DESCRIPTION
## 🐞 Bug Report

Fixes an issue where the `Agenda` component can enter an infinite re-render loop, causing a "Maximum update depth exceeded" error.

### The Problem

The `componentDidUpdate` lifecycle method in `ReservationList` uses a shallow prop comparison (`prevProps !== this.props`). This causes the component to update unconditionally if any prop is an object or function that is not memoized (e.g., `theme`, `renderItem`, `style`). This makes the component highly prone to infinite loops, especially for new users or when used with modern React patterns.

### The Solution

This PR replaces the unstable shallow prop comparison with a more specific check that only triggers an update when the props that actually affect the reservation data have changed: `items` and `selectedDay`.

This change makes the component more resilient and prevents the infinite loop without requiring the consuming developer to memoize every single prop passed to `<Agenda>`.

### How to Reproduce the Bug

1.  Create a minimal `<Agenda>` implementation.
2.  Pass a `theme` object as an inline object literal: `theme={{ backgroundColor: 'white' }}`.
3.  The app will crash with "Maximum update depth exceeded".

### How This PR Fixes It

By changing the comparison logic, the component now correctly ignores changes to stable props like `theme` and only re-calculates reservations when necessary.

I encountered this issue while building a new app and believe this change will improve the stability of the `Agenda` component for many users. Thank you for your consideration!