### PR TITLE
Fix ReservationList infinite update loop under React 18/19

### DIFF
--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -107,14 +107,31 @@ class ReservationList extends Component<ReservationListProps, State> {
   }
 
   componentDidUpdate(prevProps: ReservationListProps) {
-    if (this.props.topDay && prevProps.topDay && prevProps !== this.props) {
-      if (!sameDate(prevProps.topDay, this.props.topDay)) {
-        this.setState({reservations: []},
-          () => this.updateReservations(this.props)
-        );
-      } else {
-        this.updateReservations(this.props);
-      }
+    const {topDay, items} = this.props;
+    const {topDay: prevTopDay, items: prevItems} = prevProps;
+
+    // Only react when the visible "top day" or the agenda items actually change.
+    // Using `prevProps !== this.props` here is unsafe because React may recreate
+    // the props object on every render, which can lead to unnecessary updates and
+    // "Maximum update depth exceeded" loops under newer React versions.
+    if (!topDay || !prevTopDay) {
+      return;
+    }
+
+    const topDayChanged = !sameDate(prevTopDay, topDay);
+    const itemsChanged = prevItems !== items;
+
+    if (!topDayChanged && !itemsChanged) {
+      return;
+    }
+
+    if (topDayChanged) {
+      this.setState(
+        {reservations: []},
+        () => this.updateReservations(this.props)
+      );
+    } else if (itemsChanged) {
+      this.updateReservations(this.props);
     }
   }
 


### PR DESCRIPTION
## Summary

This change fixes a potential infinite update loop in the Agenda’s ReservationList when used with newer React versions (18/19+).

The current implementation of ReservationList.componentDidUpdate uses `prevProps !== this.props` as part of its guard:

With React 18/19 and the new architecture, props objects are often recreated on each render. As a result, `prevProps !== this.props` can be true on every update, even when the values have not changed. Combined with setState in componentDidUpdate, this can cause ReservationList to continually update, leading to:

-  Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.
-  A component stack pointing at ReservationList → Agenda.

## What this PR changes

ReservationList.componentDidUpdate is updated to only respond when:

- The visible topDay actually changes (by value), or
- The items reference changes while topDay stays the same.


This keeps the original behavior (recomputing reservations when topDay moves or items change) but avoids treating a new props object as a guaranteed change. In practice this:

- Prevents unnecessary updateReservations calls on every render.
- Avoids “Maximum update depth exceeded” loops under React 18/19/new architecture.

## Impact

- No public API changes.
- No behavior change for callers that update topDay or items explicitly.
- Improves compatibility with React 18/19 and React Native new architecture, where props identity is not stable.

I’ve tested this change against a real app using Agenda under React 19 / RN 0.81, where it eliminates the infinite update crash (ReservationList → Agenda) without regressing scrolling behavior.