### PR TITLE
fix: missing Timeline _onEventPress packedEvents dependency

### DIFF
--- a/src/timeline/Timeline.tsx
+++ b/src/timeline/Timeline.tsx
@@ -205,7 +205,7 @@ const Timeline = (props: TimelineProps) => {
         onEventPress?.(event);
       }
     },
-    [onEventPress, eventTapped]
+    [onEventPress, eventTapped, packedEvents]
   );
 
   const renderEvents = (dayIndex: number) => {


### PR DESCRIPTION
Hello,

The `_onEventPress` callback is missing `packedEvents` in its dependency array. As a result, whenever `packedEvents` is updated, the memoized function reference is not refreshed. This leads to `onEventPress` being invoked with an outdated or unexpected `event` parameter.

Including `packedEvents` in the dependencies should ensure the callback receives the correct event data after updates.

Related with #2746 .