### PR TITLE
fix(ReservationList): prevent FlatList from rendering with empty data

### DIFF
--- a/src/agenda/reservation-list/index.tsx
+++ b/src/agenda/reservation-list/index.tsx
@@ -270,6 +270,13 @@ class ReservationList extends Component<ReservationListProps, State> {
       return <ActivityIndicator style={this.style.indicator} color={theme?.indicatorColor}/>;
     }
 
+    // Prevent FlatList from rendering with empty data to avoid React Native bug
+    // where FlatList gets stuck and won't render items added later.
+    // See: https://github.com/facebook/react-native/issues/39421
+    if (!this.state.reservations || this.state.reservations.length === 0) {
+      return <ActivityIndicator style={this.style.indicator} color={theme?.indicatorColor}/>;
+    }
+
     return (
       <FlatList
         ref={this.list}


### PR DESCRIPTION
Fixes https://github.com/wix/react-native-calendars/issues/2750

## Problem

The Agenda's ReservationList has a scrolling bug where only the first ~10-20 items render and users can't scroll further. This happens intermittently and is hard to reproduce consistently.

## Root Cause

React Native's FlatList has a known issue where it gets "stuck" if initially rendered with empty data ([facebook/react-native#39421](https://github.com/facebook/react-native/issues/39421)).

In ReservationList, the state is initialized with `reservations: []` in the constructor, and the FlatList renders before `componentDidMount` populates the data. By then, the FlatList is already broken.

## Solution

Show the loading indicator until `this.state.reservations` has actual data. This ensures the FlatList is never mounted with an empty array.

```tsx
if (!this.state.reservations || this.state.reservations.length === 0) {
  return <ActivityIndicator style={this.style.indicator} color={theme?.indicatorColor}/>;
}
```

## Testing

Tested on a production app with hundreds of agenda items. Before the fix, scrolling would stop after ~20 items. After the fix, all items render and scroll correctly.