### PR TITLE
fix: removed unused react-native-safe-area-context from Dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
     "lodash": "^4.17.15",
     "memoize-one": "^5.2.1",
     "prop-types": "^15.5.10",
-    "react-native-safe-area-context": "4.5.0",
     "react-native-swipe-gestures": "^1.0.5",
     "recyclerlistview": "^4.0.0",
     "xdate": "^0.8.0"
+  },
+  "peerDependencies": {
+    "react-native-safe-area-context": ">=4.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
     "recyclerlistview": "^4.0.0",
     "xdate": "^0.8.0"
   },
-  "peerDependencies": {
-    "react-native-safe-area-context": ">=4.5.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@babel/eslint-parser": "^7.13.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9673,7 +9673,6 @@ __metadata:
     prop-types: "npm:^15.5.10"
     react: "npm:18.2.0"
     react-native: "npm:0.73.11"
-    react-native-safe-area-context: "npm:4.5.0"
     react-native-swipe-gestures: "npm:^1.0.5"
     react-recipes: "npm:^1.4.0"
     react-test-renderer: "npm:18.2.0"
@@ -9683,21 +9682,13 @@ __metadata:
     shell-utils: "npm:1.x.x"
     typescript: "npm:5.0.4"
     xdate: "npm:^0.8.0"
+  peerDependencies:
+    react-native-safe-area-context: ">=4.5.0"
   dependenciesMeta:
     moment:
       optional: true
   languageName: unknown
   linkType: soft
-
-"react-native-safe-area-context@npm:4.5.0":
-  version: 4.5.0
-  resolution: "react-native-safe-area-context@npm:4.5.0"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: 10c0/cd9dfe25803b7b120940c243d9c9f10b0b61d262ad5875245909cdbf0025684241189b2796d35028519fee0e7a94e6f47bcaf2e23fc7801875d5f633a7778296
-  languageName: node
-  linkType: hard
 
 "react-native-swipe-gestures@npm:^1.0.5":
   version: 1.0.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -9682,8 +9682,6 @@ __metadata:
     shell-utils: "npm:1.x.x"
     typescript: "npm:5.0.4"
     xdate: "npm:^0.8.0"
-  peerDependencies:
-    react-native-safe-area-context: ">=4.5.0"
   dependenciesMeta:
     moment:
       optional: true


### PR DESCRIPTION
## Summary
Removed `react-native-safe-area-context` from `dependencies` to prevent duplicate native module installations.

## Reason
Having this package as a hard dependency can lead to multiple versions of the same native module being installed, which causes build issues in Expo.

## Fix
- Removed `react-native-safe-area-context` from `dependencies`. (It was not used in the codebase)

## Verification
Tested this change by installing the forked branch in an Expo app.
`expo-doctor` no longer reports duplicate `react-native-safe-area-context` installations and the calendar renders correctly.

## Related issue
Fixes #2728 #2644