### PR TITLE
fix(calendar): sync currentMonth state when current or initialDate prop changes

### DIFF
--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -99,10 +99,11 @@ const Calendar = (props: CalendarProps & ContextProp) => {
   const weekNumberMarking = useRef({disabled: true, disableTouchEvent: true});
 
   useEffect(() => {
-    if (initialDate) {
-      setCurrentMonth(parseDate(initialDate));
+    const newDate = current || initialDate;
+    if (newDate) {
+      setCurrentMonth(parseDate(newDate));
     }
-  }, [initialDate]);
+  }, [current, initialDate]);
 
   useDidUpdate(() => {
     const _currentMonth = currentMonth.clone();


### PR DESCRIPTION
Calendar component initializes currentMonth from current or initialDate
using useState, but it does not update the state when the `current`
prop changes.

When Calendar is used inside CalendarList (FlatList virtualization),
components are reused while the `current` prop changes. Because
the state is not updated, the calendar renders incorrect months
or duplicate months.

This change synchronizes currentMonth state whenever `current`
or `initialDate` props change.