### PR TITLE
Migrate StyleSheet.absoluteFillObject

### DIFF
--- a/src/timeline/TimelineHours.tsx
+++ b/src/timeline/TimelineHours.tsx
@@ -100,7 +100,7 @@ const TimelineHours = (props: TimelineHoursProps) => {
   return (
     <>
       <TouchableWithoutFeedback onLongPress={handleBackgroundPress} onPressOut={handlePressOut}>
-        <View style={StyleSheet.absoluteFillObject}/>
+        <View style={StyleSheet.absoluteFill}/>
       </TouchableWithoutFeedback>
       {unavailableHoursBlocks.map((block, index) => (
         <View


### PR DESCRIPTION
Migrate StyleSheet.absoluteFillObject which has been removed in react-native 0.85: https://github.com/facebook/react-native/releases/tag/v0.85.0-rc.0