### PR TITLE
fix: initialize getState return value to empty string

### DIFF
--- a/src/day-state-manager.ts
+++ b/src/day-state-manager.ts
@@ -3,7 +3,7 @@ const {toMarkingFormat} = require('./interface');
 
 export function getState(day: XDate, current: XDate, props: any, disableDaySelection: boolean) {
   const {minDate, maxDate, disabledByDefault, disabledByWeekDays, context} = props;
-  let state;
+  let state = '';
 
   if (!disableDaySelection && (context?.selectedDate ?? toMarkingFormat(current)) === toMarkingFormat(day)) {
     state = 'selected';


### PR DESCRIPTION
## Summary       
`getState` returned `undefined` when no conditions matched due to uninitialized `state` variable.                                                                                                       
   
## Fix                                                                                                                                          
Initialize `state` to empty string (`''`), restoring the expected default return value.
                                                                                                                                                  
## Related issue                                                                                                                                
#2678 