### PR TITLE
Support optional flingSpeedLimit prop in CalendarList

### DIFF
--- a/src/calendar-list/calendarList.api.json
+++ b/src/calendar-list/calendarList.api.json
@@ -50,6 +50,11 @@
       "type": "boolean",
       "description": "Whether to enable or disable vertical / horizontal scroll indicator",
       "default": "false"
+    },
+    {
+      "name": "flingSpeedLimit",
+      "type": "number",
+      "description": "Optional fling speed limit for platforms that support this FlatList prop"
     }
   ]
 }

--- a/src/calendar-list/index.tsx
+++ b/src/calendar-list/index.tsx
@@ -38,6 +38,8 @@ export interface CalendarListProps extends CalendarProps, Omit<FlatListProps<any
   showScrollIndicator?: boolean;
   /** Whether to animate the auto month scroll */
   animateScroll?: boolean;
+  /** Optional fling speed limit for platforms that support this prop */
+  flingSpeedLimit?: number;
 }
 
 export interface CalendarListImperativeMethods {
@@ -103,7 +105,8 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
     onEndReached,
     onHeaderLayout,
     accessibilityElementsHidden,
-    importantForAccessibility
+    importantForAccessibility,
+    flingSpeedLimit
   } = props;
 
   const calendarProps = extractCalendarProps(props);
@@ -310,11 +313,13 @@ const CalendarList = (props: CalendarListProps & ContextProp, ref: any) => {
       onViewableItemsChanged
     }
   ]);
+  const extraFlatListProps = typeof flingSpeedLimit === 'number' ? {flingSpeedLimit} : {};
 
   return (
     <View style={style.current.flatListContainer} testID={testID}>
       <FlatList
         ref={list}
+        {...extraFlatListProps}
         windowSize={shouldFixRTL ? pastScrollRange + futureScrollRange + 1 : undefined}
         style={listStyle}
         showsVerticalScrollIndicator={showScrollIndicator}
@@ -368,5 +373,6 @@ CalendarList.propTypes = {
   keyExtractor: PropTypes.func,
   onEndReachedThreshold: PropTypes.number,
   onEndReached: PropTypes.func,
-  nestedScrollEnabled: PropTypes.bool
+  nestedScrollEnabled: PropTypes.bool,
+  flingSpeedLimit: PropTypes.number
 };


### PR DESCRIPTION
## Summary

This PR adds optional `flingSpeedLimit` prop support to `CalendarList`.

When `flingSpeedLimit` is explicitly provided, it is forwarded to the underlying `FlatList`. When it is not provided, `CalendarList` behavior remains unchanged.

## Why

Some React Native platform implementations support a `flingSpeedLimit` prop on `FlatList`. At the moment, `CalendarList` does not expose this prop, so passing it from the app layer has no effect.

This change allows consumers to opt in to that behavior without affecting existing users.

## What changed

- Added optional `flingSpeedLimit?: number` to `CalendarListProps`
- Forward `flingSpeedLimit` to the underlying `FlatList` only when explicitly provided
- Added `PropTypes.number` support for `flingSpeedLimit`
- Updated `calendarList.api.json` to document the prop

## Behavior

- No behavior change by default
- No effect when `flingSpeedLimit` is not passed
- Platforms that support this `FlatList` prop can make use of it
- Existing Android/iOS behavior remains unchanged unless consumers explicitly opt in

## Validation

- Verified the prop is conditionally forwarded only when provided
- Confirmed no lint errors in the modified files
- Type definition is included so TS consumers can use the prop directly