### PR TITLE
Fix showSixWeeks page() using aligned span instead of /6 heuristic

### DIFF
--- a/src/dateutils.ts
+++ b/src/dateutils.ts
@@ -136,7 +136,6 @@ export function page(date: XDate, firstDayOfWeek = 0, showSixWeeks = false) {
   firstDayOfWeek = firstDayOfWeek || 0;
 
   const from = days[0].clone();
-  const daysBefore = from.getDay();
 
   if (from.getDay() !== fdow) {
     from.addDays(-(from.getDay() + 7 - fdow) % 7);
@@ -148,10 +147,11 @@ export function page(date: XDate, firstDayOfWeek = 0, showSixWeeks = false) {
     to.addDays((ldow + 7 - day) % 7);
   }
 
-  const daysForSixWeeks = (daysBefore + days.length) / 6 >= 6;
-
-  if (showSixWeeks && !daysForSixWeeks) {
-    to.addDays(7);
+  if (showSixWeeks) {
+    const spanDays = from.diffDays(to) + 1;
+    if (spanDays < 42) {
+      to.addDays(7);
+    }
   }
 
   if (isLTE(from, days[0])) {


### PR DESCRIPTION
## Problem
When `showSixWeeks` is true, `page()` used `(daysBefore + monthLength) / 6 >= 6` to decide whether to extend `to` by 7 days. This does not match the real week-aligned cell count and caused:
- An extra 7th row in some months (e.g. **March 2026** with `firstDay=1`).
- Missing trailing next-month cells when the heuristic skipped the extension (e.g. **May 2026** stayed at 5 weeks).

## Solution
After aligning `from` and `to` to week boundaries, extend by one week only when `from.diffDays(to) + 1 < 42`. Remove the `/6` heuristic and the unused `daysBefore` variable.

## Testing
`yarn test src/dateutils.spec.js`

Made with [Cursor](https://cursor.com)