### PR TITLE
Avoid root lodash import for includes

### DIFF
--- a/src/expandableCalendar/Context/Provider.tsx
+++ b/src/expandableCalendar/Context/Provider.tsx
@@ -1,4 +1,4 @@
-import {includes} from 'lodash';
+import includes from 'lodash/includes';
 import XDate from 'xdate';
 
 import React, {useRef, useState, useCallback, useMemo} from 'react';


### PR DESCRIPTION
## Summary

- import `includes` from `lodash/includes` in `CalendarProvider`
- avoid pulling the root `lodash` module into Expo web bundles for this single helper

Closes #2788.

## Why

`CalendarProvider` only needs the `includes` helper. Importing it from the lodash package root can cause Metro web builds to include the full `lodash/lodash.js` module, as reported in the issue. The package already uses `lodash/includes` in nearby code, so this keeps the behavior the same while matching the existing import pattern.

## Test plan

- `YARN_GLOBAL_FOLDER=$PWD/.yarn/local-global YARN_ENABLE_SCRIPTS=false yarn install`
- `yarn build:dev`
- `yarn lint` (passes with existing warnings)
- `yarn unit --runInBand --watchman=false` (10 suites passed, 151 tests passed, 10 skipped)
- `git diff --check`

Note: plain `yarn unit --runInBand` hit the local macOS sandbox Watchman permission issue when Watchman tried to write `~/Library/LaunchAgents/com.github.facebook.watchman.plist`, so the full Jest suite was rerun with Watchman disabled.