### PR TITLE
docs: remove dead link to the Expo-published examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ react-native run-ios
 
 You can check example screens source code in [example module screens](https://github.com/wix-private/wix-react-native-calendar/tree/master/example/src/screens)
 
-This project is compatible with Expo/CRNA (without ejecting), and the examples have been [published on Expo](https://expo.io/@community/react-native-calendars-example)
+This project is compatible with Expo/CRNA (without ejecting).
 
 ## Getting Started 🔧
 


### PR DESCRIPTION
The README links to the examples "published on Expo", but that URL returns **404**:

```
https://expo.io/@community/react-native-calendars-example
```

It is dead on the legacy `expo.io` domain and on the current `expo.dev` one as well, so there is nothing to redirect it to — the examples no longer appear to be published there.

This removes only the dead link and keeps the Expo compatibility statement, which is still accurate. The link to the example screens on the line above is unaffected and still resolves.

```diff
-This project is compatible with Expo/CRNA (without ejecting), and the examples have been [published on Expo](https://expo.io/@community/react-native-calendars-example)
+This project is compatible with Expo/CRNA (without ejecting).
```