### PR TITLE
chore: Remove dev files from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "clean": "rm yarn-lock && rm -rf ./node_modules && yarn",
     "pod-install": "pod install --project-directory=ios"
   },
+  "files": ["src", "!src/**/__tests__"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wix/react-native-calendars"


### PR DESCRIPTION
Remove dev only files from npm package

<img width="945" height="546" alt="Screenshot 2026-09-12 at 14 59 48" src="https://github.com/user-attachments/assets/ccaf1f0c-d4dd-4cfd-9201-64afd26795dd" />



Check npm package files:
- https://www.npmjs.com/package/react-native-calendars?activeTab=code
- https://npmfs.com/package/react-native-calendars/1.1314.0/


To test:

```bash
npm pack --dry-run
```